### PR TITLE
Hello Argent77,

### DIFF
--- a/src/org/infinity/NearInfinity.java
+++ b/src/org/infinity/NearInfinity.java
@@ -82,6 +82,7 @@ import org.infinity.updater.UpdateCheck;
 import org.infinity.updater.UpdateInfo;
 import org.infinity.updater.Updater;
 import org.infinity.updater.Utils;
+import org.infinity.util.CharsetDetector;
 import org.infinity.util.CreMapCache;
 import org.infinity.util.FileDeletionHook;
 import org.infinity.util.IdsMapCache;
@@ -815,6 +816,9 @@ public final class NearInfinity extends JFrame implements ActionListener, Viewab
   {
     if (ResourceFactory.getKeyfile() != null) {
       ResourceFactory.getKeyfile().closeBIFFFiles();
+    }
+    if (refreshOnly == false) {
+      CharsetDetector.clearCache();
     }
     DlcManager.close();
     FileManager.reset();

--- a/src/org/infinity/gui/BrowserMenuBar.java
+++ b/src/org/infinity/gui/BrowserMenuBar.java
@@ -86,7 +86,7 @@ import org.infinity.util.io.FileManager;
 
 public final class BrowserMenuBar extends JMenuBar
 {
-  public static final String VERSION = "v2.1-20170809";
+  public static final String VERSION = "v2.1-20170907";
   public static final int OVERRIDE_IN_THREE = 0, OVERRIDE_IN_OVERRIDE = 1, OVERRIDE_SPLIT = 2;
   public static final LookAndFeelInfo DEFAULT_LOOKFEEL =
       new LookAndFeelInfo("Metal", "javax.swing.plaf.metal.MetalLookAndFeel");

--- a/src/org/infinity/gui/BrowserMenuBar.java
+++ b/src/org/infinity/gui/BrowserMenuBar.java
@@ -175,11 +175,6 @@ public final class BrowserMenuBar extends JMenuBar
     return optionsMenu.optionAutocheckBCS.isSelected();
   }
 
-  public boolean checkScriptNames()
-  {
-    return optionsMenu.optionCheckScriptNames.isSelected();
-  }
-
   public boolean showMoreCompileWarnings()
   {
     return optionsMenu.optionMoreCompileWarnings.isSelected();
@@ -1546,7 +1541,6 @@ public final class BrowserMenuBar extends JMenuBar
     private static final String OPTION_SHOWUNKNOWNRESOURCES     = "ShowUnknownResources";
     private static final String OPTION_AUTOCHECK_BCS            = "AutocheckBCS";
     private static final String OPTION_CACHEOVERRIDE            = "CacheOverride";
-    private static final String OPTION_CHECKSCRIPTNAMES         = "CheckScriptNames";
     private static final String OPTION_MORECOMPILERWARNINGS     = "MoreCompilerWarnings";
     private static final String OPTION_SHOWSTRREFS              = "ShowStrrefs";
     private static final String OPTION_DLG_SHOWICONS            = "DlgShowIcons";
@@ -1612,7 +1606,7 @@ public final class BrowserMenuBar extends JMenuBar
                               optionSQLEnableSyntax, optionTLKEnableSyntax,
                               optionGLSLEnableCodeFolding;
 
-    private JCheckBoxMenuItem optionAutocheckBCS, optionCheckScriptNames, optionMoreCompileWarnings;
+    private JCheckBoxMenuItem optionAutocheckBCS, optionMoreCompileWarnings;
 
     private JCheckBoxMenuItem optionBackupOnSave, optionShowOffset, optionIgnoreOverride,
                               optionIgnoreReadErrors, optionCacheOverride, optionShowStrrefs,
@@ -1683,11 +1677,6 @@ public final class BrowserMenuBar extends JMenuBar
           new JCheckBoxMenuItem("Autocheck BCS", getPrefs().getBoolean(OPTION_AUTOCHECK_BCS, true));
       optionAutocheckBCS.setToolTipText("Automatically scans scripts for compile error with this option enabled.");
       compilerMenu.add(optionAutocheckBCS);
-      optionCheckScriptNames =
-          new JCheckBoxMenuItem("Interactive script and resource names", getPrefs().getBoolean(OPTION_CHECKSCRIPTNAMES, true));
-      optionCheckScriptNames.setToolTipText("With this option disabled, performance may be boosted, " +
-                                            "but many features involving script or resource names will be disabled.");
-      compilerMenu.add(optionCheckScriptNames);
       optionMoreCompileWarnings =
           new JCheckBoxMenuItem("Show more compiler warnings", getPrefs().getBoolean(OPTION_MORECOMPILERWARNINGS, false));
       optionMoreCompileWarnings.setToolTipText("Script compiler will generate an additional set of less severe " +
@@ -2244,7 +2233,6 @@ public final class BrowserMenuBar extends JMenuBar
       getPrefs().putBoolean(OPTION_SHOWUNKNOWNRESOURCES, optionShowUnknownResources.isSelected());
       getPrefs().putBoolean(OPTION_AUTOCHECK_BCS, optionAutocheckBCS.isSelected());
       getPrefs().putBoolean(OPTION_CACHEOVERRIDE, optionCacheOverride.isSelected());
-      getPrefs().putBoolean(OPTION_CHECKSCRIPTNAMES, optionCheckScriptNames.isSelected());
       getPrefs().putBoolean(OPTION_MORECOMPILERWARNINGS, optionMoreCompileWarnings.isSelected());
       getPrefs().putBoolean(OPTION_SHOWSTRREFS, optionShowStrrefs.isSelected());
       getPrefs().putBoolean(OPTION_DLG_SHOWICONS, optionDlgShowIcons.isSelected());

--- a/src/org/infinity/gui/BrowserMenuBar.java
+++ b/src/org/infinity/gui/BrowserMenuBar.java
@@ -85,7 +85,7 @@ import org.infinity.util.io.FileManager;
 
 public final class BrowserMenuBar extends JMenuBar
 {
-  public static final String VERSION = "v2.1-20170731";
+  public static final String VERSION = "v2.1-20170809";
   public static final int OVERRIDE_IN_THREE = 0, OVERRIDE_IN_OVERRIDE = 1, OVERRIDE_SPLIT = 2;
   public static final LookAndFeelInfo DEFAULT_LOOKFEEL =
       new LookAndFeelInfo("Metal", "javax.swing.plaf.metal.MetalLookAndFeel");

--- a/src/org/infinity/gui/RenderCanvas.java
+++ b/src/org/infinity/gui/RenderCanvas.java
@@ -4,6 +4,7 @@
 
 package org.infinity.gui;
 
+import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Image;
@@ -86,6 +87,12 @@ public class RenderCanvas extends JComponent implements SwingConstants
         currentImage.flush();
       }
       currentImage = image;
+
+      if (currentImage != null) {
+        setPreferredSize(new Dimension(currentImage.getWidth(null), currentImage.getHeight(null)));
+      } else {
+        setPreferredSize(new Dimension(16, 16));
+      }
       update();
     }
   }

--- a/src/org/infinity/gui/RenderCanvas.java
+++ b/src/org/infinity/gui/RenderCanvas.java
@@ -86,7 +86,7 @@ public class RenderCanvas extends JComponent implements SwingConstants
         currentImage.flush();
       }
       currentImage = image;
-      updateSize();
+      update();
     }
   }
 
@@ -233,7 +233,7 @@ public class RenderCanvas extends JComponent implements SwingConstants
   {
     if (newWidth > 0 && newWidth != scaledWidth) {
       scaledWidth = newWidth;
-      updateSize();
+      update();
     }
   }
 
@@ -255,7 +255,7 @@ public class RenderCanvas extends JComponent implements SwingConstants
   {
     if (newHeight > 0 && newHeight != scaledHeight) {
       scaledHeight = newHeight;
-      updateSize();
+      update();
     }
   }
 
@@ -288,11 +288,12 @@ public class RenderCanvas extends JComponent implements SwingConstants
   }
 
 
-  protected void updateSize()
+  protected void update()
   {
-    setPreferredSize(getCanvasSize().getSize());
-    setSize(getPreferredSize());
-    repaint();
+    invalidate();
+    if (getParent() != null) {
+      getParent().repaint();
+    }
   }
 
   protected Rectangle getCanvasSize()

--- a/src/org/infinity/gui/layeritem/AbstractLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AbstractLayerItem.java
@@ -33,7 +33,7 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   private String actionCommand;
   private Viewable viewable;
   private Object objData;
-  private String message;
+  private String message, tooltip;
   private ItemState itemState;
   private Point location;
   private Point center;
@@ -66,12 +66,25 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   }
 
   /**
+   * Initialize object with a specified map location, associated viewable object and message for
+   * both info box and quick info.
+   * @param location Map location
+   * @param viewable Associated Viewable object
+   * @param message Text message for info box and quick info
+   */
+  public AbstractLayerItem(Point location, Viewable viewable, String message)
+  {
+    this(location, viewable, message, message);
+  }
+
+  /**
    * Initialize object with a specific map location, associated Viewable and an additional text message.
    * @param location Map location
    * @param viewable Associated Viewable object
-   * @param msg An arbitrary text message
+   * @param message An arbitrary text message for the info box
+   * @param tooltip A short text message shown as tooltip or menu item text
    */
-  public AbstractLayerItem(Point location, Viewable viewable, String msg)
+  public AbstractLayerItem(Point location, Viewable viewable, String message, String tooltip)
   {
     this.actionListener = new Vector<ActionListener>();
     this.itemStateListener = new Vector<LayerItemListener>();
@@ -79,7 +92,8 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
     this.itemState = ItemState.NORMAL;
     this.center = new Point();
     setMapLocation(location);
-    setMessage(msg);
+    setMessage(message);
+    setQuickInfo(tooltip);
     setActionCommand(null);
     addMouseListener(this);
     addMouseMotionListener(this);
@@ -191,7 +205,7 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   }
 
   /**
-   * Set a simple text message which can be queried at a given time
+   * Set a text message which can be queried at a given time.
    * @param msg The text message
    */
   public void setMessage(String msg)
@@ -204,12 +218,34 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   }
 
   /**
-   * Returns a simple text message associated with the component.
+   * Returns a text message associated with the component.
    * @return A text message.
    */
   public String getMessage()
   {
     return message;
+  }
+
+  /**
+   * Sets a short text message used by tooltips or menu items.
+   * @param info A short text message.
+   */
+  public void setQuickInfo(String info)
+  {
+    if (info != null) {
+      tooltip = info;
+    } else {
+      tooltip = "";
+    }
+  }
+
+  /**
+   * Returns a short text message used by tooltips and menu items.
+   * @return A short text message.
+   */
+  public String getQuickInfo()
+  {
+    return tooltip;
   }
 
   /**
@@ -341,7 +377,7 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   {
     // Tooltip is only displayed over visible areas of this component
     if (isMouseOver(event.getPoint())) {
-      return message;
+      return getQuickInfo();
     } else {
       return null;
     }

--- a/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
@@ -52,7 +52,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
    */
   public AnimatedLayerItem()
   {
-    this(null, null, null, null);
+    this(null);
   }
 
   /**
@@ -61,7 +61,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
    */
   public AnimatedLayerItem(Point location)
   {
-    this(location, null, null, null);
+    this(location, null);
   }
 
   /**
@@ -71,18 +71,30 @@ public class AnimatedLayerItem extends AbstractLayerItem
    */
   public AnimatedLayerItem(Point location, Viewable viewable)
   {
-    this(location, viewable, null, null);
+    this(location, viewable, null);
   }
 
   /**
    * Initialize object with a specific map location, associated Viewable and an additional text message.
    * @param location Map location
    * @param viewable Associated Viewable object
-   * @param msg An arbitrary text message
+   * @param message An arbitrary text message
    */
-  public AnimatedLayerItem(Point location, Viewable viewable, String msg)
+  public AnimatedLayerItem(Point location, Viewable viewable, String message)
   {
-    this(location, viewable, msg, null);
+    this(location, viewable, message, message);
+  }
+
+  /**
+   * Initialize object with a specific map location, associated Viewable and an additional text message.
+   * @param location Map location
+   * @param viewable Associated Viewable object
+   * @param message An arbitrary text message
+   * @param tooltip A short text message shown as tooltip or menu item text
+   */
+  public AnimatedLayerItem(Point location, Viewable viewable, String message, String tooltip)
+  {
+    this(location, viewable, message, tooltip, null);
   }
 
   /**
@@ -90,12 +102,14 @@ public class AnimatedLayerItem extends AbstractLayerItem
    * and an array of Frame object containing graphics data and frame centers.
    * @param location Map location
    * @param viewable Associated Viewable object
-   * @param msg An arbitrary text message
+   * @param message An arbitrary text message for the info box.
+   * @param tooltip A short text message shown as tooltip or menu item text
    * @param anim An array of Frame objects defining the animation for this layer item
    */
-  public AnimatedLayerItem(Point location, Viewable viewable, String msg, BasicAnimationProvider anim)
+  public AnimatedLayerItem(Point location, Viewable viewable, String message, String tooltip,
+                           BasicAnimationProvider anim)
   {
-    super(location, viewable, msg);
+    super(location, viewable, message, tooltip);
     init();
     initAnimation(anim);
   }

--- a/src/org/infinity/gui/layeritem/IconLayerItem.java
+++ b/src/org/infinity/gui/layeritem/IconLayerItem.java
@@ -39,7 +39,7 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
    */
   public IconLayerItem()
   {
-    this(null, null, null, null, null);
+    this(null);
   }
 
   /**
@@ -48,7 +48,7 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
    */
   public IconLayerItem(Point location)
   {
-    this(location, null, null, null, null);
+    this(location, null);
   }
 
   /**
@@ -58,18 +58,18 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
    */
   public IconLayerItem(Point location, Viewable viewable)
   {
-    this(location, viewable, null, null, null);
+    this(location, viewable, null);
   }
 
   /**
    * Initialize object with a specific map location, associated Viewable and an additional text message.
    * @param location Map location
    * @param viewable Associated Viewable object
-   * @param msg An arbitrary text message
+   * @param message An arbitrary text message
    */
-  public IconLayerItem(Point location, Viewable viewable, String msg)
+  public IconLayerItem(Point location, Viewable viewable, String message)
   {
-    this(location, viewable, msg, null, null);
+    this(location, viewable, message, message);
   }
 
   /**
@@ -77,12 +77,26 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
    * and an image for the visual representation.
    * @param location Map location
    * @param viewable Associated Viewable object
-   * @param msg An arbitrary text message
+   * @param message An arbitrary text message
+   * @param tooltip A short text message shown as tooltip or menu item text
+   */
+  public IconLayerItem(Point location, Viewable viewable, String message, String tooltip)
+  {
+    this(location, viewable, message, tooltip, null);
+  }
+
+  /**
+   * Initialize object with a specific map location, associated Viewable, an additional text message
+   * and an image for the visual representation.
+   * @param location Map location
+   * @param viewable Associated Viewable object
+   * @param message An arbitrary text message
+   * @param tooltip A short text message shown as tooltip or menu item text
    * @param image The image to display
    */
-  public IconLayerItem(Point location, Viewable viewable, String msg, Image image)
+  public IconLayerItem(Point location, Viewable viewable, String message, String tooltip, Image image)
   {
-    this(location, viewable, msg, image, null);
+    this(location, viewable, message, tooltip, image, null);
   }
 
   /**
@@ -90,13 +104,15 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
    * an image for the visual representation and a locical center position within the icon.
    * @param location Map location
    * @param viewable Associated Viewable object
-   * @param msg An arbitrary text message
+   * @param message An arbitrary text message
+   * @param tooltip A short text message shown as tooltip or menu item text
    * @param image The image to display
    * @param center Logical center position within the icon
    */
-  public IconLayerItem(Point location, Viewable viewable, String msg, Image image, Point center)
+  public IconLayerItem(Point location, Viewable viewable, String message, String tooltip,
+                       Image image, Point center)
   {
-    super(location, viewable, msg);
+    super(location, viewable, message, tooltip);
     setLayout(new BorderLayout());
     images = new EnumMap<ItemState, Image>(ItemState.class);
     frames = new EnumMap<ItemState, FrameInfo>(ItemState.class);

--- a/src/org/infinity/gui/layeritem/ShapedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/ShapedLayerItem.java
@@ -39,7 +39,7 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
    */
   public ShapedLayerItem()
   {
-    this(null, null, null, null, null);
+    this(null);
   }
 
   /**
@@ -48,7 +48,7 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
    */
   public ShapedLayerItem(Point location)
   {
-    this(location, null, null, null, null);
+    this(location, null);
   }
 
   /**
@@ -58,18 +58,18 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
    */
   public ShapedLayerItem(Point location, Viewable viewable)
   {
-    this(location, viewable, null, null, null);
+    this(location, viewable, null);
   }
 
   /**
    * Initialize object with a specific map location, associated Viewable and an additional text message.
    * @param location Map location
    * @param viewable Associated Viewable object
-   * @param msg An arbitrary text message
+   * @param message An arbitrary text message
    */
-  public ShapedLayerItem(Point location, Viewable viewable, String msg)
+  public ShapedLayerItem(Point location, Viewable viewable, String message)
   {
-    this(location, viewable, msg, null, null);
+    this(location, viewable, message, message);
   }
 
   /**
@@ -77,12 +77,26 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
    * and a shape for the visual representation.
    * @param location Map location
    * @param viewable Associated Viewable object
-   * @param msg An arbitrary text message
+   * @param message An arbitrary text message
+   * @param tooltip A short text message shown as tooltip or menu item text
+   */
+  public ShapedLayerItem(Point location, Viewable viewable, String message, String tooltip)
+  {
+    this(location, viewable, message, tooltip, null);
+  }
+
+  /**
+   * Initialize object with a specific map location, associated Viewable, an additional text message
+   * and a shape for the visual representation.
+   * @param location Map location
+   * @param viewable Associated Viewable object
+   * @param message An arbitrary text message
+   * @param tooltip A short text message shown as tooltip or menu item text
    * @param shape The shape to display
    */
-  public ShapedLayerItem(Point location, Viewable viewable, String msg, Shape shape)
+  public ShapedLayerItem(Point location, Viewable viewable, String message, String tooltip, Shape shape)
   {
-    this(location, viewable, msg, shape, null);
+    this(location, viewable, message, tooltip, shape, null);
   }
 
   /**
@@ -90,13 +104,15 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
    * a shape for the visual representation and a locical center position within the shape.
    * @param location Map location
    * @param viewable Associated Viewable object
-   * @param msg An arbitrary text message
+   * @param message An arbitrary text message
+   * @param tooltip A short text message shown as tooltip or menu item text
    * @param shape The shape to display
    * @param center Logical center position within the shape
    */
-  public ShapedLayerItem(Point location, Viewable viewable, String msg, Shape shape, Point center)
+  public ShapedLayerItem(Point location, Viewable viewable, String message, String tooltip,
+                         Shape shape, Point center)
   {
-    super(location, viewable, msg);
+    super(location, viewable, message, tooltip);
     strokeColors = new EnumMap<ItemState, Color>(ItemState.class);
     strokePen = new EnumMap<ItemState, BasicStroke>(ItemState.class);
     fillColors = new EnumMap<ItemState, Color>(ItemState.class);

--- a/src/org/infinity/resource/EffectFactory.java
+++ b/src/org/infinity/resource/EffectFactory.java
@@ -5121,7 +5121,8 @@ public final class EffectFactory
           s.add(new DecNumber(buffer, offset, 4, EFFECT_SPECIAL));
           break;
       }
-    } else if (Profile.getEngine() == Profile.Engine.BG2) {
+    } else if (Profile.getEngine() == Profile.Engine.BG2 ||
+               Profile.getEngine() == Profile.Engine.IWD2) {
       s.add(new DecNumber(buffer, offset, 4, EFFECT_SPECIAL));
     } else if (Profile.getEngine() == Profile.Engine.PST) {
       switch (effectType) {

--- a/src/org/infinity/resource/EffectFactory.java
+++ b/src/org/infinity/resource/EffectFactory.java
@@ -3001,7 +3001,7 @@ public final class EffectFactory
       case 189: // Increase casting speed factor
         s.add(new DecNumber(buffer, offset, 4, "Amount"));
         s.add(new Bitmap(buffer, offset + 4, 4, "Modifier type",
-                         new String[]{"Increment", "Set", "Set if higher"}));
+                         new String[]{"Increment", "Set", "Set if lower"}));
         break;
 
       case 190: // Increase attack speed factor

--- a/src/org/infinity/resource/EffectFactory.java
+++ b/src/org/infinity/resource/EffectFactory.java
@@ -2999,6 +2999,11 @@ public final class EffectFactory
         break;
 
       case 189: // Increase casting speed factor
+        s.add(new DecNumber(buffer, offset, 4, "Amount"));
+        s.add(new Bitmap(buffer, offset + 4, 4, "Modifier type",
+                         new String[]{"Increment", "Set", "Set if higher"}));
+        break;
+
       case 190: // Increase attack speed factor
         s.add(new DecNumber(buffer, offset, 4, "Amount"));
         s.add(new DecNumber(buffer, offset + 4, 4, AbstractStruct.COMMON_UNUSED));

--- a/src/org/infinity/resource/are/Actor.java
+++ b/src/org/infinity/resource/are/Actor.java
@@ -37,6 +37,7 @@ public final class Actor extends AbstractStruct implements AddRemovable, HasView
   public static final String ARE_ACTOR_DEST_Y               = "Destination: Y";
   public static final String ARE_ACTOR_FLAGS                = "Flags";
   public static final String ARE_ACTOR_IS_SPAWNED           = "Is spawned?";
+  public static final String ARE_ACTOR_RESREF_LETTER        = "First letter of CRE resref"; // confirm!
   public static final String ARE_ACTOR_DIFFICULTY           = "Difficulty";
   public static final String ARE_ACTOR_ANIMATION            = "Animation";
   public static final String ARE_ACTOR_ORIENTATION          = "Orientation";
@@ -199,7 +200,7 @@ public final class Actor extends AbstractStruct implements AddRemovable, HasView
     }
     addField(new Bitmap(buffer, offset + 44, 2, ARE_ACTOR_IS_SPAWNED, s_noyes));
     if (Profile.getEngine() == Profile.Engine.IWD2) {
-      addField(new Unknown(buffer, offset + 46, 1));
+      addField(new TextString(buffer, offset + 46, 1, ARE_ACTOR_RESREF_LETTER));
       addField(new Flag(buffer, offset + 47, 1, ARE_ACTOR_DIFFICULTY, s_diff));
     }
     else {

--- a/src/org/infinity/resource/are/Ambient.java
+++ b/src/org/infinity/resource/are/Ambient.java
@@ -23,6 +23,7 @@ public final class Ambient extends AbstractStruct implements AddRemovable
   public static final String ARE_AMBIENT_ORIGIN_X           = "Origin: X";
   public static final String ARE_AMBIENT_ORIGIN_Y           = "Origin: Y";
   public static final String ARE_AMBIENT_RADIUS             = "Radius";
+  public static final String ARE_AMBIENT_HEIGHT             = "Height";
   public static final String ARE_AMBIENT_PITCH_VARIATION    = "Pitch variation";
   public static final String ARE_AMBIENT_VOLUME_VARIATION   = "Volume variation";
   public static final String ARE_AMBIENT_VOLUME             = "Volume";
@@ -63,7 +64,7 @@ public final class Ambient extends AbstractStruct implements AddRemovable
     addField(new DecNumber(buffer, offset + 32, 2, ARE_AMBIENT_ORIGIN_X));
     addField(new DecNumber(buffer, offset + 34, 2, ARE_AMBIENT_ORIGIN_Y));
     addField(new DecNumber(buffer, offset + 36, 2, ARE_AMBIENT_RADIUS));
-    addField(new Unknown(buffer, offset + 38, 2));
+    addField(new DecNumber(buffer, offset + 38, 2, ARE_AMBIENT_HEIGHT));
     addField(new DecNumber(buffer, offset + 40, 4, ARE_AMBIENT_PITCH_VARIATION));
     addField(new DecNumber(buffer, offset + 44, 2, ARE_AMBIENT_VOLUME_VARIATION));
     addField(new DecNumber(buffer, offset + 46, 2, ARE_AMBIENT_VOLUME));

--- a/src/org/infinity/resource/are/Animation.java
+++ b/src/org/infinity/resource/are/Animation.java
@@ -82,7 +82,9 @@ public final class Animation extends AbstractStruct implements AddRemovable
     addField(new DecNumber(buffer, offset + 60, 2, ARE_ANIMATION_START_RANGE));
     addField(new DecNumber(buffer, offset + 62, 1, ARE_ANIMATION_LOOP_PROBABILITY));
     addField(new DecNumber(buffer, offset + 63, 1, ARE_ANIMATION_START_DELAY));
-    if (Profile.getEngine() == Profile.Engine.BG2 || Profile.isEnhancedEdition()) {
+    if (Profile.getEngine() == Profile.Engine.BG2 ||
+        Profile.getEngine() == Profile.Engine.IWD2 ||
+        Profile.isEnhancedEdition()) {
       addField(new ResourceRef(buffer, offset + 64, ARE_ANIMATION_PALETTE, "BMP"));
     } else {
       addField(new Unknown(buffer, offset + 64, 8));

--- a/src/org/infinity/resource/are/AreResource.java
+++ b/src/org/infinity/resource/are/AreResource.java
@@ -71,6 +71,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
   public static final String ARE_OVERLAY_TRANSPARENCY     = "Overlay transparency";
   public static final String ARE_AREA_DIFFICULTY_2        = "Area difficulty 2";
   public static final String ARE_AREA_DIFFICULTY_3        = "Area difficulty 3";
+  public static final String ARE_AREA_CUR_DIFFICULTY      = "Current area difficulty";  // confirm!
   public static final String ARE_OFFSET_ACTORS            = "Actors offset";
   public static final String ARE_OFFSET_TRIGGERS          = "Triggers offset";
   public static final String ARE_OFFSET_SPAWN_POINTS      = "Spawn points offset";
@@ -495,7 +496,8 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     if (version.toString().equalsIgnoreCase("V9.1")) {
       addField(new DecNumber(buffer, offset + 84, 1, ARE_AREA_DIFFICULTY_2));
       addField(new DecNumber(buffer, offset + 85, 1, ARE_AREA_DIFFICULTY_3));
-      addField(new Unknown(buffer, offset + 86, 14));
+      addField(new DecNumber(buffer, offset + 86, 2, ARE_AREA_CUR_DIFFICULTY));
+      addField(new Unknown(buffer, offset + 88, 12));
       offset += 16;
     }
     SectionOffset offset_actors = new SectionOffset(buffer, offset + 84, ARE_OFFSET_ACTORS,

--- a/src/org/infinity/resource/are/viewer/AreaViewer.java
+++ b/src/org/infinity/resource/are/viewer/AreaViewer.java
@@ -1290,16 +1290,16 @@ public class AreaViewer extends ChildFrame
                   }
                   sb.append(": ");
                   int lenPrefix = sb.length();
-                  int lenMsg = items[k].getMessage().length();
+                  int lenMsg = items[k].getQuickInfo().length();
                   if (lenPrefix + lenMsg > MaxLen) {
-                    sb.append(items[k].getMessage().substring(0, MaxLen - lenPrefix));
+                    sb.append(items[k].getQuickInfo().substring(0, MaxLen - lenPrefix));
                     sb.append("...");
                   } else {
-                    sb.append(items[k].getMessage());
+                    sb.append(items[k].getQuickInfo());
                   }
                   DataMenuItem dmi = new DataMenuItem(sb.toString(), null, items[k]);
                   if (lenPrefix + lenMsg > MaxLen) {
-                    dmi.setToolTipText(items[k].getMessage());
+                    dmi.setToolTipText(items[k].getQuickInfo());
                   }
                   dmi.addActionListener(getListeners());
                   menuItems.add(dmi);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
@@ -223,6 +223,7 @@ public class LayerObjectAmbient extends LayerObject
 
       // creating sound item
       itemIcon = new IconLayerItem(location, ambient, msg, msg, icon[0], Center);
+      itemIcon.setLabelEnabled(Settings.ShowLabelSounds);
       itemIcon.setName(getCategory());
       itemIcon.setToolTipText(msg);
       itemIcon.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
@@ -222,7 +222,7 @@ public class LayerObjectAmbient extends LayerObject
       }
 
       // creating sound item
-      itemIcon = new IconLayerItem(location, ambient, msg, icon[0], Center);
+      itemIcon = new IconLayerItem(location, ambient, msg, msg, icon[0], Center);
       itemIcon.setName(getCategory());
       itemIcon.setToolTipText(msg);
       itemIcon.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
@@ -230,7 +230,7 @@ public class LayerObjectAmbient extends LayerObject
 
       // creating sound range item
       if (icon == IconLocal) {
-        itemShape = new ShapedLayerItem(location, ambient, msg, circle, new Point(radiusLocal, radiusLocal));
+        itemShape = new ShapedLayerItem(location, ambient, msg, msg, circle, new Point(radiusLocal, radiusLocal));
         itemShape.setName(getCategory());
         itemShape.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, color[0]);
         itemShape.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, color[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
@@ -340,7 +340,7 @@ public class LayerObjectAnimation extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      IconLayerItem item1 = new IconLayerItem(location, anim, msg, icon[0], Center);
+      IconLayerItem item1 = new IconLayerItem(location, anim, msg, msg, icon[0], Center);
       item1.setData(keyIcon);
       item1.setName(getCategory());
       item1.setToolTipText(msg);
@@ -348,7 +348,7 @@ public class LayerObjectAnimation extends LayerObject
       item1.setVisible(isVisible());
       items[0] = item1;
 
-      AnimatedLayerItem item2 = new AnimatedLayerItem(location, anim, msg, animation);
+      AnimatedLayerItem item2 = new AnimatedLayerItem(location, anim, msg, msg, animation);
       item2.setData(keyAnim);
       item2.setName(getCategory());
       item2.setToolTipText(msg);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
@@ -342,6 +342,7 @@ public class LayerObjectAnimation extends LayerObject
 
       IconLayerItem item1 = new IconLayerItem(location, anim, msg, msg, icon[0], Center);
       item1.setData(keyIcon);
+      item1.setLabelEnabled(Settings.ShowLabelAnimations);
       item1.setName(getCategory());
       item1.setToolTipText(msg);
       item1.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
@@ -10,6 +10,7 @@ import java.awt.Point;
 import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.Flag;
 import org.infinity.datatype.IdsBitmap;
+import org.infinity.datatype.IsTextual;
 import org.infinity.datatype.ResourceRef;
 import org.infinity.datatype.StringRef;
 import org.infinity.datatype.TextString;
@@ -78,10 +79,12 @@ public class LayerObjectAreActor extends LayerObjectActor
   private void init()
   {
     if (actor != null) {
-      String msg = "";
+      String actorName = "";
+      String actorCreName = "";
       Image[] icon = IconNeutral;
       int ea = 128;   // default: neutral
       try {
+        actorName = ((IsTextual)actor.getAttribute(Actor.ARE_ACTOR_NAME)).getText();
         location.x = ((DecNumber)actor.getAttribute(Actor.ARE_ACTOR_POS_X)).getValue();
         location.y = ((DecNumber)actor.getAttribute(Actor.ARE_ACTOR_POS_Y)).getValue();
 
@@ -99,7 +102,7 @@ public class LayerObjectAreActor extends LayerObjectActor
           }
         }
         if (cre != null) {
-          msg = ((StringRef)cre.getAttribute(Actor.ARE_ACTOR_NAME)).toString();
+          actorCreName = ((StringRef)cre.getAttribute(Actor.ARE_ACTOR_NAME)).toString();
           ea = (int)((IdsBitmap)cre.getAttribute(CreResource.CRE_ALLEGIANCE)).getValue();
         }
         if (ea >= 2 && ea <= 30) {
@@ -123,9 +126,14 @@ public class LayerObjectAreActor extends LayerObjectActor
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, actor, msg, icon[0], Center);
+      String info = actorName.isEmpty() ? actorCreName : actorName;
+      String msg = actorName;
+      if (!actorCreName.equals(actorName)) {
+        msg += " (" + actorCreName + ")";
+      }
+      item = new IconLayerItem(location, actor, msg, info, icon[0], Center);
       item.setName(getCategory());
-      item.setToolTipText(msg);
+      item.setToolTipText(info);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
       item.setVisible(isVisible());
     }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
@@ -132,6 +132,7 @@ public class LayerObjectAreActor extends LayerObjectActor
         msg += " (" + actorCreName + ")";
       }
       item = new IconLayerItem(location, actor, msg, info, icon[0], Center);
+      item.setLabelEnabled(Settings.ShowLabelActorsAre);
       item.setName(getCategory());
       item.setToolTipText(info);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
@@ -207,6 +207,7 @@ public class LayerObjectAutomap extends LayerObject
       }
 
       item = new IconLayerItem(location, note, msg, msg, icon[0], Center);
+      item.setLabelEnabled(Settings.ShowLabelMapNotes);
       item.setName(getCategory());
       item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
@@ -206,7 +206,7 @@ public class LayerObjectAutomap extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, note, msg, icon[0], Center);
+      item = new IconLayerItem(location, note, msg, msg, icon[0], Center);
       item.setName(getCategory());
       item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
@@ -123,7 +123,7 @@ public class LayerObjectAutomapPST extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, note, msg, icon[0], Center);
+      item = new IconLayerItem(location, note, msg, msg, icon[0], Center);
       item.setName(getCategory());
       item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
@@ -124,6 +124,7 @@ public class LayerObjectAutomapPST extends LayerObject
       }
 
       item = new IconLayerItem(location, note, msg, msg, icon[0], Center);
+      item.setLabelEnabled(Settings.ShowLabelMapNotes);
       item.setName(getCategory());
       item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
@@ -143,7 +143,7 @@ public class LayerObjectContainer extends LayerObject
       }
 
       location.x = bounds.x; location.y = bounds.y;
-      item = new ShapedLayerItem(location, container, msg, poly);
+      item = new ShapedLayerItem(location, container, msg, msg, poly);
       item.setName(getCategory());
       item.setToolTipText(msg);
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, Color[0]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -160,7 +160,7 @@ public class LayerObjectDoor extends LayerObject
 
       for (int i = 0; i < 2; i++) {
         location[i].x = bounds[i].x; location[i].y = bounds[i].y;
-        items[i] = new ShapedLayerItem(location[i], door, msg[i], poly[i]);
+        items[i] = new ShapedLayerItem(location[i], door, msg[i], msg[i], poly[i]);
         items[i].setName(getCategory());
         items[i].setToolTipText(msg[i]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.NORMAL, Color[0]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
@@ -163,6 +163,7 @@ public class LayerObjectDoorPoly extends LayerObject
     if (door != null) {
       location = null;
       shapeCoords = null;
+      String[] info = null;
       String[] msg = null;
       Polygon[] poly = null;
       Rectangle[] bounds = null;
@@ -176,6 +177,7 @@ public class LayerObjectDoorPoly extends LayerObject
         openCount = numOpen;
         location = new Point[count];
         shapeCoords = new Point[count][];
+        info = new String[count];
         msg = new String[count];
         poly = new Polygon[count];
         bounds = new Rectangle[count];
@@ -187,6 +189,7 @@ public class LayerObjectDoorPoly extends LayerObject
           if (p != null) {
             String s = ((TextString)door.getAttribute(Door.WED_DOOR_NAME)).toString();
             Flag flags = (Flag)p.getAttribute(org.infinity.resource.wed.Polygon.WED_POLY_FLAGS);
+            info[i] = s;
             if (numOpen > 1) {
               msg[i] = String.format("%1$s %2$d/%3$d %4$s", s, i+1, numOpen, createFlags(flags, desc));
             } else {
@@ -206,6 +209,7 @@ public class LayerObjectDoorPoly extends LayerObject
           if (p != null) {
             String s = ((TextString)door.getAttribute(Door.WED_DOOR_NAME)).toString();
             Flag flags = (Flag)p.getAttribute(org.infinity.resource.wed.Polygon.WED_POLY_FLAGS);
+            info[numOpen+i] = s;
             if (numClosed > 1) {
               msg[numOpen+i] = String.format("%1$s %2$d/%3$d %4$s", s, i+1, numClosed, createFlags(flags, desc));
             } else {
@@ -223,6 +227,9 @@ public class LayerObjectDoorPoly extends LayerObject
         if (shapeCoords == null) {
           shapeCoords = new Point[count][];
         }
+        if (info == null) {
+          info = new String[count];
+        }
         if (msg == null) {
           msg = new String[count];
         }
@@ -239,6 +246,9 @@ public class LayerObjectDoorPoly extends LayerObject
         if (shapeCoords[i] == null) {
           shapeCoords[i] = new Point[0];
         }
+        if (info[i] == null) {
+          info[i] = "";
+        }
         if (msg[i] == null) {
           msg[i] = "";
         }
@@ -254,9 +264,9 @@ public class LayerObjectDoorPoly extends LayerObject
       items = new ShapedLayerItem[count];
       for (int i = 0; i < count; i++) {
         location[i] = new Point(bounds[i].x, bounds[i].y);
-        items[i] = new ShapedLayerItem(location[i], door, msg[i], poly[i]);
+        items[i] = new ShapedLayerItem(location[i], door, msg[i], info[i], poly[i]);
         items[i].setName(getCategory());
-        items[i].setToolTipText(msg[i]);
+        items[i].setToolTipText(info[i]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.NORMAL, Color[0]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, Color[1]);
         items[i].setFillColor(AbstractLayerItem.ItemState.NORMAL, Color[2]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
@@ -100,12 +100,14 @@ public class LayerObjectEntrance extends LayerObject
   private void init()
   {
     if (entrance != null) {
+      String info = "";
       String msg = "";
       try {
         location.x = ((DecNumber)entrance.getAttribute(Entrance.ARE_ENTRANCE_LOCATION_X)).getValue();
         location.y = ((DecNumber)entrance.getAttribute(Entrance.ARE_ENTRANCE_LOCATION_Y)).getValue();
         int o = ((Bitmap)entrance.getAttribute(Entrance.ARE_ENTRANCE_ORIENTATION)).getValue();
         if (o < 0) o = 0; else if (o >= Actor.s_orientation.length) o = Actor.s_orientation.length - 1;
+        info = ((TextString)entrance.getAttribute(Entrance.ARE_ENTRANCE_NAME)).toString();
         msg = String.format("%1$s (%2$s)", ((TextString)entrance.getAttribute(Entrance.ARE_ENTRANCE_NAME)).toString(),
                             Actor.s_orientation[o]);
       } catch (Exception e) {
@@ -124,9 +126,10 @@ public class LayerObjectEntrance extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, entrance, msg, msg, icon[0], Center);
+      item = new IconLayerItem(location, entrance, msg, info, icon[0], Center);
+      item.setLabelEnabled(Settings.ShowLabelEntrances);
       item.setName(getCategory());
-      item.setToolTipText(msg);
+      item.setToolTipText(info);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
       item.setVisible(isVisible());
     }

--- a/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
@@ -124,7 +124,7 @@ public class LayerObjectEntrance extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, entrance, msg, icon[0], Center);
+      item = new IconLayerItem(location, entrance, msg, msg, icon[0], Center);
       item.setName(getCategory());
       item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
@@ -151,6 +151,7 @@ public class LayerObjectIniActor extends LayerObjectActor
 
       ini.setHighlightedLine(creData.getLine() + 1);
       item = new IconLayerItem(location, ini, msg, info, icon[0], Center);
+      item.setLabelEnabled(Settings.ShowLabelActorsIni);
       item.setName(getCategory());
       item.setToolTipText(info);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
@@ -120,6 +120,7 @@ public class LayerObjectIniActor extends LayerObjectActor
 
       // initializations
       Image[] icon;
+      String info = sectionName;
       String msg = ((StringRef)cre.getAttribute(CreResource.CRE_NAME)).toString() + " [" + sectionName + "]";
       int ea = (int)((IdsBitmap)cre.getAttribute(CreResource.CRE_ALLEGIANCE)).getValue();
       location.x = pos[0];
@@ -149,9 +150,9 @@ public class LayerObjectIniActor extends LayerObjectActor
       }
 
       ini.setHighlightedLine(creData.getLine() + 1);
-      item = new IconLayerItem(location, ini, msg, icon[0], Center);
+      item = new IconLayerItem(location, ini, msg, info, icon[0], Center);
       item.setName(getCategory());
-      item.setToolTipText(msg);
+      item.setToolTipText(info);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
       item.setVisible(isVisible());
     }

--- a/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
@@ -127,7 +127,7 @@ public class LayerObjectProTrap extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, trap, msg, icon[0], Center);
+      item = new IconLayerItem(location, trap, msg, msg, icon[0], Center);
       item.setName(getCategory());
       item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
@@ -132,7 +132,7 @@ public class LayerObjectRegion extends LayerObject
       }
 
       location.x = bounds.x; location.y = bounds.y;
-      item = new ShapedLayerItem(location, region, msg, poly);
+      item = new ShapedLayerItem(location, region, msg, msg, poly);
       item.setName(getCategory());
       item.setToolTipText(msg);
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, Color[0]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
@@ -136,7 +136,7 @@ public class LayerObjectSpawnPoint extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, sp, msg, icon[0], Center);
+      item = new IconLayerItem(location, sp, msg, msg, icon[0], Center);
       item.setName(getCategory());
       item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
@@ -137,6 +137,7 @@ public class LayerObjectSpawnPoint extends LayerObject
       }
 
       item = new IconLayerItem(location, sp, msg, msg, icon[0], Center);
+      item.setLabelEnabled(Settings.ShowLabelSpawnPoints);
       item.setName(getCategory());
       item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
@@ -106,7 +106,7 @@ public class LayerObjectWallPoly extends LayerObject
   {
     if (wall != null) {
       shapeCoords = null;
-      String msg = "";
+      String msg = "", info = "";
       Polygon poly = null;
       Rectangle bounds = null;
       int count = 0;
@@ -115,6 +115,7 @@ public class LayerObjectWallPoly extends LayerObject
         int ofs = wall.getOffset();
         count = (ofs - baseOfs) / wall.getSize();
         Flag flags = (Flag)wall.getAttribute(WallPolygon.WED_POLY_FLAGS);
+        info = "Wall polygon #" + count;
         msg = String.format("Wall polygon #%1$d %2$s", count,
                             createFlags(flags, org.infinity.resource.wed.Polygon.s_flags));
         int vNum = ((DecNumber)wall.getAttribute(WallPolygon.WED_POLY_NUM_VERTICES)).getValue();
@@ -137,9 +138,9 @@ public class LayerObjectWallPoly extends LayerObject
       }
 
       location.x = bounds.x; location.y = bounds.y;
-      item = new ShapedLayerItem(location, wall, msg, poly);
+      item = new ShapedLayerItem(location, wall, msg, info, poly);
       item.setName(getCategory());
-      item.setToolTipText(msg);
+      item.setToolTipText(info);
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, Color[0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, Color[1]);
       item.setFillColor(AbstractLayerItem.ItemState.NORMAL, Color[2]);

--- a/src/org/infinity/resource/are/viewer/Settings.java
+++ b/src/org/infinity/resource/are/viewer/Settings.java
@@ -80,6 +80,17 @@ public class Settings
   public static double MiniMapAlpha = getDefaultMiniMapAlpha();
   // One of the MAP_XXX constants for minimaps
   public static int MiniMap = getDefaultMiniMap();
+  // Show label for various layer item types
+  public static boolean ShowLabelActorsAre = getDefaultLabelActorsAre();
+  public static boolean ShowLabelActorsIni = getDefaultLabelActorsIni();
+  public static boolean ShowLabelRegions = getDefaultLabelRegions();
+  public static boolean ShowLabelEntrances = getDefaultLabelEntrances();
+  public static boolean ShowLabelContainers = getDefaultLabelContainers();
+  public static boolean ShowLabelSounds = getDefaultLabelSounds();
+  public static boolean ShowLabelDoors = getDefaultLabelDoors();
+  public static boolean ShowLabelAnimations = getDefaultLabelAnimations();
+  public static boolean ShowLabelMapNotes = getDefaultLabelMapNotes();
+  public static boolean ShowLabelSpawnPoints = getDefaultLabelSpawnPoints();
 
   // Preferences keys for specific settings
   private static final String PREFS_STORESETTINGS           = "StoreSettings";
@@ -102,6 +113,16 @@ public class Settings
   private static final String PREFS_FRAMERATE_ANIMS         = "FrameRateAnims";
   private static final String PREFS_MINIMAP_ALPHA           = "MiniMapAlpha";
   private static final String PREFS_MINIMAP                 = "MiniMap";
+  private static final String PREFS_LABEL_ACTOR_ARE         = "LabelActorAre";
+  private static final String PREFS_LABEL_ACTOR_INI         = "LabelActorIni";
+  private static final String PREFS_LABEL_REGIONS           = "LabelRegions";
+  private static final String PREFS_LABEL_ENTRANCES         = "LabelEntrances";
+  private static final String PREFS_LABEL_CONTAINERS        = "LabelContainers";
+  private static final String PREFS_LABEL_SOUNDS            = "LabelSounds";
+  private static final String PREFS_LABEL_DOORS             = "LabelDoors";
+  private static final String PREFS_LABEL_ANIMATIONS        = "LabelAnimations";
+  private static final String PREFS_LABEL_MAPNOTES          = "LabelMapNotes";
+  private static final String PREFS_LABEL_SPAWNPOINTS       = "LabelSpawnPoints";
 
   private static boolean SettingsLoaded = false;
 
@@ -123,6 +144,16 @@ public class Settings
       FrameRateOverlays = prefs.getDouble(PREFS_FRAMERATE_OVERLAYS, getDefaultFrameRateOverlays());
       FrameRateAnimations = prefs.getDouble(PREFS_FRAMERATE_ANIMS, getDefaultFrameRateAnimations());
       MiniMapAlpha = prefs.getDouble(PREFS_MINIMAP_ALPHA, getDefaultMiniMapAlpha());
+      ShowLabelActorsAre = prefs.getBoolean(PREFS_LABEL_ACTOR_ARE, getDefaultLabelActorsAre());
+      ShowLabelActorsIni = prefs.getBoolean(PREFS_LABEL_ACTOR_INI, getDefaultLabelActorsIni());
+      ShowLabelRegions = prefs.getBoolean(PREFS_LABEL_REGIONS, getDefaultLabelRegions());
+      ShowLabelEntrances = prefs.getBoolean(PREFS_LABEL_ENTRANCES, getDefaultLabelEntrances());
+      ShowLabelContainers = prefs.getBoolean(PREFS_LABEL_CONTAINERS, getDefaultLabelContainers());
+      ShowLabelSounds = prefs.getBoolean(PREFS_LABEL_SOUNDS, getDefaultLabelSounds());
+      ShowLabelDoors = prefs.getBoolean(PREFS_LABEL_DOORS, getDefaultLabelDoors());
+      ShowLabelAnimations = prefs.getBoolean(PREFS_LABEL_ANIMATIONS, getDefaultLabelAnimations());
+      ShowLabelMapNotes = prefs.getBoolean(PREFS_LABEL_MAPNOTES, getDefaultLabelMapNotes());
+      ShowLabelSpawnPoints = prefs.getBoolean(PREFS_LABEL_SPAWNPOINTS, getDefaultLabelSpawnPoints());
 
       // loading layer z-order
       ListLayerOrder.clear();
@@ -172,6 +203,16 @@ public class Settings
     prefs.putDouble(PREFS_FRAMERATE_OVERLAYS, FrameRateOverlays);
     prefs.putDouble(PREFS_FRAMERATE_ANIMS, FrameRateAnimations);
     prefs.putDouble(PREFS_MINIMAP_ALPHA, MiniMapAlpha);
+    prefs.putBoolean(PREFS_LABEL_ACTOR_ARE, ShowLabelActorsAre);
+    prefs.putBoolean(PREFS_LABEL_ACTOR_INI, ShowLabelActorsIni);
+    prefs.putBoolean(PREFS_LABEL_REGIONS, ShowLabelRegions);
+    prefs.putBoolean(PREFS_LABEL_ENTRANCES, ShowLabelEntrances);
+    prefs.putBoolean(PREFS_LABEL_CONTAINERS, ShowLabelContainers);
+    prefs.putBoolean(PREFS_LABEL_SOUNDS, ShowLabelSounds);
+    prefs.putBoolean(PREFS_LABEL_DOORS, ShowLabelDoors);
+    prefs.putBoolean(PREFS_LABEL_ANIMATIONS, ShowLabelAnimations);
+    prefs.putBoolean(PREFS_LABEL_MAPNOTES, ShowLabelMapNotes);
+    prefs.putBoolean(PREFS_LABEL_SPAWNPOINTS, ShowLabelSpawnPoints);
 
     // storing layer z-order
     for (int i = 0; i < ListLayerOrder.size(); i++) {
@@ -346,6 +387,55 @@ public class Settings
     return ViewerConstants.MAP_NONE;
   }
 
+  public static boolean getDefaultLabelActorsAre()
+  {
+    return true;
+  }
+
+  public static boolean getDefaultLabelActorsIni()
+  {
+    return true;
+  }
+
+  public static boolean getDefaultLabelRegions()
+  {
+    return false;
+  }
+
+  public static boolean getDefaultLabelEntrances()
+  {
+    return false;
+  }
+
+  public static boolean getDefaultLabelContainers()
+  {
+    return false;
+  }
+
+  public static boolean getDefaultLabelSounds()
+  {
+    return false;
+  }
+
+  public static boolean getDefaultLabelDoors()
+  {
+    return false;
+  }
+
+  public static boolean getDefaultLabelAnimations()
+  {
+    return false;
+  }
+
+  public static boolean getDefaultLabelMapNotes()
+  {
+    return false;
+  }
+
+  public static boolean getDefaultLabelSpawnPoints()
+  {
+    return false;
+  }
 
   // Converts values from LayerStackingType to LayerType
   public static LayerType stackingToLayer(LayerStackingType type)

--- a/src/org/infinity/resource/are/viewer/Settings.java
+++ b/src/org/infinity/resource/are/viewer/Settings.java
@@ -83,11 +83,11 @@ public class Settings
   // Show label for various layer item types
   public static boolean ShowLabelActorsAre = getDefaultLabelActorsAre();
   public static boolean ShowLabelActorsIni = getDefaultLabelActorsIni();
-  public static boolean ShowLabelRegions = getDefaultLabelRegions();
+//  public static boolean ShowLabelRegions = getDefaultLabelRegions();
   public static boolean ShowLabelEntrances = getDefaultLabelEntrances();
-  public static boolean ShowLabelContainers = getDefaultLabelContainers();
+//  public static boolean ShowLabelContainers = getDefaultLabelContainers();
   public static boolean ShowLabelSounds = getDefaultLabelSounds();
-  public static boolean ShowLabelDoors = getDefaultLabelDoors();
+//  public static boolean ShowLabelDoors = getDefaultLabelDoors();
   public static boolean ShowLabelAnimations = getDefaultLabelAnimations();
   public static boolean ShowLabelMapNotes = getDefaultLabelMapNotes();
   public static boolean ShowLabelSpawnPoints = getDefaultLabelSpawnPoints();
@@ -115,11 +115,11 @@ public class Settings
   private static final String PREFS_MINIMAP                 = "MiniMap";
   private static final String PREFS_LABEL_ACTOR_ARE         = "LabelActorAre";
   private static final String PREFS_LABEL_ACTOR_INI         = "LabelActorIni";
-  private static final String PREFS_LABEL_REGIONS           = "LabelRegions";
+//  private static final String PREFS_LABEL_REGIONS           = "LabelRegions";
   private static final String PREFS_LABEL_ENTRANCES         = "LabelEntrances";
-  private static final String PREFS_LABEL_CONTAINERS        = "LabelContainers";
+//  private static final String PREFS_LABEL_CONTAINERS        = "LabelContainers";
   private static final String PREFS_LABEL_SOUNDS            = "LabelSounds";
-  private static final String PREFS_LABEL_DOORS             = "LabelDoors";
+//  private static final String PREFS_LABEL_DOORS             = "LabelDoors";
   private static final String PREFS_LABEL_ANIMATIONS        = "LabelAnimations";
   private static final String PREFS_LABEL_MAPNOTES          = "LabelMapNotes";
   private static final String PREFS_LABEL_SPAWNPOINTS       = "LabelSpawnPoints";
@@ -146,11 +146,11 @@ public class Settings
       MiniMapAlpha = prefs.getDouble(PREFS_MINIMAP_ALPHA, getDefaultMiniMapAlpha());
       ShowLabelActorsAre = prefs.getBoolean(PREFS_LABEL_ACTOR_ARE, getDefaultLabelActorsAre());
       ShowLabelActorsIni = prefs.getBoolean(PREFS_LABEL_ACTOR_INI, getDefaultLabelActorsIni());
-      ShowLabelRegions = prefs.getBoolean(PREFS_LABEL_REGIONS, getDefaultLabelRegions());
+//      ShowLabelRegions = prefs.getBoolean(PREFS_LABEL_REGIONS, getDefaultLabelRegions());
       ShowLabelEntrances = prefs.getBoolean(PREFS_LABEL_ENTRANCES, getDefaultLabelEntrances());
-      ShowLabelContainers = prefs.getBoolean(PREFS_LABEL_CONTAINERS, getDefaultLabelContainers());
+//      ShowLabelContainers = prefs.getBoolean(PREFS_LABEL_CONTAINERS, getDefaultLabelContainers());
       ShowLabelSounds = prefs.getBoolean(PREFS_LABEL_SOUNDS, getDefaultLabelSounds());
-      ShowLabelDoors = prefs.getBoolean(PREFS_LABEL_DOORS, getDefaultLabelDoors());
+//      ShowLabelDoors = prefs.getBoolean(PREFS_LABEL_DOORS, getDefaultLabelDoors());
       ShowLabelAnimations = prefs.getBoolean(PREFS_LABEL_ANIMATIONS, getDefaultLabelAnimations());
       ShowLabelMapNotes = prefs.getBoolean(PREFS_LABEL_MAPNOTES, getDefaultLabelMapNotes());
       ShowLabelSpawnPoints = prefs.getBoolean(PREFS_LABEL_SPAWNPOINTS, getDefaultLabelSpawnPoints());
@@ -205,11 +205,11 @@ public class Settings
     prefs.putDouble(PREFS_MINIMAP_ALPHA, MiniMapAlpha);
     prefs.putBoolean(PREFS_LABEL_ACTOR_ARE, ShowLabelActorsAre);
     prefs.putBoolean(PREFS_LABEL_ACTOR_INI, ShowLabelActorsIni);
-    prefs.putBoolean(PREFS_LABEL_REGIONS, ShowLabelRegions);
+//    prefs.putBoolean(PREFS_LABEL_REGIONS, ShowLabelRegions);
     prefs.putBoolean(PREFS_LABEL_ENTRANCES, ShowLabelEntrances);
-    prefs.putBoolean(PREFS_LABEL_CONTAINERS, ShowLabelContainers);
+//    prefs.putBoolean(PREFS_LABEL_CONTAINERS, ShowLabelContainers);
     prefs.putBoolean(PREFS_LABEL_SOUNDS, ShowLabelSounds);
-    prefs.putBoolean(PREFS_LABEL_DOORS, ShowLabelDoors);
+//    prefs.putBoolean(PREFS_LABEL_DOORS, ShowLabelDoors);
     prefs.putBoolean(PREFS_LABEL_ANIMATIONS, ShowLabelAnimations);
     prefs.putBoolean(PREFS_LABEL_MAPNOTES, ShowLabelMapNotes);
     prefs.putBoolean(PREFS_LABEL_SPAWNPOINTS, ShowLabelSpawnPoints);
@@ -397,30 +397,30 @@ public class Settings
     return true;
   }
 
-  public static boolean getDefaultLabelRegions()
-  {
-    return false;
-  }
+//  public static boolean getDefaultLabelRegions()
+//  {
+//    return false;
+//  }
 
   public static boolean getDefaultLabelEntrances()
   {
     return false;
   }
 
-  public static boolean getDefaultLabelContainers()
-  {
-    return false;
-  }
+//  public static boolean getDefaultLabelContainers()
+//  {
+//    return false;
+//  }
 
   public static boolean getDefaultLabelSounds()
   {
     return false;
   }
 
-  public static boolean getDefaultLabelDoors()
-  {
-    return false;
-  }
+//  public static boolean getDefaultLabelDoors()
+//  {
+//    return false;
+//  }
 
   public static boolean getDefaultLabelAnimations()
   {

--- a/src/org/infinity/resource/are/viewer/SettingsDialog.java
+++ b/src/org/infinity/resource/are/viewer/SettingsDialog.java
@@ -61,7 +61,19 @@ public class SettingsDialog extends JDialog
                                              "Doors", "Background Animations", "Automap Notes",
                                              "Spawn Points", "Map Transitions", "Projectile Traps",
                                              "Door Polygons", "Wall Polygons" };
+  private static final int INDEX_LABEL_ACTORS_ARE   = 0;
+  private static final int INDEX_LABEL_ACTORS_INI   = 1;
+  private static final int INDEX_LABEL_REGIONS      = 2;
+  private static final int INDEX_LABEL_ENTRANCES    = 3;
+  private static final int INDEX_LABEL_CONTAINERS   = 4;
+  private static final int INDEX_LABEL_SOUNDS       = 5;
+  private static final int INDEX_LABEL_DOORS        = 6;
+  private static final int INDEX_LABEL_ANIMATIONS   = 7;
+  private static final int INDEX_LABEL_MAPNOTES     = 8;
+  private static final int INDEX_LABEL_SPAWNPOINTS  = 9;
+  private static final int INDEX_LABEL_COUNT        = 10;
 
+  private JCheckBox[] cbLabels;
   private SimpleListModel<LayerEntry> modelLayers;
   private JList<LayerEntry> listLayers;
   private JButton bUp, bDown, bDefaultOrder;
@@ -126,6 +138,17 @@ public class SettingsDialog extends JDialog
       Settings.ListLayerOrder.set(i, lt.layer);
     }
 
+    Settings.ShowLabelActorsAre = cbLabels[INDEX_LABEL_ACTORS_ARE].isSelected();
+    Settings.ShowLabelActorsIni = cbLabels[INDEX_LABEL_ACTORS_INI].isSelected();
+    Settings.ShowLabelRegions = cbLabels[INDEX_LABEL_REGIONS].isSelected();
+    Settings.ShowLabelEntrances = cbLabels[INDEX_LABEL_ENTRANCES].isSelected();
+    Settings.ShowLabelContainers = cbLabels[INDEX_LABEL_CONTAINERS].isSelected();
+    Settings.ShowLabelSounds = cbLabels[INDEX_LABEL_SOUNDS].isSelected();
+    Settings.ShowLabelDoors = cbLabels[INDEX_LABEL_DOORS].isSelected();
+    Settings.ShowLabelAnimations = cbLabels[INDEX_LABEL_ANIMATIONS].isSelected();
+    Settings.ShowLabelMapNotes = cbLabels[INDEX_LABEL_MAPNOTES].isSelected();
+    Settings.ShowLabelSpawnPoints = cbLabels[INDEX_LABEL_SPAWNPOINTS].isSelected();
+
     Settings.ShowFrame = cbFrames.getSelectedIndex();
     Settings.OverrideAnimVisibility = cbOverrideAnimVisibility.isSelected();
 
@@ -164,6 +187,17 @@ public class SettingsDialog extends JDialog
   private void resetDialogSettings()
   {
     resetLayerOrder();
+
+    cbLabels[INDEX_LABEL_ACTORS_ARE].setSelected(Settings.getDefaultLabelActorsAre());
+    cbLabels[INDEX_LABEL_ACTORS_INI].setSelected(Settings.getDefaultLabelActorsIni());
+    cbLabels[INDEX_LABEL_REGIONS].setSelected(Settings.getDefaultLabelRegions());
+    cbLabels[INDEX_LABEL_ENTRANCES].setSelected(Settings.getDefaultLabelEntrances());
+    cbLabels[INDEX_LABEL_CONTAINERS].setSelected(Settings.getDefaultLabelContainers());
+    cbLabels[INDEX_LABEL_SOUNDS].setSelected(Settings.getDefaultLabelSounds());
+    cbLabels[INDEX_LABEL_DOORS].setSelected(Settings.getDefaultLabelDoors());
+    cbLabels[INDEX_LABEL_ANIMATIONS].setSelected(Settings.getDefaultLabelAnimations());
+    cbLabels[INDEX_LABEL_MAPNOTES].setSelected(Settings.getDefaultLabelMapNotes());
+    cbLabels[INDEX_LABEL_SPAWNPOINTS].setSelected(Settings.getDefaultLabelSpawnPoints());
 
     cbFrames.setSelectedIndex(Settings.getDefaultShowFrame());
     cbOverrideAnimVisibility.setSelected(Settings.getDefaultOverrideAnimVisibility());
@@ -287,6 +321,47 @@ public class SettingsDialog extends JDialog
     pLayers.add(new JPanel(), c);
 
     // Initializing options
+    // Icon labels
+    JPanel pShowLabels = new JPanel(new GridBagLayout());
+    pShowLabels.setBorder(BorderFactory.createTitledBorder("Show item labels for: "));
+    cbLabels = new JCheckBox[INDEX_LABEL_COUNT];
+    cbLabels[INDEX_LABEL_ACTORS_ARE] = new JCheckBox("Actors (ARE)");
+    cbLabels[INDEX_LABEL_ACTORS_ARE].setSelected(Settings.ShowLabelActorsAre);
+    cbLabels[INDEX_LABEL_ACTORS_INI] = new JCheckBox("Actors (INI)");
+    cbLabels[INDEX_LABEL_ACTORS_INI].setSelected(Settings.ShowLabelActorsIni);
+    cbLabels[INDEX_LABEL_REGIONS] = new JCheckBox("Regions");
+    cbLabels[INDEX_LABEL_REGIONS].setEnabled(false);
+    cbLabels[INDEX_LABEL_REGIONS].setToolTipText("Not yet supported");
+    cbLabels[INDEX_LABEL_REGIONS].setSelected(Settings.ShowLabelRegions);
+    cbLabels[INDEX_LABEL_ENTRANCES] = new JCheckBox("Entrances");
+    cbLabels[INDEX_LABEL_ENTRANCES].setSelected(Settings.ShowLabelEntrances);
+    cbLabels[INDEX_LABEL_CONTAINERS] = new JCheckBox("Containers");
+    cbLabels[INDEX_LABEL_CONTAINERS].setEnabled(false);
+    cbLabels[INDEX_LABEL_CONTAINERS].setToolTipText("Not yet supported");
+    cbLabels[INDEX_LABEL_CONTAINERS].setSelected(Settings.ShowLabelContainers);
+    cbLabels[INDEX_LABEL_SOUNDS] = new JCheckBox("Ambient Sounds");
+    cbLabels[INDEX_LABEL_SOUNDS].setSelected(Settings.ShowLabelSounds);
+    cbLabels[INDEX_LABEL_DOORS] = new JCheckBox("Doors");
+    cbLabels[INDEX_LABEL_DOORS].setEnabled(false);
+    cbLabels[INDEX_LABEL_DOORS].setToolTipText("Not yet supported");
+    cbLabels[INDEX_LABEL_DOORS].setSelected(Settings.ShowLabelDoors);
+    cbLabels[INDEX_LABEL_ANIMATIONS] = new JCheckBox("Background Animations");
+    cbLabels[INDEX_LABEL_ANIMATIONS].setSelected(Settings.ShowLabelAnimations);
+    cbLabels[INDEX_LABEL_MAPNOTES] = new JCheckBox("Automap Notes");
+    cbLabels[INDEX_LABEL_MAPNOTES].setSelected(Settings.ShowLabelMapNotes);
+    cbLabels[INDEX_LABEL_SPAWNPOINTS] = new JCheckBox("Spawn Points");
+    cbLabels[INDEX_LABEL_SPAWNPOINTS].setSelected(Settings.ShowLabelSpawnPoints);
+    for (int idx = 0; idx < cbLabels.length; idx++) {
+      // spread entries over two columns
+      int x = idx & 1;
+      int y = idx / 2;
+      int bottom = (idx == cbLabels.length - 1 || (idx == cbLabels.length - 2 && x == 0)) ? 4 : 0;
+      c = ViewerUtil.setGBC(c, x, y, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START,
+                            GridBagConstraints.NONE, new Insets(0, 4, bottom, 4), 0, 0);
+      pShowLabels.add(cbLabels[idx], c);
+    }
+
+
     // Background animation frame
     JPanel pShowFrame = new JPanel(new GridBagLayout());
     pShowFrame.setBorder(BorderFactory.createTitledBorder("Background animations: "));
@@ -420,23 +495,26 @@ public class SettingsDialog extends JDialog
     JPanel pOptions = new JPanel(new GridBagLayout());
     c = ViewerUtil.setGBC(c, 0, 0, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START,
                           GridBagConstraints.HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0);
-    pOptions.add(pShowFrame, c);
+    pOptions.add(pShowLabels, c);
     c = ViewerUtil.setGBC(c, 0, 1, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START,
                           GridBagConstraints.HORIZONTAL, new Insets(4, 0, 0, 0), 0, 0);
-    pOptions.add(pQuality, c);
+    pOptions.add(pShowFrame, c);
     c = ViewerUtil.setGBC(c, 0, 2, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START,
                           GridBagConstraints.HORIZONTAL, new Insets(4, 0, 0, 0), 0, 0);
-    pOptions.add(pFrameRates, c);
+    pOptions.add(pQuality, c);
     c = ViewerUtil.setGBC(c, 0, 3, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START,
                           GridBagConstraints.HORIZONTAL, new Insets(4, 0, 0, 0), 0, 0);
-    pOptions.add(pMiniMap, c);
+    pOptions.add(pFrameRates, c);
     c = ViewerUtil.setGBC(c, 0, 4, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START,
                           GridBagConstraints.HORIZONTAL, new Insets(4, 0, 0, 0), 0, 0);
+    pOptions.add(pMiniMap, c);
+    c = ViewerUtil.setGBC(c, 0, 5, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START,
+                          GridBagConstraints.HORIZONTAL, new Insets(4, 0, 0, 0), 0, 0);
     pOptions.add(pMisc, c);
-    c = ViewerUtil.setGBC(c, 0, 5, 1, 1, 1.0, 1.0, GridBagConstraints.LINE_START,
+    c = ViewerUtil.setGBC(c, 0, 6, 1, 1, 1.0, 1.0, GridBagConstraints.LINE_START,
                           GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0);
     pOptions.add(new JPanel(), c);
-    c = ViewerUtil.setGBC(c, 0, 6, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START,
+    c = ViewerUtil.setGBC(c, 0, 7, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START,
                           GridBagConstraints.HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0);
     pOptions.add(pButtons, c);
 

--- a/src/org/infinity/resource/are/viewer/SettingsDialog.java
+++ b/src/org/infinity/resource/are/viewer/SettingsDialog.java
@@ -63,15 +63,15 @@ public class SettingsDialog extends JDialog
                                              "Door Polygons", "Wall Polygons" };
   private static final int INDEX_LABEL_ACTORS_ARE   = 0;
   private static final int INDEX_LABEL_ACTORS_INI   = 1;
-  private static final int INDEX_LABEL_REGIONS      = 2;
-  private static final int INDEX_LABEL_ENTRANCES    = 3;
-  private static final int INDEX_LABEL_CONTAINERS   = 4;
-  private static final int INDEX_LABEL_SOUNDS       = 5;
-  private static final int INDEX_LABEL_DOORS        = 6;
-  private static final int INDEX_LABEL_ANIMATIONS   = 7;
-  private static final int INDEX_LABEL_MAPNOTES     = 8;
-  private static final int INDEX_LABEL_SPAWNPOINTS  = 9;
-  private static final int INDEX_LABEL_COUNT        = 10;
+//  private static final int INDEX_LABEL_REGIONS      = 2;
+  private static final int INDEX_LABEL_ENTRANCES    = 2;
+//  private static final int INDEX_LABEL_CONTAINERS   = 4;
+  private static final int INDEX_LABEL_SOUNDS       = 3;
+//  private static final int INDEX_LABEL_DOORS        = 6;
+  private static final int INDEX_LABEL_ANIMATIONS   = 4;
+  private static final int INDEX_LABEL_MAPNOTES     = 5;
+  private static final int INDEX_LABEL_SPAWNPOINTS  = 6;
+  private static final int INDEX_LABEL_COUNT        = 7;
 
   private JCheckBox[] cbLabels;
   private SimpleListModel<LayerEntry> modelLayers;
@@ -140,11 +140,11 @@ public class SettingsDialog extends JDialog
 
     Settings.ShowLabelActorsAre = cbLabels[INDEX_LABEL_ACTORS_ARE].isSelected();
     Settings.ShowLabelActorsIni = cbLabels[INDEX_LABEL_ACTORS_INI].isSelected();
-    Settings.ShowLabelRegions = cbLabels[INDEX_LABEL_REGIONS].isSelected();
+//    Settings.ShowLabelRegions = cbLabels[INDEX_LABEL_REGIONS].isSelected();
     Settings.ShowLabelEntrances = cbLabels[INDEX_LABEL_ENTRANCES].isSelected();
-    Settings.ShowLabelContainers = cbLabels[INDEX_LABEL_CONTAINERS].isSelected();
+//    Settings.ShowLabelContainers = cbLabels[INDEX_LABEL_CONTAINERS].isSelected();
     Settings.ShowLabelSounds = cbLabels[INDEX_LABEL_SOUNDS].isSelected();
-    Settings.ShowLabelDoors = cbLabels[INDEX_LABEL_DOORS].isSelected();
+//    Settings.ShowLabelDoors = cbLabels[INDEX_LABEL_DOORS].isSelected();
     Settings.ShowLabelAnimations = cbLabels[INDEX_LABEL_ANIMATIONS].isSelected();
     Settings.ShowLabelMapNotes = cbLabels[INDEX_LABEL_MAPNOTES].isSelected();
     Settings.ShowLabelSpawnPoints = cbLabels[INDEX_LABEL_SPAWNPOINTS].isSelected();
@@ -190,11 +190,11 @@ public class SettingsDialog extends JDialog
 
     cbLabels[INDEX_LABEL_ACTORS_ARE].setSelected(Settings.getDefaultLabelActorsAre());
     cbLabels[INDEX_LABEL_ACTORS_INI].setSelected(Settings.getDefaultLabelActorsIni());
-    cbLabels[INDEX_LABEL_REGIONS].setSelected(Settings.getDefaultLabelRegions());
+//    cbLabels[INDEX_LABEL_REGIONS].setSelected(Settings.getDefaultLabelRegions());
     cbLabels[INDEX_LABEL_ENTRANCES].setSelected(Settings.getDefaultLabelEntrances());
-    cbLabels[INDEX_LABEL_CONTAINERS].setSelected(Settings.getDefaultLabelContainers());
+//    cbLabels[INDEX_LABEL_CONTAINERS].setSelected(Settings.getDefaultLabelContainers());
     cbLabels[INDEX_LABEL_SOUNDS].setSelected(Settings.getDefaultLabelSounds());
-    cbLabels[INDEX_LABEL_DOORS].setSelected(Settings.getDefaultLabelDoors());
+//    cbLabels[INDEX_LABEL_DOORS].setSelected(Settings.getDefaultLabelDoors());
     cbLabels[INDEX_LABEL_ANIMATIONS].setSelected(Settings.getDefaultLabelAnimations());
     cbLabels[INDEX_LABEL_MAPNOTES].setSelected(Settings.getDefaultLabelMapNotes());
     cbLabels[INDEX_LABEL_SPAWNPOINTS].setSelected(Settings.getDefaultLabelSpawnPoints());
@@ -323,28 +323,28 @@ public class SettingsDialog extends JDialog
     // Initializing options
     // Icon labels
     JPanel pShowLabels = new JPanel(new GridBagLayout());
-    pShowLabels.setBorder(BorderFactory.createTitledBorder("Show item labels for: "));
+    pShowLabels.setBorder(BorderFactory.createTitledBorder("Show icon labels for: "));
     cbLabels = new JCheckBox[INDEX_LABEL_COUNT];
     cbLabels[INDEX_LABEL_ACTORS_ARE] = new JCheckBox("Actors (ARE)");
     cbLabels[INDEX_LABEL_ACTORS_ARE].setSelected(Settings.ShowLabelActorsAre);
     cbLabels[INDEX_LABEL_ACTORS_INI] = new JCheckBox("Actors (INI)");
     cbLabels[INDEX_LABEL_ACTORS_INI].setSelected(Settings.ShowLabelActorsIni);
-    cbLabels[INDEX_LABEL_REGIONS] = new JCheckBox("Regions");
-    cbLabels[INDEX_LABEL_REGIONS].setEnabled(false);
-    cbLabels[INDEX_LABEL_REGIONS].setToolTipText("Not yet supported");
-    cbLabels[INDEX_LABEL_REGIONS].setSelected(Settings.ShowLabelRegions);
+//    cbLabels[INDEX_LABEL_REGIONS] = new JCheckBox("Regions");
+//    cbLabels[INDEX_LABEL_REGIONS].setEnabled(false);
+//    cbLabels[INDEX_LABEL_REGIONS].setToolTipText("Not yet supported");
+//    cbLabels[INDEX_LABEL_REGIONS].setSelected(Settings.ShowLabelRegions);
     cbLabels[INDEX_LABEL_ENTRANCES] = new JCheckBox("Entrances");
     cbLabels[INDEX_LABEL_ENTRANCES].setSelected(Settings.ShowLabelEntrances);
-    cbLabels[INDEX_LABEL_CONTAINERS] = new JCheckBox("Containers");
-    cbLabels[INDEX_LABEL_CONTAINERS].setEnabled(false);
-    cbLabels[INDEX_LABEL_CONTAINERS].setToolTipText("Not yet supported");
-    cbLabels[INDEX_LABEL_CONTAINERS].setSelected(Settings.ShowLabelContainers);
+//    cbLabels[INDEX_LABEL_CONTAINERS] = new JCheckBox("Containers");
+//    cbLabels[INDEX_LABEL_CONTAINERS].setEnabled(false);
+//    cbLabels[INDEX_LABEL_CONTAINERS].setToolTipText("Not yet supported");
+//    cbLabels[INDEX_LABEL_CONTAINERS].setSelected(Settings.ShowLabelContainers);
     cbLabels[INDEX_LABEL_SOUNDS] = new JCheckBox("Ambient Sounds");
     cbLabels[INDEX_LABEL_SOUNDS].setSelected(Settings.ShowLabelSounds);
-    cbLabels[INDEX_LABEL_DOORS] = new JCheckBox("Doors");
-    cbLabels[INDEX_LABEL_DOORS].setEnabled(false);
-    cbLabels[INDEX_LABEL_DOORS].setToolTipText("Not yet supported");
-    cbLabels[INDEX_LABEL_DOORS].setSelected(Settings.ShowLabelDoors);
+//    cbLabels[INDEX_LABEL_DOORS] = new JCheckBox("Doors");
+//    cbLabels[INDEX_LABEL_DOORS].setEnabled(false);
+//    cbLabels[INDEX_LABEL_DOORS].setToolTipText("Not yet supported");
+//    cbLabels[INDEX_LABEL_DOORS].setSelected(Settings.ShowLabelDoors);
     cbLabels[INDEX_LABEL_ANIMATIONS] = new JCheckBox("Background Animations");
     cbLabels[INDEX_LABEL_ANIMATIONS].setSelected(Settings.ShowLabelAnimations);
     cbLabels[INDEX_LABEL_MAPNOTES] = new JCheckBox("Automap Notes");

--- a/src/org/infinity/resource/bcs/Decompiler.java
+++ b/src/org/infinity/resource/bcs/Decompiler.java
@@ -1063,8 +1063,7 @@ public final class Decompiler
   {
     StringBuilder sb = new StringBuilder();
 
-    if (enable && (isGenerateComments() || isGenerateResourcesUsed()) &&
-        BrowserMenuBar.getInstance().checkScriptNames()) {
+    if (enable && (isGenerateComments() || isGenerateResourcesUsed())) {
       ResourceEntry entry = null;
       String[] types = param.getResourceType();
       for (String type: types) {
@@ -1102,8 +1101,7 @@ public final class Decompiler
   {
     StringBuilder sb = new StringBuilder();
 
-    if (enable && (isGenerateComments() || isGenerateResourcesUsed()) &&
-        BrowserMenuBar.getInstance().checkScriptNames() && !value.isEmpty()) {
+    if (enable && (isGenerateComments() || isGenerateResourcesUsed()) && !value.isEmpty()) {
       String[] types = param.getResourceType();
       for (String type: types) {
         if (type.equals(Signatures.Function.Parameter.RESTYPE_SCRIPT) &&
@@ -1173,7 +1171,7 @@ public final class Decompiler
   {
     StringBuilder sb = new StringBuilder();
 
-    if (enable && isGenerateComments() && BrowserMenuBar.getInstance().checkScriptNames()) {
+    if (enable && isGenerateComments()) {
       if (!object.name.isEmpty()) {
         Set<ResourceEntry> set = CreMapCache.getCreForScriptName(object.name);
         if (set != null && !set.isEmpty()) {

--- a/src/org/infinity/resource/bcs/ScriptInfo.java
+++ b/src/org/infinity/resource/bcs/ScriptInfo.java
@@ -515,6 +515,7 @@ public class ScriptInfo
         this.FUNCTION_SIGNATURES.put(ft, new ArrayList<String>(oldList));
       }
     }
+    this.FUNCTION_PARAM_COMMENT.putAll(obj.FUNCTION_PARAM_COMMENT);
   }
 
   /** Returns object specifier IDS resource names. */

--- a/src/org/infinity/resource/cre/CreResource.java
+++ b/src/org/infinity/resource/cre/CreResource.java
@@ -169,6 +169,7 @@ public final class CreResource extends AbstractStruct
   public static final String CRE_LEVEL_WIZARD                 = "Wizard level";
   public static final String CRE_SOUND_SLOT_FMT               = "Sound: %s";
   public static final String CRE_SOUND_SLOT_GENERIC           = "Soundset string";
+  public static final String CRE_ENCHANTMENT_LEVEL            = "Enchantment level";
   public static final String CRE_FEATS_1                      = "Feats (1/3)";
   public static final String CRE_FEATS_2                      = "Feats (2/3)";
   public static final String CRE_FEATS_3                      = "Feats (3/3)";
@@ -1026,7 +1027,7 @@ public final class CreResource extends AbstractStruct
     addField(new ResourceRef(buffer, offset + 44, CRE_PORTRAIT_SMALL, "BMP"));
     addField(new ResourceRef(buffer, offset + 52, CRE_PORTRAIT_LARGE, "BMP"));
     addField(new DecNumber(buffer, offset + 60, 1, CRE_REPUTATION));
-    addField(new Unknown(buffer, offset + 61, 1));
+    addField(new DecNumber(buffer, offset + 61, 1, CRE_HIDE_IN_SHADOWS));
     addField(new DecNumber(buffer, offset + 62, 2, CRE_ARMOR_CLASS));
     addField(new DecNumber(buffer, offset + 64, 2, CRE_AC_MOD_BLUDGEONING));
     addField(new DecNumber(buffer, offset + 66, 2, CRE_AC_MOD_MISSILE));
@@ -1090,7 +1091,8 @@ public final class CreResource extends AbstractStruct
 
     addField(new ResourceRef(buffer, offset + 420, CRE_SCRIPT_TEAM, "BCS"));
     addField(new ResourceRef(buffer, offset + 428, CRE_SCRIPT_SPECIAL_1, "BCS"));
-    addField(new Unknown(buffer, offset + 436, 4));
+    addField(new DecNumber(buffer, offset + 436, 2, CRE_ENCHANTMENT_LEVEL));
+    addField(new Unknown(buffer, offset + 438, 2));
     addField(new Flag(buffer, offset + 440, 4, CRE_FEATS_1, s_feats1));
     addField(new Flag(buffer, offset + 444, 4, CRE_FEATS_2, s_feats2));
     addField(new Flag(buffer, offset + 448, 4, CRE_FEATS_3, s_feats3));

--- a/src/org/infinity/resource/dlg/DlgResource.java
+++ b/src/org/infinity/resource/dlg/DlgResource.java
@@ -96,21 +96,23 @@ public final class DlgResource extends AbstractStruct
       ButtonPanel panel = view.getButtonPanel();
 
       JButton b = (JButton)panel.getControlByType(ButtonPanel.Control.EXPORT_BUTTON);
-      for (final ActionListener l: b.getActionListeners()) {
-        b.removeActionListener(l);
+      if (b != null) {
+        for (final ActionListener l: b.getActionListeners()) {
+          b.removeActionListener(l);
+        }
+        int position = panel.getControlPosition(b);
+        panel.removeControl(position);
+
+        ButtonPopupMenu bpmExport = new ButtonPopupMenu(b.getText());
+        bpmExport.setIcon(b.getIcon());
+
+        miExport = new JMenuItem("as DLG file");
+        miExport.addActionListener(this);
+        miExportWeiDUDialog = new JMenuItem("as WeiDU dialog file");
+        miExportWeiDUDialog.addActionListener(this);
+        bpmExport.setMenuItems(new JMenuItem[]{miExport, miExportWeiDUDialog}, false);
+        panel.addControl(position, bpmExport);
       }
-      int position = panel.getControlPosition(b);
-      panel.removeControl(position);
-
-      ButtonPopupMenu bpmExport = new ButtonPopupMenu(b.getText());
-      bpmExport.setIcon(b.getIcon());
-
-      miExport = new JMenuItem("as DLG file");
-      miExport.addActionListener(this);
-      miExportWeiDUDialog = new JMenuItem("as WeiDU dialog file");
-      miExportWeiDUDialog.addActionListener(this);
-      bpmExport.setMenuItems(new JMenuItem[]{miExport, miExportWeiDUDialog}, false);
-      panel.addControl(position, bpmExport);
     }
 
     return retVal;

--- a/src/org/infinity/resource/pro/ProResource.java
+++ b/src/org/infinity/resource/pro/ProResource.java
@@ -55,6 +55,14 @@ public final class ProResource extends AbstractStruct implements Resource, HasAd
   public static final String PRO_CREATURE_TYPE = "Creature type";
   public static final String PRO_SPELL_DEFAULT = "Default spell";
   public static final String PRO_SPELL_SUCCESS = "Success spell";
+  public static final String PRO_SPELL_ANGLE_MIN = "Angle increase minimum";
+  public static final String PRO_SPELL_ANGLE_MAX = "Angle increase maximum";
+  public static final String PRO_SPELL_CURVE_MIN = "Curve minimum";
+  public static final String PRO_SPELL_CURVE_MAX = "Curve maximum";
+  public static final String PRO_SPELL_THAC0_BONUS = "THAC0 bonus";
+  public static final String PRO_SPELL_THAC0_BONUS_2 = "THAC0 bonus (non-actor)";
+  public static final String PRO_SPELL_RADIUS_MIN = "Radius minimum";
+  public static final String PRO_SPELL_RADIUS_MAX = "Radius maximum";
 
   public static final String[] s_color = {"", "Black", "Blue", "Chromatic", "Gold",
                                            "Green", "Purple", "Red", "White", "Ice",
@@ -237,42 +245,33 @@ public final class ProResource extends AbstractStruct implements Resource, HasAd
       addField(new ColorPicker(buffer, offset + 52, PRO_COLOR, ColorPicker.Format.BGRX));
       addField(new DecNumber(buffer, offset + 56, 2, PRO_COLOR_SPEED));
       addField(new DecNumber(buffer, offset + 58, 2, PRO_SCREEN_SHAKE_AMOUNT));
-      if (Profile.isEnhancedEdition()) {
-        flag.addUpdateListener(this);
-        if (flag.isFlagSet(30)) {
-          SpellProtType type = new SpellProtType(buffer, offset + 62, 2, PRO_CREATURE_TYPE, 1);
-          addField(type.createCreatureValueFromType(buffer, offset + 60));
-          addField(type);
-          type = new SpellProtType(buffer, offset + 66, 2, PRO_CREATURE_TYPE, 2);
-          addField(type.createCreatureValueFromType(buffer, offset + 64));
-          addField(type);
-        } else {
-          IdsTargetType type = new IdsTargetType(buffer, offset + 62, 2, null, 1, null, false);
-          addField(type.createIdsValueFromType(buffer));
-          addField(type);
-          type = new IdsTargetType(buffer, offset + 66, 2, null, 2, null, false);
-          addField(type.createIdsValueFromType(buffer));
-          addField(type);
-        }
+      flag.addUpdateListener(this);
+      if (flag.isFlagSet(30)) {
+        SpellProtType type = new SpellProtType(buffer, offset + 62, 2, PRO_CREATURE_TYPE, 1);
+        addField(type.createCreatureValueFromType(buffer, offset + 60));
+        addField(type);
+        type = new SpellProtType(buffer, offset + 66, 2, PRO_CREATURE_TYPE, 2);
+        addField(type.createCreatureValueFromType(buffer, offset + 64));
+        addField(type);
       } else {
         IdsTargetType type = new IdsTargetType(buffer, offset + 62, 2, null, 1, null, false);
         addField(type.createIdsValueFromType(buffer));
         addField(type);
-        type = new IdsTargetType(buffer, offset + 62, 2, null, 2, null, false);
+        type = new IdsTargetType(buffer, offset + 66, 2, null, 2, null, false);
         addField(type.createIdsValueFromType(buffer));
         addField(type);
       }
       addField(new ResourceRef(buffer, 68, PRO_SPELL_DEFAULT, "SPL"));
       addField(new ResourceRef(buffer, 76, PRO_SPELL_SUCCESS, "SPL"));
       if (Profile.getGame() == Profile.Game.PSTEE) {
-        addField(new DecNumber(buffer, 84, 2, "Angle increase minimum"));
-        addField(new DecNumber(buffer, 86, 2, "Angle increase maximum"));
-        addField(new DecNumber(buffer, 88, 2, "Curve minimum"));
-        addField(new DecNumber(buffer, 90, 2, "Curve maximum"));
-        addField(new DecNumber(buffer, 92, 2, "THAC0 bonus"));
-        addField(new DecNumber(buffer, 94, 2, "THAC0 bonus (non-actor)"));
-        addField(new DecNumber(buffer, 96, 2, "Radium minimum"));
-        addField(new DecNumber(buffer, 98, 2, "Radium maximum"));
+        addField(new DecNumber(buffer, 84, 2, PRO_SPELL_ANGLE_MIN));
+        addField(new DecNumber(buffer, 86, 2, PRO_SPELL_ANGLE_MAX));
+        addField(new DecNumber(buffer, 88, 2, PRO_SPELL_CURVE_MIN));
+        addField(new DecNumber(buffer, 90, 2, PRO_SPELL_CURVE_MAX));
+        addField(new DecNumber(buffer, 92, 2, PRO_SPELL_THAC0_BONUS));
+        addField(new DecNumber(buffer, 94, 2, PRO_SPELL_THAC0_BONUS_2));
+        addField(new DecNumber(buffer, 96, 2, PRO_SPELL_RADIUS_MIN));
+        addField(new DecNumber(buffer, 98, 2, PRO_SPELL_RADIUS_MAX));
         addField(new Unknown(buffer, offset + 100, 156));
       } else {
         addField(new Unknown(buffer, offset + 84, 172));

--- a/src/org/infinity/resource/spl/SplResource.java
+++ b/src/org/infinity/resource/spl/SplResource.java
@@ -55,6 +55,7 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   public static final String SPL_TYPE                             = "Spell type";
   public static final String SPL_EXCLUSION_FLAGS                  = "Exclusion flags";
   public static final String SPL_CASTING_ANIMATION                = "Casting animation";
+  public static final String SPL_MINIMUM_LEVEL                    = "Minimum level (unused)";
   public static final String SPL_PRIMARY_TYPE                     = "Primary type (school)";
   public static final String SPL_SECONDARY_TYPE                   = "Secondary type";
   public static final String SPL_LEVEL                            = "Spell level";
@@ -361,21 +362,21 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
     } else {
       addField(new Bitmap(buffer, offset + 34, 2, SPL_CASTING_ANIMATION, s_anim));  // 0x22
     }
-    addField(new Unknown(buffer, offset + 36, 1));                                    // 0x23
+    addField(new Unknown(buffer, offset + 36, 1, COMMON_UNUSED));               // 0x24
     addField(new PriTypeBitmap(buffer, offset + 37, 1, SPL_PRIMARY_TYPE)); // 0x25
-    addField(new Unknown(buffer, offset + 38, 1));
+    addField(new Unknown(buffer, offset + 38, 1, COMMON_UNUSED));
     addField(new SecTypeBitmap(buffer, offset + 39, 1, SPL_SECONDARY_TYPE));       // 0x27
-    addField(new Unknown(buffer, offset + 40, 12));
+    addField(new Unknown(buffer, offset + 40, 12, COMMON_UNUSED));
     addField(new DecNumber(buffer, offset + 52, 4, SPL_LEVEL));
-    addField(new Unknown(buffer, offset + 56, 2));
+    addField(new Unknown(buffer, offset + 56, 2, COMMON_UNUSED));
     addField(new ResourceRef(buffer, offset + 58, SPL_ICON, "BAM"));
-    addField(new Unknown(buffer, offset + 66, 2));
-    addField(new ResourceRef(buffer, offset + 68, SPL_ICON_GROUND, "BAM"));
-    addField(new Unknown(buffer, offset + 76, 4));
+    addField(new Unknown(buffer, offset + 66, 2, COMMON_UNUSED));
+    addField(new Unknown(buffer, offset + 68, 8, COMMON_UNUSED));
+    addField(new Unknown(buffer, offset + 76, 4, COMMON_UNUSED));
     addField(new StringRef(buffer, offset + 80, SPL_DESCRIPTION));
     addField(new StringRef(buffer, offset + 84, SPL_DESCRIPTION_IDENTIFIED));
     addField(new ResourceRef(buffer, offset + 88, SPL_DESCRIPTION_IMAGE, "BAM"));
-    addField(new Unknown(buffer, offset + 96, 4));
+    addField(new Unknown(buffer, offset + 96, 4, COMMON_UNUSED));
     SectionOffset abil_offset = new SectionOffset(buffer, offset + 100, SPL_OFFSET_ABILITIES,
                                                   Ability.class);
     addField(abil_offset);

--- a/src/org/infinity/resource/sto/ItemSale.java
+++ b/src/org/infinity/resource/sto/ItemSale.java
@@ -10,7 +10,6 @@ import org.infinity.datatype.Bitmap;
 import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.Flag;
 import org.infinity.datatype.ResourceRef;
-import org.infinity.datatype.Unknown;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.util.io.StreamUtils;
@@ -20,6 +19,7 @@ public final class ItemSale extends AbstractStruct implements AddRemovable
   // STO/ItemSale-specific field labels
   public static final String STO_SALE                 = "Item for sale";
   public static final String STO_SALE_ITEM            = "Item";
+  public static final String STO_SALE_EXPIRATION      = "Expiration time";
   public static final String STO_SALE_QUANTITY_FMT    = "Quantity/Charges %d";
   public static final String STO_SALE_FLAGS           = "Flags";
   public static final String STO_SALE_NUM_IN_STOCK    = "# in stock";
@@ -53,7 +53,7 @@ public final class ItemSale extends AbstractStruct implements AddRemovable
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
     addField(new ResourceRef(buffer, offset, STO_SALE_ITEM, "ITM"));
-    addField(new Unknown(buffer, offset + 8, 2));
+    addField(new DecNumber(buffer, offset + 8, 2, STO_SALE_EXPIRATION));
     for (int i = 0; i < 3; i++) {
       addField(new DecNumber(buffer, offset + 10 + (i * 2), 2, String.format(STO_SALE_QUANTITY_FMT, i+1)));
     }

--- a/src/org/infinity/resource/sto/ItemSale11.java
+++ b/src/org/infinity/resource/sto/ItemSale11.java
@@ -21,6 +21,7 @@ public final class ItemSale11 extends AbstractStruct implements AddRemovable
   // STO/ItemSale-specific field labels
   public static final String STO_SALE                 = "Item for sale";
   public static final String STO_SALE_ITEM            = "Item";
+  public static final String STO_SALE_EXPIRATION      = "Expiration time";
   public static final String STO_SALE_QUANTITY_FMT    = "Quantity/Charges %d";
   public static final String STO_SALE_FLAGS           = "Flags";
   public static final String STO_SALE_NUM_IN_STOCK    = "# in stock";
@@ -54,7 +55,7 @@ public final class ItemSale11 extends AbstractStruct implements AddRemovable
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
     addField(new ResourceRef(buffer, offset, STO_SALE_ITEM, "ITM"));
-    addField(new Unknown(buffer, offset + 8, 2));
+    addField(new DecNumber(buffer, offset + 8, 2, STO_SALE_EXPIRATION));
     for (int i = 0; i < 3; i++) {
       addField(new DecNumber(buffer, offset + 10 + (i * 2), 2, String.format(STO_SALE_QUANTITY_FMT, i+1)));
     }

--- a/src/org/infinity/util/CharsetDetector.java
+++ b/src/org/infinity/util/CharsetDetector.java
@@ -1,0 +1,346 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.util;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.infinity.resource.Profile;
+import org.infinity.util.io.FileManager;
+import org.infinity.util.io.StreamUtils;
+
+/**
+ * This class provides methods to determine character sets and conversions for selected
+ * games and languages.
+ */
+public class CharsetDetector
+{
+  // Static list of dialog.tlk samples and associated character sets
+  private static final List<Sample> samples = new ArrayList<>();
+
+  // Only samples of non-standard codepages should be listed (i.e. all except windows-1252 and utf-8)
+  static {
+    // Polish BG1 (requires extra translation)
+    samples.add(new Sample("windows-1250", 7, new byte[]{
+        (byte)0x44, (byte)0x6F, (byte)0x73, (byte)0x6B, (byte)0x6F, (byte)0x6E,
+        (byte)0x61, (byte)0x6C, (byte)0x65, (byte)0x2C, (byte)0x20, (byte)0x77,
+        (byte)0x79, (byte)0xF6, (byte)0x79, (byte)0x77, (byte)0x61, (byte)0x6A,
+        (byte)0x20, (byte)0x73, (byte)0x69, (byte)0xF0, (byte)0x20, (byte)0x6A,
+        (byte)0x61, (byte)0x6B, (byte)0x20, (byte)0x70, (byte)0x6F, (byte)0x74,
+        (byte)0x72, (byte)0x61, (byte)0x66, (byte)0x69, (byte)0x73, (byte)0x7A,
+        (byte)0x2C, (byte)0x20, (byte)0x73, (byte)0x74, (byte)0x61, (byte)0x72,
+        (byte)0x79, (byte)0x20, (byte)0x70, (byte)0x69, (byte)0x65, (byte)0x72,
+        (byte)0x6E, (byte)0x69, (byte)0x6B, (byte)0x75, (byte)0x2E, (byte)0x0D,
+        (byte)0x0A},
+        // uses a custom translation table for selected character codes
+        new CharLookup(new String(new byte[]{(byte)0xe5, (byte)0xe6, (byte)0xe7, (byte)0xe8, (byte)0xe9, (byte)0xea,
+                                             (byte)0xeb, (byte)0xec, (byte)0xed, (byte)0xee, (byte)0xef, (byte)0xf0,
+                                             (byte)0xf1, (byte)0xf2, (byte)0xf4, (byte)0xf5, (byte)0xf6}, Charset.forName("windows-1250")),
+                       new String(new byte[]{(byte)0xa5, (byte)0xc6, (byte)0xca, (byte)0xa3, (byte)0xd3, (byte)0xd1,
+                                             (byte)0x8c, (byte)0x8f, (byte)0xaf, (byte)0xb9, (byte)0xe6, (byte)0xea,
+                                             (byte)0xb3, (byte)0xf1, (byte)0x9c, (byte)0x9f, (byte)0xbf}, Charset.forName("windows-1250")),
+                       new int[]{10249, 20186, 20714})));
+    // Polish BG2
+    samples.add(new Sample("windows-1250", 2, new byte[]{
+        (byte)0x47, (byte)0x72, (byte)0x61, (byte)0xB3, (byte)0x65, (byte)0x9C,
+        (byte)0x20, (byte)0x45, (byte)0x6C, (byte)0x6D, (byte)0x69, (byte)0x6E,
+        (byte)0x73, (byte)0x74, (byte)0x65, (byte)0x72, (byte)0x61, (byte)0x3F}, null));
+    // Polish IWD
+    samples.add(new Sample("windows-1250", 9, new byte[]{(
+        byte)0x53, (byte)0x74, (byte)0x72, (byte)0x61, (byte)0xBF, (byte)0x6E,
+        (byte)0x69, (byte)0x6B}, null));
+    // Polish IWD2
+    samples.add(new Sample("windows-1250", 9, new byte[]{
+        (byte)0x43, (byte)0x68, (byte)0x61, (byte)0x68, (byte)0x6F, (byte)0x70,
+        (byte)0x65, (byte)0x6B, (byte)0x20, (byte)0x53, (byte)0x74, (byte)0x72,
+        (byte)0x61, (byte)0xBF, (byte)0x6E, (byte)0x69, (byte)0x6B}, null));
+    // Polish PST
+    samples.add(new Sample("windows-1250", 8, new byte[]{
+        (byte)0x4E, (byte)0x69, (byte)0x65, (byte)0x73, (byte)0x6B, (byte)0x61,
+        (byte)0x6C, (byte)0x61, (byte)0x6E, (byte)0x79, (byte)0x20, (byte)0x67,
+        (byte)0x6F, (byte)0x72, (byte)0x73, (byte)0x65, (byte)0x74, (byte)0x20,
+        (byte)0x4E, (byte)0x69, (byte)0x65, (byte)0x2D, (byte)0x53, (byte)0xB3,
+        (byte)0x61, (byte)0x77, (byte)0x79}, null));
+    // Czech BG1 (TODO: Confirm!)
+    samples.add(new Sample("windows-1250", 1, new byte[]{
+        (byte)0x44, (byte)0x6F, (byte)0x73, (byte)0x6B, (byte)0x6F, (byte)0x6E,
+        (byte)0x61, (byte)0x6C, (byte)0x65, (byte)0x2C, (byte)0x20, (byte)0x77,
+        (byte)0x79, (byte)0xF6, (byte)0x79, (byte)0x77, (byte)0x61, (byte)0x6A,
+        (byte)0x20, (byte)0x73, (byte)0x69, (byte)0xF0, (byte)0x20, (byte)0x6A,
+        (byte)0x61, (byte)0x6B, (byte)0x20, (byte)0x70, (byte)0x6F, (byte)0x74,
+        (byte)0x72, (byte)0x61, (byte)0x66, (byte)0x69, (byte)0x73, (byte)0x7A,
+        (byte)0x2C, (byte)0x20, (byte)0x73, (byte)0x74, (byte)0x61, (byte)0x72,
+        (byte)0x79, (byte)0x20, (byte)0x70, (byte)0x69, (byte)0x65, (byte)0x72,
+        (byte)0x6E, (byte)0x69, (byte)0x6B, (byte)0x75, (byte)0x2E, (byte)0x0D,
+        (byte)0x0A}, null));
+    // TODO: Czech BG2
+    // Czech IWD (TODO: Confirm!)
+    samples.add(new Sample("windows-1250", 10, new byte[]{
+        (byte)0x52, (byte)0x6F, (byte)0x68, (byte)0xE1, (byte)0xE8, (byte)0x20,
+        (byte)0x6F, (byte)0x62, (byte)0xF8, (byte)0xED}, null));
+    // TODO: Czech IWD2
+    // TODO: Czech PST
+    // Hungarian BG1 (TODO: Confirm!)
+    samples.add(new Sample("windows-1250", 6, new byte[]{
+        (byte)0x44, (byte)0x65, (byte)0x20, (byte)0xE9, (byte)0x6E, (byte)0x20,
+        (byte)0x73, (byte)0x65, (byte)0x6D, (byte)0x6D, (byte)0x69, (byte)0x20,
+        (byte)0x72, (byte)0x6F, (byte)0x73, (byte)0x73, (byte)0x7A, (byte)0x61,
+        (byte)0x74, (byte)0x20, (byte)0x6E, (byte)0x65, (byte)0x6D, (byte)0x20,
+        (byte)0x74, (byte)0x65, (byte)0x74, (byte)0x74, (byte)0x65, (byte)0x6D,
+        (byte)0x21, (byte)0x20, (byte)0x4D, (byte)0x69, (byte)0xE9, (byte)0x72,
+        (byte)0x74, (byte)0x20, (byte)0x76, (byte)0xE1, (byte)0x64, (byte)0x6F,
+        (byte)0x6C, (byte)0x73, (byte)0x7A, (byte)0x3F}, null));
+    // Russian BG1 (TODO: Confirm!)
+    samples.add(new Sample("windows-1251", 6, new byte[]{
+        (byte)0xCD, (byte)0xEE, (byte)0x20, (byte)0xFF, (byte)0x20, (byte)0xED,
+        (byte)0xE5, (byte)0x20, (byte)0xF1, (byte)0xE4, (byte)0xE5, (byte)0xEB,
+        (byte)0xE0, (byte)0xEB, (byte)0x20, (byte)0xED, (byte)0xE8, (byte)0xF7,
+        (byte)0xE5, (byte)0xE3, (byte)0xEE, (byte)0x20, (byte)0xEF, (byte)0xEB,
+        (byte)0xEE, (byte)0xF5, (byte)0xEE, (byte)0xE3, (byte)0xEE, (byte)0x21,
+        (byte)0x20, (byte)0xCF, (byte)0xEE, (byte)0xF7, (byte)0xE5, (byte)0xEC,
+        (byte)0xF3, (byte)0x20, (byte)0xF2, (byte)0xFB, (byte)0x20, (byte)0xEE,
+        (byte)0xE1, (byte)0xE2, (byte)0xE8, (byte)0xED, (byte)0xFF, (byte)0xE5,
+        (byte)0xF8, (byte)0xFC, (byte)0x20, (byte)0xEC, (byte)0xE5, (byte)0xED,
+        (byte)0xFF, (byte)0x20, (byte)0xE2, (byte)0x20, (byte)0xFD, (byte)0xF2,
+        (byte)0xEE, (byte)0xEC, (byte)0x3F}, null));
+    // TODO: Russian BG2
+    // Russian IWD (TODO: Confirm!)
+    samples.add(new Sample("windows-1251", 10, new byte[]{
+        (byte)0xC6, (byte)0xF3, (byte)0xEA, (byte)0x2D, (byte)0xED, (byte)0xEE,
+        (byte)0xF1, (byte)0xEE, (byte)0xF0, (byte)0xEE, (byte)0xE3}, null));
+    // TODO: Russian IWD2
+    // TODO: Russian PST
+    // Turkish BG1 (TODO: Confirm!)
+    samples.add(new Sample("windows-1254", 14, new byte[]{
+        (byte)0x42, (byte)0x69, (byte)0x7A, (byte)0x65, (byte)0x20, (byte)0x79,
+        (byte)0x61, (byte)0x72, (byte)0x64, (byte)0xFD, (byte)0x6D, (byte)0x20,
+        (byte)0x65, (byte)0x74, (byte)0x74, (byte)0x69, (byte)0xF0, (byte)0x69,
+        (byte)0x6E, (byte)0x20, (byte)0x69, (byte)0xE7, (byte)0x69, (byte)0x6E,
+        (byte)0x20, (byte)0x74, (byte)0x65, (byte)0xFE, (byte)0x65, (byte)0x6B,
+        (byte)0x6B, (byte)0xFC, (byte)0x72, (byte)0x20, (byte)0x65, (byte)0x64,
+        (byte)0x65, (byte)0x72, (byte)0x69, (byte)0x7A, (byte)0x2E}, null));
+  }
+
+  private static String charset = null;
+  private static CharLookup lookup = null;
+
+  // not needed
+  protected CharsetDetector() {}
+
+  /** Resets autodetection of character set */
+  public static void clearCache()
+  {
+    charset = null;
+    lookup = null;
+  }
+
+  /**
+   * Attempts to determine the right character set used by the current game.
+   * @param detect {@code false} to return the default charset based on EE or non-EE.
+   *               {@code true} to determine charset from the dialog.tlk based on sample data.
+   * @return the assumed or detected character set.
+   */
+  public static String guessCharset(boolean detect)
+  {
+    if (charset != null) {
+      return charset;
+    }
+
+    String retVal = Profile.isEnhancedEdition() ? Misc.CHARSET_UTF8.name() : Misc.CHARSET_DEFAULT.name();
+    if (!Profile.isEnhancedEdition() && detect) {
+      // finding dialog.tlk
+      Path tlkFile = Profile.getProperty(Profile.Key.GET_GAME_DIALOG_FILE);
+      if (tlkFile == null) {
+        tlkFile = FileManager.queryExisting(Profile.getGameRoot(), "dialog.tlk");
+      }
+
+      if (tlkFile != null) {
+        try (FileChannel ch = FileChannel.open(tlkFile, StandardOpenOption.READ)) {
+          String sig = StreamUtils.readString(ch, 8);
+          if ("TLK V1  ".equals(sig)) {
+            ch.position(0x0a);
+            int numEntries = StreamUtils.readInt(ch);
+            int ofsStrings = StreamUtils.readInt(ch);
+
+            // cycling through all available string samples to find a match
+            for (final Sample sample: samples) {
+              if (sample.strref < numEntries) {
+                int ofs = 0x12 + (sample.strref * 0x1a);
+                int lenString = StreamUtils.readInt(ch.position(ofs + 0x16));
+                if (lenString > 0) {
+                  int ofsString = ofsStrings + StreamUtils.readInt(ch.position(ofs + 0x12));
+                  ByteBuffer buf = StreamUtils.getByteBuffer(lenString);
+                  buf.position(0);
+                  ch.position(ofsString).read(buf);
+                  if (Arrays.equals(buf.array(), sample.data)) {
+                    retVal = sample.charset;
+                    charset = retVal;
+                    lookup = sample.lookup;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+          ch.close();
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+    }
+    return retVal;
+  }
+
+  /**
+   * Marks the specified charset as active charset.
+   * @param charsetName The charset to activate.
+   * @return Charset name.
+   */
+  public static String setCharset(String charsetName)
+  {
+    if (charset == null) {
+      try {
+        Charset.forName(charsetName);
+      } catch (Throwable t) {
+        charsetName = Misc.CHARSET_DEFAULT.name();
+      }
+      charset = charsetName;
+    }
+
+    return charset;
+  }
+
+  /**
+   * Returns the translation table needed for the current dialog.tlk data. This method will only
+   * return a meaningful translation table for Polish BG1. Any other game and language uses an
+   * official character set.
+   * @return A translation table to convert characters to and from an official character set.
+   */
+  public static CharLookup getLookup()
+  {
+    if (lookup == null) {
+      guessCharset(true);
+      lookup = new CharLookup();
+    }
+    return lookup;
+  }
+
+//-------------------------- INNER CLASSES --------------------------
+
+  // Handles character decoding and encoding
+  public static class CharLookup
+  {
+    private final String encoded, decoded;
+    private final int[] excluded;
+
+    /** Initializes an empty {@code CharLookup} object. */
+    public CharLookup()
+    {
+      this(null, null, null);
+    }
+
+    /**
+     * Initializes translation tables.
+     * @param encoded Contains sequence of characters to decode.
+     * @param decoded Contains sequence of corresponding decoded characters.
+     * @param excludedStrrefs List of strrefs that should not be decoded.
+     */
+    public CharLookup(String encoded, String decoded, int[] excludedStrrefs)
+    {
+      if (encoded == null) encoded = "";
+      if (decoded == null) decoded = "";
+      if (excludedStrrefs == null) excludedStrrefs = new int[]{};
+      if (decoded.length() < encoded.length()) {
+        encoded = encoded.substring(0, decoded.length());
+      } else if (encoded.length() < decoded.length()) {
+        decoded = decoded.substring(0, encoded.length());
+      }
+      this.encoded = encoded;
+      this.decoded = decoded;
+      this.excluded = excludedStrrefs;
+    }
+
+    /** Returns whether the specified string is excluded from the encoding process. */
+    public boolean isExcluded(int strref)
+    {
+      for (int i = 0; i < excluded.length; i++) {
+        if (excluded[i] == strref) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /** Decodes the specified string into an official charset. */
+    public String decodeString(String text)
+    {
+      if (!encoded.isEmpty()) {
+        StringBuilder sb = new StringBuilder(text);
+        for (int idx = 0, cnt = sb.length(); idx < cnt; idx++) {
+          sb.setCharAt(idx, decode(sb.charAt(idx)));
+        }
+        text = sb.toString();
+      }
+      return text;
+    }
+
+    /** Encodes the specified string with the character translation table. */
+    public String encodeString(String text)
+    {
+      if (!decoded.isEmpty()) {
+        StringBuilder sb = new StringBuilder(text);
+        for (int idx = 0, cnt = sb.length(); idx < cnt; idx++) {
+          sb.setCharAt(idx, encode(sb.charAt(idx)));
+        }
+        text = sb.toString();
+      }
+      return text;
+    }
+
+    /** Decodes a single character. */
+    public char decode(char ch)
+    {
+      int idx = encoded.indexOf(ch);
+      if (idx >= 0) {
+        ch = decoded.charAt(idx);
+      }
+      return ch;
+    }
+
+    /** Encodes a single character. */
+    public char encode(char ch)
+    {
+      int idx = decoded.indexOf(ch);
+      if (idx >= 0) {
+        ch = encoded.charAt(idx);
+      }
+      return ch;
+    }
+
+  }
+
+  // Stores a single string -> charset pair
+  private static class Sample
+  {
+    public CharLookup lookup;
+    public String charset;
+    public int strref;
+    public byte[] data;
+
+    public Sample(String charset, int strref, byte[] data, CharLookup lookup)
+    {
+      this.charset = charset;
+      this.strref = strref;
+      this.data = data;
+      this.lookup = (lookup != null) ? lookup : new CharLookup();
+    }
+  }
+}

--- a/src/org/infinity/util/CreMapCache.java
+++ b/src/org/infinity/util/CreMapCache.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.infinity.NearInfinity;
-import org.infinity.gui.BrowserMenuBar;
 import org.infinity.gui.StatusBar;
 import org.infinity.resource.Profile;
 import org.infinity.resource.ResourceFactory;
@@ -30,7 +29,6 @@ public final class CreMapCache
   private static final Map<String, Set<ResourceEntry>> scriptNamesCre = new HashMap<>();
   private static final Set<String> scriptNamesAre = new HashSet<>();
 
-  private static boolean enabled = false;
   private static boolean initialized = false;
 
   public static void creInvalid(ResourceEntry entry)
@@ -53,22 +51,13 @@ public final class CreMapCache
       scriptNamesCre.clear();
       scriptNamesAre.clear();
       initialized = false;
-      enabled = false;
     }
   }
 
   public static void reset()
   {
-    enabled = BrowserMenuBar.getInstance() != null && BrowserMenuBar.getInstance().checkScriptNames();
-    if (enabled) {
-      clearCache();
-      init();
-    }
-  }
-
-  public static boolean isEnabled()
-  {
-    return enabled;
+    clearCache();
+    init();
   }
 
   public static boolean isInitialized()
@@ -91,7 +80,7 @@ public final class CreMapCache
     if (isInitialized() && name != null) {
       return scriptNamesCre.containsKey(normalized(name));
     } else {
-      return !isEnabled();
+      return false;
     }
   }
 
@@ -101,7 +90,7 @@ public final class CreMapCache
     if (isInitialized() && name != null) {
       return scriptNamesAre.contains(normalized(name));
     } else {
-      return !isEnabled();
+      return false;
     }
   }
 
@@ -128,7 +117,7 @@ public final class CreMapCache
   private static boolean ensureInitialized(int timeOutMS)
   {
     long timeOut = (timeOutMS >= 0) ? System.nanoTime() + (timeOutMS * 1000000L) : -1L;
-    while (isEnabled() && !isInitialized() &&
+    while (!isInitialized() &&
            (timeOut == -1L || System.nanoTime() < timeOut)) {
       try {
         Thread.sleep(1);

--- a/src/org/infinity/util/CreMapCache.java
+++ b/src/org/infinity/util/CreMapCache.java
@@ -30,6 +30,7 @@ public final class CreMapCache
   private static final Map<String, Set<ResourceEntry>> scriptNamesCre = new HashMap<>();
   private static final Set<String> scriptNamesAre = new HashSet<>();
 
+  private static boolean enabled = false;
   private static boolean initialized = false;
 
   public static void creInvalid(ResourceEntry entry)
@@ -52,15 +53,22 @@ public final class CreMapCache
       scriptNamesCre.clear();
       scriptNamesAre.clear();
       initialized = false;
+      enabled = false;
     }
   }
 
   public static void reset()
   {
-    if (BrowserMenuBar.getInstance() != null && BrowserMenuBar.getInstance().checkScriptNames()) {
+    enabled = BrowserMenuBar.getInstance() != null && BrowserMenuBar.getInstance().checkScriptNames();
+    if (enabled) {
       clearCache();
       init();
     }
+  }
+
+  public static boolean isEnabled()
+  {
+    return enabled;
   }
 
   public static boolean isInitialized()
@@ -83,7 +91,7 @@ public final class CreMapCache
     if (isInitialized() && name != null) {
       return scriptNamesCre.containsKey(normalized(name));
     } else {
-      return false;
+      return !isEnabled();
     }
   }
 
@@ -93,7 +101,7 @@ public final class CreMapCache
     if (isInitialized() && name != null) {
       return scriptNamesAre.contains(normalized(name));
     } else {
-      return false;
+      return !isEnabled();
     }
   }
 
@@ -120,7 +128,7 @@ public final class CreMapCache
   private static boolean ensureInitialized(int timeOutMS)
   {
     long timeOut = (timeOutMS >= 0) ? System.nanoTime() + (timeOutMS * 1000000L) : -1L;
-    while (!isInitialized() &&
+    while (isEnabled() && !isInitialized() &&
            (timeOut == -1L || System.nanoTime() < timeOut)) {
       try {
         Thread.sleep(1);


### PR DESCRIPTION
I've been using NI and it helps me a lot for gameplay and building Baldur's Gate wikia, thank you!
I have but one request, as of the currently version of NI, exporting area map to .png will only grant plain map images, but I know that we can use "Automap Notes" show marker for creatures, doors, chests, and other map notes, I've been wondering if you can implement this feature to exported images, which is, the option to export the exact images we're viewing in NI with highlighted map notes. I hope it's not too much to ask, but as of now, I have to use a 3rd party screencapture software to do the work, which isn't easy for large maps.
Oh, a question if I may, instead of listing the code tree, now can I, if possible, switch to a list with actual in-game names, that would be easier to search for a particular thing based on in-game name.
Thank you.
You may also find me at baldursgate.wikia.com/wiki/User_talk:Islandking, and in BD forum where I think we've exchanged a few words in the Ascension mod thread. :-)