### PR TITLE
Fix compilation on JDK >= 9

### DIFF
--- a/src/org/infinity/gui/OpenResourceDialog.java
+++ b/src/org/infinity/gui/OpenResourceDialog.java
@@ -252,7 +252,7 @@ public class OpenResourceDialog extends JDialog
   }
 
 
-  private void accept()
+  private void acceptDialog()
   {
     setVisible(false);
     List<ResourceEntry> entries = list.getSelectedValuesList();
@@ -441,7 +441,7 @@ public class OpenResourceDialog extends JDialog
       @Override
       public void actionPerformed(ActionEvent e)
       {
-        accept();
+        acceptDialog();
       }
     };
     AbstractAction actCancel = new AbstractAction("Cancel") {
@@ -489,7 +489,7 @@ public class OpenResourceDialog extends JDialog
       public void mouseClicked(MouseEvent event)
       {
         if (event.getClickCount() == 2 && !list.isSelectionEmpty()) {
-          accept();
+          acceptDialog();
         }
       }
     });

--- a/src/org/infinity/gui/converter/ConvertToBam.java
+++ b/src/org/infinity/gui/converter/ConvertToBam.java
@@ -5001,7 +5001,7 @@ public class ConvertToBam extends ChildFrame
     public void actionPerformed(ActionEvent event)
     {
       if (event.getSource() == bAccept) {
-        accept();
+        acceptDialog();
       } else if (event.getSource() == bCancel) {
         cancel();
       } else if (event.getSource() instanceof JCheckBox) {
@@ -5761,7 +5761,7 @@ public class ConvertToBam extends ChildFrame
     }
 
     // Disposes the dialog and marks it as accepted
-    private void accept()
+    private void acceptDialog()
     {
       setVisible(false);
       accepted = true;
@@ -5796,7 +5796,7 @@ public class ConvertToBam extends ChildFrame
         @Override
         public void actionPerformed(ActionEvent e)
         {
-          accept();
+          acceptDialog();
         }
       });
 


### PR DESCRIPTION
In java9 interface Action get default method `accept` which conflicts with some methods in the codebase:
```
error: method accept in interface Action cannot be applied to given types;
        accept();
  required: Object
  found: no arguments
  reason: actual and formal argument lists differ in length
```
See https://docs.oracle.com/javase/9/docs/api/javax/swing/Action.html#accept-java.lang.Object-.