### PR TITLE
Refactor AbstractStruct usage - use iterators where possible

### DIFF
--- a/src/org/infinity/check/CreInvChecker.java
+++ b/src/org/infinity/check/CreInvChecker.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.check;
@@ -200,8 +200,7 @@ public final class CreInvChecker extends AbstractSearcher implements Runnable, A
     final List<Item> items = new ArrayList<>();
     final List<DecNumber> slots = new ArrayList<>();
     final DecNumber slots_offset = (DecNumber)cre.getAttribute(CreResource.CRE_OFFSET_ITEM_SLOTS);
-    for (int i = 0; i < cre.getFieldCount(); i++) {
-      final StructEntry entry = cre.getField(i);
+    for (final StructEntry entry : cre.getList()) {
       if (entry instanceof Item) {
         items.add((Item)entry);
       } else if (entry.getOffset() >= slots_offset.getValue() + cre.getOffset() &&

--- a/src/org/infinity/check/CreInvChecker.java
+++ b/src/org/infinity/check/CreInvChecker.java
@@ -200,7 +200,7 @@ public final class CreInvChecker extends AbstractSearcher implements Runnable, A
     final List<Item> items = new ArrayList<>();
     final List<DecNumber> slots = new ArrayList<>();
     final DecNumber slots_offset = (DecNumber)cre.getAttribute(CreResource.CRE_OFFSET_ITEM_SLOTS);
-    for (final StructEntry entry : cre.getList()) {
+    for (final StructEntry entry : cre.getFields()) {
       if (entry instanceof Item) {
         items.add((Item)entry);
       } else if (entry.getOffset() >= slots_offset.getValue() + cre.getOffset() &&

--- a/src/org/infinity/check/DialogChecker.java
+++ b/src/org/infinity/check/DialogChecker.java
@@ -245,8 +245,7 @@ public final class DialogChecker extends AbstractSearcher implements Runnable, A
     return () -> {
       try {
         final DlgResource dialog = new DlgResource(entry);
-        for (int i = 0; i < dialog.getFieldCount(); ++i) {
-          final StructEntry o = dialog.getField(i);
+        for (final StructEntry o : dialog.getList()) {
           if (o instanceof AbstractCode) {
             checkCode(entry, (AbstractCode)o);
           } else

--- a/src/org/infinity/check/DialogChecker.java
+++ b/src/org/infinity/check/DialogChecker.java
@@ -245,7 +245,7 @@ public final class DialogChecker extends AbstractSearcher implements Runnable, A
     return () -> {
       try {
         final DlgResource dialog = new DlgResource(entry);
-        for (final StructEntry o : dialog.getList()) {
+        for (final StructEntry o : dialog.getFields()) {
           if (o instanceof AbstractCode) {
             checkCode(entry, (AbstractCode)o);
           } else

--- a/src/org/infinity/check/EffectsIndexChecker.java
+++ b/src/org/infinity/check/EffectsIndexChecker.java
@@ -58,7 +58,7 @@ public class EffectsIndexChecker extends AbstractChecker
   {
     final int numGlobalEffects = ((SectionCount) struct.getAttribute(SplResource.SPL_NUM_GLOBAL_EFFECTS)).getValue();
     int expectedEffectsIndex = numGlobalEffects;
-    for (StructEntry e : struct.getList()) {
+    for (final StructEntry e : struct.getFields()) {
       if (e instanceof AbstractAbility) {
         final AbstractAbility abil = (AbstractAbility) e;
         final int effectsIndex = ((DecNumber) abil.getAttribute(AbstractAbility.ABILITY_FIRST_EFFECT_INDEX)).getValue();

--- a/src/org/infinity/check/IDSRefChecker.java
+++ b/src/org/infinity/check/IDSRefChecker.java
@@ -53,7 +53,7 @@ public final class IDSRefChecker extends AbstractChecker
 
   private void search(ResourceEntry entry, AbstractStruct struct)
   {
-    for (StructEntry e : struct.getFlatList()) {
+    for (final StructEntry e : struct.getFlatFields()) {
       if (e instanceof IdsBitmap) {
         final IdsBitmap ref = (IdsBitmap)e;
         final long value = ref.getLongValue();

--- a/src/org/infinity/check/ResRefChecker.java
+++ b/src/org/infinity/check/ResRefChecker.java
@@ -66,7 +66,7 @@ public final class ResRefChecker extends AbstractChecker
 
   private void search(ResourceEntry entry, AbstractStruct struct)
   {
-    for (StructEntry e : struct.getFlatList()) {
+    for (final StructEntry e : struct.getFlatFields()) {
       if (!(e instanceof ResourceRef)) { continue; }
 
       final ResourceRef ref = (ResourceRef)e;

--- a/src/org/infinity/check/ResourceUseChecker.java
+++ b/src/org/infinity/check/ResourceUseChecker.java
@@ -275,7 +275,7 @@ public final class ResourceUseChecker extends AbstractSearcher implements Runnab
 
   private void checkDialog(DlgResource dialog)
   {
-    for (StructEntry entry : dialog.getList()) {
+    for (final StructEntry entry : dialog.getFields()) {
       if (entry instanceof ResourceRef) {
         checkResourceRef((ResourceRef)entry);
       }
@@ -292,7 +292,7 @@ public final class ResourceUseChecker extends AbstractSearcher implements Runnab
       }
       else if (checkType.equalsIgnoreCase("WAV") &&
                (entry instanceof State || entry instanceof Transition)) {
-        for (StructEntry e : ((AbstractStruct)entry).getFlatList()) {
+        for (final StructEntry e : ((AbstractStruct)entry).getFlatFields()) {
           if (e instanceof StringRef) {
             checkSound((StringRef)e);
           }
@@ -312,7 +312,7 @@ public final class ResourceUseChecker extends AbstractSearcher implements Runnab
 
   private void checkStruct(AbstractStruct struct)
   {
-    for (StructEntry entry : struct.getFlatList()) {
+    for (final StructEntry entry : struct.getFlatFields()) {
       if (entry instanceof ResourceRef) {
         checkResourceRef((ResourceRef)entry);
       }

--- a/src/org/infinity/check/StringUseChecker.java
+++ b/src/org/infinity/check/StringUseChecker.java
@@ -215,7 +215,7 @@ public final class StringUseChecker extends AbstractSearcher implements Runnable
 
   private void checkDialog(DlgResource dialog)
   {
-    for (StructEntry entry : dialog.getFlatList()) {
+    for (final StructEntry entry : dialog.getFlatFields()) {
       if (entry instanceof StringRef) {
         checkStringRef((StringRef)entry);
       }
@@ -244,7 +244,7 @@ public final class StringUseChecker extends AbstractSearcher implements Runnable
 
   private void checkStruct(AbstractStruct struct)
   {
-    for (StructEntry entry : struct.getFlatList()) {
+    for (final StructEntry entry : struct.getFlatFields()) {
       if (entry instanceof StringRef) {
         checkStringRef((StringRef)entry);
       }

--- a/src/org/infinity/check/StrrefIndexChecker.java
+++ b/src/org/infinity/check/StrrefIndexChecker.java
@@ -200,7 +200,7 @@ public class StrrefIndexChecker extends AbstractChecker implements ListSelection
 
   private void checkDialog(DlgResource dialog)
   {
-    for (final StructEntry entry : dialog.getFlatList()) {
+    for (final StructEntry entry : dialog.getFlatFields()) {
       if (entry instanceof StringRef) {
         final int strref = ((StringRef)entry).getValue();
         if (strref < -1 || strref >= strrefCount) {
@@ -270,7 +270,7 @@ public class StrrefIndexChecker extends AbstractChecker implements ListSelection
 
   private void checkStruct(AbstractStruct struct)
   {
-    for (final StructEntry entry : struct.getFlatList()) {
+    for (final StructEntry entry : struct.getFlatFields()) {
       if (entry instanceof StringRef) {
         final int strref = ((StringRef)entry).getValue();
         if (strref < -1 || strref >= strrefCount) {

--- a/src/org/infinity/check/StructChecker.java
+++ b/src/org/infinity/check/StructChecker.java
@@ -206,7 +206,7 @@ public final class StructChecker extends AbstractChecker implements ListSelectio
 
   private void search(ResourceEntry entry, AbstractStruct struct)
   {
-    List<StructEntry> flatList = struct.getFlatList();
+    final List<StructEntry> flatList = struct.getFlatFields();
     if (flatList.size() < 2) {
       return;
     }
@@ -350,10 +350,9 @@ public final class StructChecker extends AbstractChecker implements ListSelectio
         int tileEndOfs = tileStartOfs + numTiles*tileSize;
         int indexEndOfs = indexStartOfs + 2*numTiles;
         // caching tile maps and tile lookup indices
-        HashMap<Integer, Tilemap> mapTiles = new HashMap<Integer, Tilemap>(numTiles*3/2, 0.8f);
-        HashMap<Integer, Integer> mapIndices = new HashMap<Integer, Integer>(numTiles*3/2, 0.8f);
-        for (Iterator<StructEntry> iter = overlay.getList().iterator(); iter.hasNext();) {
-          StructEntry item = iter.next();
+        final HashMap<Integer, Tilemap> mapTiles = new HashMap<>(numTiles*3/2, 0.8f);
+        final HashMap<Integer, Integer> mapIndices = new HashMap<>(numTiles*3/2, 0.8f);
+        for (final StructEntry item : overlay.getFields()) {
           int curOfs = item.getOffset();
           if (curOfs >= tileStartOfs && curOfs < tileEndOfs && item instanceof Tilemap) {
             int index = (curOfs - tileStartOfs) / item.getSize();

--- a/src/org/infinity/datatype/Bestiary.java
+++ b/src/org/infinity/datatype/Bestiary.java
@@ -220,7 +220,7 @@ public final class Bestiary extends Datatype implements Editable, TableModel
       KillVariable var = (KillVariable)game.getAttribute(offset.getValue(), KillVariable.class, false);
       if (var == null) return null;
 
-      final List<StructEntry> fields = game.getList();
+      final List<StructEntry> fields = game.getFields();
       final ListIterator<StructEntry> it = fields.listIterator(fields.indexOf(var));
       while (it.hasNext()) {
         final StructEntry entry = it.next();

--- a/src/org/infinity/datatype/Datatype.java
+++ b/src/org/infinity/datatype/Datatype.java
@@ -45,7 +45,7 @@ public abstract class Datatype implements StructEntry
 
   private String name;
   private int offset;
-  private StructEntry parent;
+  private AbstractStruct parent;
 
   protected Datatype(int offset, int length, String name)
   {
@@ -81,7 +81,7 @@ public abstract class Datatype implements StructEntry
   }
 
   @Override
-  public StructEntry getParent()
+  public AbstractStruct getParent()
   {
     return parent;
   }
@@ -137,7 +137,7 @@ public abstract class Datatype implements StructEntry
   }
 
   @Override
-  public void setParent(StructEntry parent)
+  public void setParent(AbstractStruct parent)
   {
     this.parent = parent;
   }

--- a/src/org/infinity/datatype/EffectType.java
+++ b/src/org/infinity/datatype/EffectType.java
@@ -43,7 +43,7 @@ public final class EffectType extends Bitmap implements UpdateListener
         StructEntry entry = list.get(i);
         entry.setOffset(entry.getOffset() + getOffset() + getSize());
       }
-      struct.addToList(this, list);
+      struct.addFields(this, list);
       return true;
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/org/infinity/datatype/IdsTargetType.java
+++ b/src/org/infinity/datatype/IdsTargetType.java
@@ -6,7 +6,7 @@ package org.infinity.datatype;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 
 import org.infinity.resource.AbstractStruct;
@@ -85,14 +85,15 @@ public class IdsTargetType extends Bitmap
     boolean retVal = super.updateValue(struct);
     if (updateIdsValues && retVal) {
       int valueOffset = getOffset() - getSize();
-      List<StructEntry> list = struct.getList();
-      for (int i = 0, size = list.size(); i < size; i++) {
-        StructEntry entry = list.get(i);
+      final ListIterator<StructEntry> it = struct.getFields().listIterator();
+      while (it.hasNext()) {
+        final int i = it.nextIndex();
+        final StructEntry entry = it.next();
         if (entry.getOffset() == valueOffset && entry instanceof Datatype) {
-          ByteBuffer buffer = ((Datatype)entry).getDataBuffer();
+          final ByteBuffer buffer = entry.getDataBuffer();
           StructEntry newEntry = createIdsValueFromType(buffer, 0);
           newEntry.setOffset(valueOffset);
-          list.set(i, newEntry);
+          it.set(newEntry);
 
           // notifying listeners
           struct.fireTableRowsUpdated(i, i);

--- a/src/org/infinity/datatype/SpellProtType.java
+++ b/src/org/infinity/datatype/SpellProtType.java
@@ -6,7 +6,7 @@ package org.infinity.datatype;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.List;
+import java.util.ListIterator;
 
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.Profile;
@@ -107,14 +107,15 @@ public class SpellProtType extends Bitmap
     boolean retVal = super.updateValue(struct);
     if (updateIdsValues && retVal) {
       int valueOffset = getOffset() - getSize();
-      List<StructEntry> list = struct.getList();
-      for (int i = 0, size = list.size(); i < size; i++) {
-        StructEntry entry = list.get(i);
+      final ListIterator<StructEntry> it = struct.getFields().listIterator();
+      while (it.hasNext()) {
+        final int i = it.nextIndex();
+        final StructEntry entry = it.next();
         if (entry.getOffset() == valueOffset && entry instanceof Datatype) {
           final ByteBuffer buffer = entry.getDataBuffer();
           final StructEntry newEntry = createCreatureValueFromType(buffer, 0);
           newEntry.setOffset(valueOffset);
-          list.set(i, newEntry);
+          it.set(newEntry);
 
           // notifying listeners
           struct.fireTableRowsUpdated(i, i);

--- a/src/org/infinity/gui/StringEditor.java
+++ b/src/org/infinity/gui/StringEditor.java
@@ -1042,7 +1042,7 @@ public class StringEditor extends ChildFrame implements SearchClient
 
       StringTable.StringEntry entry = StringTable.getStringEntry(getSelectedDialogType(), index);
       entry.fillList(index);
-      return entry.getField(selectedRow).toString();
+      return entry.getList().get(selectedRow).toString();
     }
 
     @Override

--- a/src/org/infinity/gui/StringEditor.java
+++ b/src/org/infinity/gui/StringEditor.java
@@ -1042,7 +1042,7 @@ public class StringEditor extends ChildFrame implements SearchClient
 
       StringTable.StringEntry entry = StringTable.getStringEntry(getSelectedDialogType(), index);
       entry.fillList(index);
-      return entry.getList().get(selectedRow).toString();
+      return entry.getFields().get(selectedRow).toString();
     }
 
     @Override

--- a/src/org/infinity/gui/StructViewer.java
+++ b/src/org/infinity/gui/StructViewer.java
@@ -322,7 +322,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
     lowerpanel.addComponentListener(this);
     cards.show(lowerpanel, CARD_EMPTY);
 
-    if (struct instanceof HasAddRemovable && !struct.getList().isEmpty()) {
+    if (struct instanceof HasAddRemovable && !struct.getFields().isEmpty()) {
       try {
         emptyTypes = ((HasAddRemovable)struct).getAddRemovables();
       } catch (Exception e) {
@@ -369,7 +369,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
     bView.setEnabled(false);
     bView.addActionListener(this);
     ((JButton)buttonPanel.addControl(ButtonPanel.Control.PRINT)).addActionListener(this);
-    if (struct instanceof Resource && !struct.getList().isEmpty() && struct.getParent() == null) {
+    if (struct instanceof Resource && !struct.getFields().isEmpty() && struct.getParent() == null) {
       ((JButton)buttonPanel.addControl(ButtonPanel.Control.EXPORT_BUTTON)).addActionListener(this);
       ((JButton)buttonPanel.addControl(ButtonPanel.Control.SAVE)).addActionListener(this);
     }
@@ -519,7 +519,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
     } else if (UPDATE_VALUE.equals(cmd)) {
       if (editable != null && editable.updateValue(struct)) {
         struct.setStructChanged(true);
-        final int index = struct.getList().indexOf(editable);
+        final int index = struct.getFields().indexOf(editable);
         struct.fireTableRowsUpdated(index, index);
         if (editable instanceof EffectType) {
           // don't lose current selection
@@ -817,7 +817,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
   public void tableChanged(TableModelEvent event)
   {
     if (event.getType() == TableModelEvent.UPDATE) {
-      final StructEntry structEntry = struct.getList().get(event.getFirstRow());
+      final StructEntry structEntry = struct.getFields().get(event.getFirstRow());
       if (structEntry instanceof Editable && (editable == null || (structEntry.getOffset() == editable.getOffset() &&
                                                                    structEntry != editable))) {
         edit((Editable)structEntry);
@@ -969,7 +969,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
   public void selectEntry(String name)
   {
-    for (final StructEntry entry : struct.getList()) {
+    for (final StructEntry entry : struct.getFields()) {
       if (entry.getName().equals(name)) {
         selectEntry(entry);
         return;
@@ -984,7 +984,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
   public void selectEntry(int offset, boolean recursive)
   {
-    for (final StructEntry entry : struct.getList()) {
+    for (final StructEntry entry : struct.getFields()) {
       if (entry instanceof AbstractStruct && recursive) {
         selectEntry((AbstractStruct)entry, offset);
       } else if (entry.getOffset() == offset) {
@@ -1182,7 +1182,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
   private void convertAttribute(int index, JMenuItem menuitem)
   {
-    final StructEntry entry = struct.getList().get(index);
+    final StructEntry entry = struct.getFields().get(index);
     if (!isCachedStructEntry(entry.getOffset())) setCachedStructEntry(entry);
     ByteBuffer bb = StreamUtils.getByteBuffer(entry.getSize());
     try {
@@ -1218,7 +1218,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
         throw new NullPointerException();
       }
       newentry.setOffset(entry.getOffset());
-      struct.setListEntry(index, newentry);
+      struct.setField(index, newentry);
       table.getSelectionModel().removeSelectionInterval(index, index);
       table.getSelectionModel().addSelectionInterval(index, index);
     } catch (Exception e) {
@@ -1229,7 +1229,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
   private void selectEntry(StructEntry structEntry)
   {
     int i = 0;
-    for (final StructEntry o : struct.getList()) {
+    for (final StructEntry o : struct.getFields()) {
       if (structEntry == o) {
         table.getSelectionModel().setSelectionInterval(i, i);
         selectEditTab();
@@ -1244,7 +1244,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
   private void selectEntry(AbstractStruct subStruct, int offset)
   {
-    for (final StructEntry entry : subStruct.getList()) {
+    for (final StructEntry entry : subStruct.getFields()) {
       if (entry instanceof AbstractStruct)
         selectEntry((AbstractStruct)entry, offset);
       else if (entry.getOffset() == offset)
@@ -1255,7 +1255,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
   private void selectSubEntry(AbstractStruct subStruct, StructEntry structEntry)
   {
     int i = 0;
-    for (final StructEntry o : subStruct.getList()) {
+    for (final StructEntry o : subStruct.getFields()) {
       if (structEntry == o) {
         createViewFrame(getTopLevelAncestor(), subStruct);
 //        new ViewFrame(getTopLevelAncestor(), subStruct);
@@ -1359,7 +1359,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
    */
   private void select(StructEntry field)
   {
-    final int index = struct.getList().indexOf(field);
+    final int index = struct.getFields().indexOf(field);
     if (index >= 0) {
       table.getSelectionModel().setSelectionInterval(index, index);
 

--- a/src/org/infinity/gui/StructViewer.java
+++ b/src/org/infinity/gui/StructViewer.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.gui;
@@ -350,7 +350,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
       miFindAttribute = new JMenuItem("selected attribute");
       miFindAttribute.setEnabled(false);
       miFindReferences = new JMenuItem("references to this file");
-      miFindReferences.setEnabled(struct instanceof Resource && struct.getSuperStruct() == null);
+      miFindReferences.setEnabled(struct instanceof Resource && struct.getParent() == null);
       miFindStateReferences = new JMenuItem("references to this state");
       miFindStateReferences.setEnabled(false);
       miFindRefToItem = new JMenuItem("references to selected item in this file");
@@ -362,14 +362,14 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
       miFindAttribute = new JMenuItem("selected attribute");
       miFindAttribute.setEnabled(false);
       miFindReferences = new JMenuItem("references to this file");
-      miFindReferences.setEnabled(struct instanceof Resource && struct.getSuperStruct() == null);
+      miFindReferences.setEnabled(struct instanceof Resource && struct.getParent() == null);
       bpmFind.setMenuItems(new JMenuItem[]{miFindAttribute, miFindReferences});
     }
     JButton bView = (JButton)buttonPanel.addControl(ButtonPanel.Control.VIEW_EDIT);
     bView.setEnabled(false);
     bView.addActionListener(this);
     ((JButton)buttonPanel.addControl(ButtonPanel.Control.PRINT)).addActionListener(this);
-    if (struct instanceof Resource && struct.getFieldCount() > 0 && struct.getSuperStruct() == null) {
+    if (struct instanceof Resource && struct.getFieldCount() > 0 && struct.getParent() == null) {
       ((JButton)buttonPanel.addControl(ButtonPanel.Control.EXPORT_BUTTON)).addActionListener(this);
       ((JButton)buttonPanel.addControl(ButtonPanel.Control.SAVE)).addActionListener(this);
     }
@@ -421,10 +421,10 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
       }
 
       add(tabbedPane, BorderLayout.CENTER);
-      if (struct.getSuperStruct() != null && struct.getSuperStruct() instanceof HasViewerTabs) {
-        StructViewer sViewer = struct.getSuperStruct().getViewer();
+      if (struct.getParent() instanceof HasViewerTabs) {
+        StructViewer sViewer = struct.getParent().getViewer();
         if (sViewer == null) {
-          sViewer = struct.getSuperStruct().getSuperStruct().getViewer();
+          sViewer = struct.getParent().getParent().getViewer();
         }
         if (sViewer != null && sViewer.tabbedPane != null) {
           tabbedPane.setSelectedIndex(sViewer.tabbedPane.getSelectedIndex());
@@ -1383,7 +1383,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
     final int offset = entry.getValue();
     final StructEntry field = struct.getAttribute(offset, entry.getSection());
     if (field != null) {
-      final AbstractStruct parent = (AbstractStruct)field.getParent();
+      final AbstractStruct parent = field.getParent();
       if (parent != struct) {
         new ViewFrame(this, parent);
       }

--- a/src/org/infinity/gui/StructViewer.java
+++ b/src/org/infinity/gui/StructViewer.java
@@ -322,7 +322,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
     lowerpanel.addComponentListener(this);
     cards.show(lowerpanel, CARD_EMPTY);
 
-    if (struct instanceof HasAddRemovable && struct.getFieldCount() > 0) {
+    if (struct instanceof HasAddRemovable && !struct.getList().isEmpty()) {
       try {
         emptyTypes = ((HasAddRemovable)struct).getAddRemovables();
       } catch (Exception e) {
@@ -369,7 +369,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
     bView.setEnabled(false);
     bView.addActionListener(this);
     ((JButton)buttonPanel.addControl(ButtonPanel.Control.PRINT)).addActionListener(this);
-    if (struct instanceof Resource && struct.getFieldCount() > 0 && struct.getParent() == null) {
+    if (struct instanceof Resource && !struct.getList().isEmpty() && struct.getParent() == null) {
       ((JButton)buttonPanel.addControl(ButtonPanel.Control.EXPORT_BUTTON)).addActionListener(this);
       ((JButton)buttonPanel.addControl(ButtonPanel.Control.SAVE)).addActionListener(this);
     }
@@ -519,7 +519,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
     } else if (UPDATE_VALUE.equals(cmd)) {
       if (editable != null && editable.updateValue(struct)) {
         struct.setStructChanged(true);
-        final int index = struct.getIndexOf(editable);
+        final int index = struct.getList().indexOf(editable);
         struct.fireTableRowsUpdated(index, index);
         if (editable instanceof EffectType) {
           // don't lose current selection
@@ -817,7 +817,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
   public void tableChanged(TableModelEvent event)
   {
     if (event.getType() == TableModelEvent.UPDATE) {
-      StructEntry structEntry = struct.getField(event.getFirstRow());
+      final StructEntry structEntry = struct.getList().get(event.getFirstRow());
       if (structEntry instanceof Editable && (editable == null || (structEntry.getOffset() == editable.getOffset() &&
                                                                    structEntry != editable))) {
         edit((Editable)structEntry);
@@ -969,8 +969,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
   public void selectEntry(String name)
   {
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      StructEntry entry = struct.getField(i);
+    for (final StructEntry entry : struct.getList()) {
       if (entry.getName().equals(name)) {
         selectEntry(entry);
         return;
@@ -985,8 +984,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
   public void selectEntry(int offset, boolean recursive)
   {
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      StructEntry entry = struct.getField(i);
+    for (final StructEntry entry : struct.getList()) {
       if (entry instanceof AbstractStruct && recursive) {
         selectEntry((AbstractStruct)entry, offset);
       } else if (entry.getOffset() == offset) {
@@ -1184,7 +1182,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
   private void convertAttribute(int index, JMenuItem menuitem)
   {
-    StructEntry entry = struct.getField(index);
+    final StructEntry entry = struct.getList().get(index);
     if (!isCachedStructEntry(entry.getOffset())) setCachedStructEntry(entry);
     ByteBuffer bb = StreamUtils.getByteBuffer(entry.getSize());
     try {
@@ -1230,22 +1228,23 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
   private void selectEntry(StructEntry structEntry)
   {
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      StructEntry o = struct.getField(i);
+    int i = 0;
+    for (final StructEntry o : struct.getList()) {
       if (structEntry == o) {
         table.getSelectionModel().setSelectionInterval(i, i);
         selectEditTab();
         return;
       }
-      else if (o instanceof AbstractStruct)
+      else if (o instanceof AbstractStruct) {
         selectSubEntry((AbstractStruct)o, structEntry);
+      }
+      ++i;
     }
   }
 
   private void selectEntry(AbstractStruct subStruct, int offset)
   {
-    for (int i = 0; i < subStruct.getFieldCount(); i++) {
-      StructEntry entry = subStruct.getField(i);
+    for (final StructEntry entry : subStruct.getList()) {
       if (entry instanceof AbstractStruct)
         selectEntry((AbstractStruct)entry, offset);
       else if (entry.getOffset() == offset)
@@ -1255,8 +1254,8 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
   private void selectSubEntry(AbstractStruct subStruct, StructEntry structEntry)
   {
-    for (int i = 0; i < subStruct.getFieldCount(); i++) {
-      StructEntry o = subStruct.getField(i);
+    int i = 0;
+    for (final StructEntry o : subStruct.getList()) {
       if (structEntry == o) {
         createViewFrame(getTopLevelAncestor(), subStruct);
 //        new ViewFrame(getTopLevelAncestor(), subStruct);
@@ -1266,8 +1265,10 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
         viewer.selectEditTab();
         return;
       }
-      else if (o instanceof AbstractStruct)
+      else if (o instanceof AbstractStruct) {
         selectSubEntry((AbstractStruct)o, structEntry);
+      }
+      ++i;
     }
   }
 

--- a/src/org/infinity/gui/ViewFrame.java
+++ b/src/org/infinity/gui/ViewFrame.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.gui;
@@ -66,8 +66,8 @@ public final class ViewFrame extends ChildFrame implements ViewableContainer
     else {
       setIconImage(Keyfile.ICON_STRUCT.getImage());
       setTitle(((StructEntry)viewable).getName());
-      if (((AbstractStruct)viewable).getSuperStruct() != null)
-        statusBar.setMessage("Parent structure: " + ((AbstractStruct)viewable).getSuperStruct().getName());
+      if (((StructEntry)viewable).getParent() != null)
+        statusBar.setMessage("Parent structure: " + ((StructEntry)viewable).getParent().getName());
     }
     JPanel pane = (JPanel)getContentPane();
     pane.setLayout(new BorderLayout());
@@ -91,4 +91,3 @@ public final class ViewFrame extends ChildFrame implements ViewableContainer
     return super.windowClosing(forced);
   }
 }
-

--- a/src/org/infinity/gui/ViewerUtil.java
+++ b/src/org/infinity/gui/ViewerUtil.java
@@ -343,7 +343,7 @@ public final class ViewerUtil
         list.setCellRenderer(renderer);
       }
       if (attrName == null) {
-        for (final StructEntry o : struct.getList()) {
+        for (final StructEntry o : struct.getFields()) {
           if (o.getClass() == listClass) {
             listModel.addElement(o);
           }
@@ -354,7 +354,7 @@ public final class ViewerUtil
           list.setCellRenderer(new StructListRenderer(attrName));
         }
         final List<AbstractStruct> templist = new ArrayList<>();
-        for (final StructEntry o : struct.getList()) {
+        for (final StructEntry o : struct.getFields()) {
           if (o.getClass() == listClass) {
             templist.add((AbstractStruct)o);
           }
@@ -407,7 +407,7 @@ public final class ViewerUtil
       if (event.getType() == TableModelEvent.DELETE) {
 
         // go through the list and find what was deleted
-        listModel.retainAll(struct.getList());
+        listModel.retainAll(struct.getFields());
         /*
         // Ineffective - any better solutions?
         if (comp == null) {
@@ -439,7 +439,7 @@ public final class ViewerUtil
         bOpen.setEnabled(!listModel.isEmpty() && listModel.get(0) instanceof Viewable);
       }
       else if (event.getType() == TableModelEvent.INSERT) {
-        final List<StructEntry> fields = struct.getList();
+        final List<StructEntry> fields = struct.getFields();
         for (int i = event.getFirstRow(); i <= event.getLastRow(); i++) {
           if (i >= fields.size()) {
             break;

--- a/src/org/infinity/gui/hexview/BasicColorMap.java
+++ b/src/org/infinity/gui/hexview/BasicColorMap.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.gui.hexview;
@@ -163,8 +163,7 @@ public class BasicColorMap implements IColormap
       listBlocks.clear();
     }
 
-    List<StructEntry> flatList = getStruct().getFlatList();
-    for (final StructEntry curEntry: flatList) {
+    for (final StructEntry curEntry : getStruct().getFlatFields()) {
       List<StructEntry> chain = curEntry.getStructChain();
       boolean found = false;
       for (int i = 0; !found && i < chain.size(); i++) {
@@ -193,8 +192,6 @@ public class BasicColorMap implements IColormap
       chain.clear();
       chain = null;
     }
-    flatList.clear();
-    flatList = null;
 
     combineColoredBlocks();
   }
@@ -208,7 +205,7 @@ public class BasicColorMap implements IColormap
     typeMap.clear();
     Coloring[] colors = Coloring.values();
     int colIdx = 0;
-    List<StructEntry> list = getStruct().getList();
+    final List<StructEntry> list = getStruct().getFields();
     Collections.sort(list);
     for (final StructEntry entry: list) {
       if (entry instanceof SectionOffset) {
@@ -371,7 +368,7 @@ public class BasicColorMap implements IColormap
       // check if structure is defined by section offset and count fields
       isTable = false;
       so = null; sc = null;
-      for (final StructEntry entry: struct.getList()) {
+      for (final StructEntry entry: struct.getFields()) {
         if (so == null &&
             entry instanceof SectionOffset &&
             ((SectionOffset)entry).getSection() == classType) {
@@ -390,7 +387,7 @@ public class BasicColorMap implements IColormap
       if (so == null || sc == null) {
         // no section offset and count -> use static table lookup instead
         isTable = true;
-        for (final StructEntry entry: struct.getList()) {
+        for (final StructEntry entry: struct.getFields()) {
           if (entry.getClass() == classType) {
             structures.add(entry);
           }
@@ -418,7 +415,7 @@ public class BasicColorMap implements IColormap
       } else if (sc.getValue() > 0) {
         // structure size not yet cached?
         if (structureSize < 0) {
-          for (final StructEntry entry: getStruct().getList()) {
+          for (final StructEntry entry: getStruct().getFields()) {
             if(entry.getClass() == classType) {
               structureSize = entry.getSize();
               break;
@@ -429,7 +426,7 @@ public class BasicColorMap implements IColormap
         // AbstractCode instances consist of two separate data blocks
         if (AbstractCode.class.isAssignableFrom(classType)) {
           int curIndex = 0;
-          for (final StructEntry entry: getStruct().getList()) {
+          for (final StructEntry entry: getStruct().getFields()) {
             if (entry.getClass() == classType) {
               AbstractCode ac = (AbstractCode)entry;
               if ((offset >= ac.getTextOffset() && offset < ac.getTextOffset()+ac.getTextLength())) {

--- a/src/org/infinity/gui/hexview/StructuredDataProvider.java
+++ b/src/org/infinity/gui/hexview/StructuredDataProvider.java
@@ -236,7 +236,7 @@ public class StructuredDataProvider implements IDataProvider
   public void reset()
   {
     close();
-    listStructures = getStruct().getFlatList();
+    listStructures = getStruct().getFlatFields();
     dataSize = 0;
     for (final StructEntry e: listStructures) {
       dataSize = Math.max(dataSize, e.getOffset()+e.getSize());

--- a/src/org/infinity/gui/hexview/StructuredDataProvider.java
+++ b/src/org/infinity/gui/hexview/StructuredDataProvider.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.gui.hexview;
@@ -27,7 +27,7 @@ import tv.porst.jhexview.IDataProvider;
  */
 public class StructuredDataProvider implements IDataProvider
 {
-  private final ArrayList<IDataChangedListener> listeners = new ArrayList<IDataChangedListener>();
+  private final ArrayList<IDataChangedListener> listeners = new ArrayList<>();
   private final AbstractStruct struct;
 
   private List<StructEntry> listStructures;
@@ -65,7 +65,7 @@ public class StructuredDataProvider implements IDataProvider
     }
 
     if (length > 0) {
-      ArrayList<StructEntry> listEntries = new ArrayList<StructEntry>();
+      ArrayList<StructEntry> listEntries = new ArrayList<>();
       int entryIndex = findStructureIndex((int)offset);
       if (entryIndex >= 0) {
         // collecting matching entries
@@ -168,7 +168,7 @@ public class StructuredDataProvider implements IDataProvider
       }
 
       if (length > 0) {
-        ArrayList<StructEntry> listEntries = new ArrayList<StructEntry>();
+        ArrayList<StructEntry> listEntries = new ArrayList<>();
         int entryIndex = findStructureIndex((int)offset);
         // collecting matching entries
         if (entryIndex >= 0) {
@@ -270,7 +270,7 @@ public class StructuredDataProvider implements IDataProvider
     }
   }
 
-  // Returns the list of cached top-level StructEntry objects
+  /** Returns the list of cached top-level StructEntry objects. */
   private List<StructEntry> getCachedList()
   {
     if (listStructures == null) {
@@ -279,7 +279,7 @@ public class StructuredDataProvider implements IDataProvider
     return listStructures;
   }
 
-  // Returns the list index of the StructEntry containing the specified offset. Returns -1 on failure.
+  /** Returns the list index of the StructEntry containing the specified offset. Returns -1 on failure. */
   private int findStructureIndex(int offset)
   {
     StructEntry key = new EmptyStructure(offset);
@@ -307,7 +307,7 @@ public class StructuredDataProvider implements IDataProvider
 //-------------------------- INNER CLASSES --------------------------
 
   /** A dummy {@link StructEntry} implementation that can be used as key in a search operations. */
-  private class EmptyStructure implements StructEntry
+  private static final class EmptyStructure implements StructEntry
   {
     private int offset;
 
@@ -338,7 +338,7 @@ public class StructuredDataProvider implements IDataProvider
     public int getOffset() { return offset; }
 
     @Override
-    public StructEntry getParent() { return null; }
+    public AbstractStruct getParent() { return null; }
 
     @Override
     public int getSize() { return 0; }
@@ -353,6 +353,6 @@ public class StructuredDataProvider implements IDataProvider
     public void setOffset(int newoffset) { this.offset = newoffset; }
 
     @Override
-    public void setParent(StructEntry parent) {}
+    public void setParent(AbstractStruct parent) {}
   }
 }

--- a/src/org/infinity/resource/AbstractAbility.java
+++ b/src/org/infinity/resource/AbstractAbility.java
@@ -348,8 +348,7 @@ public abstract class AbstractAbility extends AbstractStruct
   @Override
   public void write(OutputStream os) throws IOException
   {
-    for (int i = 0; i < getFieldCount(); i++) {
-      Writeable w = getField(i);
+    for (final StructEntry w : getList()) {
       if (w instanceof Effect) {
         return;
       }
@@ -397,8 +396,7 @@ public abstract class AbstractAbility extends AbstractStruct
 
   public void writeEffects(OutputStream os) throws IOException
   {
-    for (int i = 0; i < getFieldCount(); i++) {
-      Writeable w = getField(i);
+    for (final StructEntry w : getList()) {
       if (w instanceof Effect) {
         w.write(os);
       }

--- a/src/org/infinity/resource/AbstractAbility.java
+++ b/src/org/infinity/resource/AbstractAbility.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource;
@@ -363,7 +363,7 @@ public abstract class AbstractAbility extends AbstractStruct
   protected void setAddRemovableOffset(AddRemovable datatype)
   {
     if (datatype instanceof Effect && getEffectsCount() >= 1) {
-      SectionOffset effectOffset = (SectionOffset)getSuperStruct().getAttribute(SplResource.SPL_OFFSET_EFFECTS);
+      final SectionOffset effectOffset = (SectionOffset)getParent().getAttribute(SplResource.SPL_OFFSET_EFFECTS);
       int effectIndex = ((DecNumber)getAttribute(Ability.ABILITY_FIRST_EFFECT_INDEX)).getValue() + getEffectsCount() - 1;
       datatype.setOffset(effectOffset.getValue() + effectIndex * 48);
     }
@@ -405,4 +405,3 @@ public abstract class AbstractAbility extends AbstractStruct
     }
   }
 }
-

--- a/src/org/infinity/resource/AbstractAbility.java
+++ b/src/org/infinity/resource/AbstractAbility.java
@@ -348,7 +348,7 @@ public abstract class AbstractAbility extends AbstractStruct
   @Override
   public void write(OutputStream os) throws IOException
   {
-    for (final StructEntry w : getList()) {
+    for (final StructEntry w : getFields()) {
       if (w instanceof Effect) {
         return;
       }
@@ -396,7 +396,7 @@ public abstract class AbstractAbility extends AbstractStruct
 
   public void writeEffects(OutputStream os) throws IOException
   {
-    for (final StructEntry w : getList()) {
+    for (final StructEntry w : getFields()) {
       if (w instanceof Effect) {
         w.write(os);
       }

--- a/src/org/infinity/resource/AbstractStruct.java
+++ b/src/org/infinity/resource/AbstractStruct.java
@@ -287,7 +287,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   @Override
   public int getRowCount()
   {
-    return getFieldCount();
+    return list.size();
   }
 
   @Override
@@ -322,8 +322,8 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   @Override
   public Object getValueAt(int row, int column)
   {
-    if (getField(row) instanceof StructEntry) {
-      StructEntry data = getField(row);
+    if (row >= 0 && row < list.size()) {
+      final StructEntry data = list.get(row);
       switch (column) {
         case 0:
           return data.getName();
@@ -380,8 +380,8 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     // limit text length to speed things up
     int capacity = 160;
     final StringBuilder sb = new StringBuilder(capacity);
-    for (int i = 0, count = getFieldCount(); i < count; i++) {
-      final StructEntry field = getField(i);
+    for (int i = 0, count = list.size(); i < count; i++) {
+      final StructEntry field = list.get(i);
       final String text = field.getName() + ": " + field;
 
       if (i != 0) {
@@ -410,15 +410,15 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
       index = viewer.getSelectedRow();
     } else if (offsetmap.containsKey(addedEntry.getClass())) {
       int offset = offsetmap.get(addedEntry.getClass()).getValue() + extraoffset;
-      int fieldCount = getFieldCount();
+      final int fieldCount = list.size();
       int extraIndex = 0;
-      while (extraIndex < fieldCount && getField(extraIndex).getOffset() < extraoffset) {
+      while (extraIndex < fieldCount && list.get(extraIndex).getOffset() < extraoffset) {
         extraIndex++;
       }
-      while (index < fieldCount && getField(index).getOffset() < offset) {
+      while (index < fieldCount && list.get(index).getOffset() < offset) {
         index++;
       }
-      while (index < fieldCount && addedEntry.getClass() == (getField(index)).getClass()) {
+      while (index < fieldCount && addedEntry.getClass() == list.get(index).getClass()) {
         index++;
       }
       if (index == extraIndex) {
@@ -427,7 +427,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
           index = fieldCount;
           int newOffset = getSize();
           if (extraIndex > 0) {
-            newOffset -= getField(extraIndex).getOffset();
+            newOffset -= list.get(extraIndex).getOffset();
           }
           soffset.setValue(newOffset);
         }
@@ -461,21 +461,21 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
       countmap.get(addedEntry.getClass()).incValue(1);
 
     // Set addedEntry offset
-    if (index > 0 && getField(index - 1).getClass() == addedEntry.getClass()) {
-      StructEntry prev = getField(index - 1);
+    if (index > 0 && list.get(index - 1).getClass() == addedEntry.getClass()) {
+      final StructEntry prev = list.get(index - 1);
       addedEntry.setOffset(prev.getOffset() + prev.getSize());
     }
     else if (offsetmap.containsKey(addedEntry.getClass())) {
       addedEntry.setOffset(offsetmap.get(addedEntry.getClass()).getValue() + extraoffset);
     }
-    else if (index == 0 && getFieldCount() > 0) {
-      StructEntry next = getField(0);
+    else if (index == 0 && !list.isEmpty()) {
+      final StructEntry next = list.get(0);
       addedEntry.setOffset(next.getOffset());
     }
     else {
       setAddRemovableOffset(addedEntry);
-      for (int i = 0; i < getFieldCount(); i++) {
-        StructEntry structEntry = getField(i);
+      for (int i = 0; i < list.size(); i++) {
+        final StructEntry structEntry = list.get(i);
         if (structEntry.getOffset() == addedEntry.getOffset()) {
           index = i;
           break;
@@ -516,7 +516,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
    */
   public StructEntry addField(StructEntry entry)
   {
-    return addField(entry, getFieldCount());
+    return addField(entry, list.size());
   }
 
   /**
@@ -728,7 +728,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
 
   public List<StructEntry> getFlatList()
   {
-    final List<StructEntry> flatList = new ArrayList<>(2 * getFieldCount());
+    final List<StructEntry> flatList = new ArrayList<>(2 * list.size());
     addFlatList(flatList);
     Collections.sort(flatList);
     return flatList;

--- a/src/org/infinity/resource/AbstractStruct.java
+++ b/src/org/infinity/resource/AbstractStruct.java
@@ -238,9 +238,9 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   }
 
   @Override
-  public StructEntry getParent()
+  public AbstractStruct getParent()
   {
-    return getSuperStruct();
+    return superStruct;
   }
 
   @Override
@@ -289,12 +289,14 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   }
 
   @Override
-  public void setParent(StructEntry parent)
+  public void setParent(AbstractStruct parent)
   {
-    if (parent instanceof AbstractStruct) {
-      setSuperStruct((AbstractStruct)parent);
-    } else {
-      setSuperStruct(null);
+    if (superStruct != null) {
+      removePropertyChangeListener(superStruct);
+    }
+    superStruct = parent;
+    if (parent != null) {
+      addPropertyChangeListener(parent);
     }
   }
   //</editor-fold>
@@ -760,11 +762,6 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     return entry;
   }
 
-  public AbstractStruct getSuperStruct()
-  {
-    return superStruct;
-  }
-
   public AbstractStruct getSuperStruct(StructEntry structEntry)
   {
     for (final StructEntry e : list) {
@@ -786,12 +783,12 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   public boolean isChildOf(Class<? extends AbstractStruct> struct)
   {
     if (struct != null) {
-      AbstractStruct parent = getSuperStruct();
+      AbstractStruct parent = superStruct;
       while (parent != null) {
         if (struct.isInstance(parent)) {
           return true;
         }
-        parent = parent.getSuperStruct();
+        parent = parent.superStruct;
       }
     }
     return false;
@@ -1151,17 +1148,6 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
       list = newList;
     } else {
       list.clear();
-    }
-  }
-
-  protected void setSuperStruct(AbstractStruct struct)
-  {
-    if (superStruct != null) {
-      removePropertyChangeListener(struct);
-    }
-    this.superStruct = struct;
-    if (struct != null) {
-      addPropertyChangeListener(struct);
     }
   }
 

--- a/src/org/infinity/resource/AbstractStruct.java
+++ b/src/org/infinity/resource/AbstractStruct.java
@@ -196,8 +196,9 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     newstruct.superStruct = null;
     newstruct.list = new ArrayList<>(list.size());
     newstruct.viewer = null;
-    for (StructEntry e : list)
+    for (final StructEntry e : list) {
       newstruct.list.add(e.clone());
+    }
 //    for (Iterator i = newstruct.list.iterator(); i.hasNext();) {
 //      StructEntry sentry = (StructEntry)i.next();
 //      if (sentry.getOffset() <= 0)
@@ -455,7 +456,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
       }
     }
     else {
-      index = getAddedPosition();
+      index = getInsertPosition();
     }
     return index;
   }
@@ -580,7 +581,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
    */
   public void clearFields()
   {
-    Iterator<StructEntry> iter = list.iterator();
+    final Iterator<StructEntry> iter = list.iterator();
     while (iter.hasNext()) {
       StructEntry e = iter.next();
       e.setParent(null);
@@ -719,15 +720,15 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     return extraoffset;
   }
 
+  /**
+   * Returns modifiable list of fields of this structure.
+   * Modification of this list do not notify listeners.
+   *
+   * @return Internal list of fields
+   */
   public List<StructEntry> getList()
   {
     return list;
-  }
-
-  /** Returns the number of fields in the current structure. */
-  public int getFieldCount()
-  {
-    return list.size();
   }
 
   /**
@@ -750,11 +751,6 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     addFlatList(flatList);
     Collections.sort(flatList);
     return flatList;
-  }
-
-  public int getIndexOf(StructEntry structEntry)
-  {
-    return list.indexOf(structEntry);
   }
 
   public ResourceEntry getResourceEntry()
@@ -939,6 +935,14 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     return false;
   }
 
+  /**
+   * Replaces value of the specified field to specified value and notify listeners.
+   *
+   * @param index Index of the field to update
+   * @param structEntry New value of the field
+   * @throws IndexOutOfBoundsException If the index is out of range
+   *         ({@code index < 0 || index >= getList().size()})
+   */
   public void setListEntry(int index, StructEntry structEntry)
   {
     list.set(index, structEntry);
@@ -1097,7 +1101,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   }
 
   /** To be overriden by subclasses. */
-  protected int getAddedPosition()
+  protected int getInsertPosition()
   {
     return list.size(); // Default: Add at end
   }
@@ -1138,16 +1142,6 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   {
     for (final StructEntry e : getFlatList()) {
       e.write(os);
-    }
-  }
-
-  /** Assign a new list of fields. Clears current list if argument is null. */
-  protected void setList(List<StructEntry> newList)
-  {
-    if (newList != null) {
-      list = newList;
-    } else {
-      list.clear();
     }
   }
 

--- a/src/org/infinity/resource/AbstractStruct.java
+++ b/src/org/infinity/resource/AbstractStruct.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource;
@@ -152,11 +152,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     }
   }
 
-// --------------------- Begin Interface Closeable ---------------------
-
-  // end - extends AbstractTableModel
-
-  // begin - implements Closeable
+  //<editor-fold defaultstate="collapsed" desc="Closeable">
   @Override
   public void close() throws Exception
   {
@@ -167,24 +163,17 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
       viewer.close();
     }
   }
+  //</editor-fold>
 
-// --------------------- End Interface Closeable ---------------------
-
-
-// --------------------- Begin Interface Comparable ---------------------
-
-  // begin - implements StructEntry
+  //<editor-fold defaultstate="collapsed" desc="Comparable">
   @Override
   public int compareTo(StructEntry o)
   {
     return getOffset() - o.getOffset();
   }
+  //</editor-fold>
 
-// --------------------- End Interface Comparable ---------------------
-
-
-// --------------------- Begin Interface StructEntry ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="StructEntry">
   @Override
   public AbstractStruct clone() throws CloneNotSupportedException
   {
@@ -293,13 +282,9 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
       setSuperStruct(null);
     }
   }
+  //</editor-fold>
 
-// --------------------- End Interface StructEntry ---------------------
-
-
-// --------------------- Begin Interface TableModel ---------------------
-
-  // start - extends AbstractTableModel
+  //<editor-fold defaultstate="collapsed" desc="TableModel">
   @Override
   public int getRowCount()
   {
@@ -313,58 +298,6 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
       return 3;
     return 2;
   }
-
-  @Override
-  public Object getValueAt(int row, int column)
-  {
-    if (getField(row) instanceof StructEntry) {
-      StructEntry data = getField(row);
-      switch (column) {
-        case 0:
-          return data.getName();
-        case 1:
-          return data;
-        case 2:
-          return Integer.toHexString(data.getOffset()) + " h";
-      }
-    }
-    return "Unknown datatype";
-  }
-
-// --------------------- End Interface TableModel ---------------------
-
-
-// --------------------- Begin Interface Viewable ---------------------
-
-  // end - implements Closeable
-
-  // begin - implements Viewable
-  @Override
-  public JComponent makeViewer(ViewableContainer container)
-  {
-    if (viewer == null) {
-      viewer = new StructViewer(this, viewerComponents);
-      viewerInitialized(viewer);
-    }
-    return viewer;
-  }
-
-// --------------------- End Interface Viewable ---------------------
-
-
-// --------------------- Begin Interface Writeable ---------------------
-
-  // begin - implements Writeable
-  @Override
-  public void write(OutputStream os) throws IOException
-  {
-    Collections.sort(getList()); // This way we can writeField out in the order in list - sorted by offset
-    for (int i = 0, count = getFieldCount(); i < count; i++) {
-      getField(i).write(os);
-    }
-  }
-
-// --------------------- End Interface Writeable ---------------------
 
   @Override
   public String getColumnName(int columnIndex)
@@ -388,6 +321,23 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   }
 
   @Override
+  public Object getValueAt(int row, int column)
+  {
+    if (getField(row) instanceof StructEntry) {
+      StructEntry data = getField(row);
+      switch (column) {
+        case 0:
+          return data.getName();
+        case 1:
+          return data;
+        case 2:
+          return Integer.toHexString(data.getOffset()) + " h";
+      }
+    }
+    return "Unknown datatype";
+  }
+
+  @Override
   public void setValueAt(Object value, int row, int column)
   {
     Object o = getValueAt(row, column);
@@ -400,6 +350,30 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
       }
     }
   }
+  //</editor-fold>
+
+  //<editor-fold defaultstate="collapsed" desc="Viewable">
+  @Override
+  public JComponent makeViewer(ViewableContainer container)
+  {
+    if (viewer == null) {
+      viewer = new StructViewer(this, viewerComponents);
+      viewerInitialized(viewer);
+    }
+    return viewer;
+  }
+  //</editor-fold>
+
+  //<editor-fold defaultstate="collapsed" desc="Writable">
+  @Override
+  public void write(OutputStream os) throws IOException
+  {
+    Collections.sort(getList()); // This way we can writeField out in the order in list - sorted by offset
+    for (int i = 0, count = getFieldCount(); i < count; i++) {
+      getField(i).write(os);
+    }
+  }
+  //</editor-fold>
 
   @Override
   public String toString()
@@ -428,7 +402,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     return sb.toString();
   }
 
-  // Returns the table row index where the specified AddRemovable structure can be inserted
+  /** Returns the table row index where the specified AddRemovable structure can be inserted. */
   public int getDatatypeIndex(AddRemovable addedEntry)
   {
     int index = 0;
@@ -469,7 +443,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     return index;
   }
 
-  // Returns whether structure of currently selected table row is compatible with "addedEntry"
+  /** Returns whether structure of currently selected table row is compatible with "addedEntry". */
   public boolean isCompatibleDatatypeSelection(AddRemovable addedEntry)
   {
     return viewer != null && viewer.getSelectedEntry() != null &&
@@ -809,8 +783,6 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     return false;
   }
 
-  // end - implements Viewable
-
   public StructViewer getViewer()
   {
     return viewer;
@@ -1062,29 +1034,29 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     }
   }
 
-  // To be overriden by subclasses
+  /** To be overriden by subclasses. */
   protected void viewerInitialized(StructViewer viewer)
   {
   }
 
-  // To be overriden by subclasses
+  /** To be overriden by subclasses. */
   protected void datatypeAdded(AddRemovable datatype)
   {
   }
 
-  // To be overriden by subclasses
+  /** To be overriden by subclasses. */
   protected void datatypeAddedInChild(AbstractStruct child, AddRemovable datatype)
   {
     if (superStruct != null)
       superStruct.datatypeAddedInChild(child, datatype);
   }
 
-  // To be overriden by subclasses
+  /** To be overriden by subclasses. */
   protected void datatypeRemoved(AddRemovable datatype)
   {
   }
 
-  // To be overriden by subclasses
+  /** To be overriden by subclasses. */
   protected void datatypeRemovedInChild(AbstractStruct child, AddRemovable datatype)
   {
     if (superStruct != null)
@@ -1116,7 +1088,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     }
   }
 
-  // To be overriden by subclasses
+  /** To be overriden by subclasses. */
   protected int getAddedPosition()
   {
     return list.size(); // Default: Add at end
@@ -1139,12 +1111,10 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     }
   }
 
-  // To be overriden by subclasses
+  /** To be overriden by subclasses. */
   protected void setAddRemovableOffset(AddRemovable datatype)
   {
   }
-
-  // end - implements StructEntry
 
   protected void setExtraOffset(int offset)
   {
@@ -1155,8 +1125,6 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   {
     startoffset = offset;
   }
-
-  // end - implements Writeable
 
   protected void writeFlatList(OutputStream os) throws IOException
   {

--- a/src/org/infinity/resource/Effect.java
+++ b/src/org/infinity/resource/Effect.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource;
@@ -47,9 +47,9 @@ public final class Effect extends AbstractStruct implements AddRemovable
   {
     EffectType type = new EffectType(buffer, offset, 2);
     addField(type);
-    List<StructEntry> list = new ArrayList<StructEntry>();
+    final List<StructEntry> list = new ArrayList<>();
     offset = type.readAttributes(buffer, offset + 2, list);
-    addToList(getList().size() - 1, list);
+    addFields(getFields().size() - 1, list);
     return offset;
   }
 
@@ -125,4 +125,3 @@ public final class Effect extends AbstractStruct implements AddRemovable
     return retVal;
   }
 }
-

--- a/src/org/infinity/resource/Effect2.java
+++ b/src/org/infinity/resource/Effect2.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource;
@@ -148,20 +148,20 @@ public final class Effect2 extends AbstractStruct implements AddRemovable
     addField(new TextString(buffer, offset + 4, 4, COMMON_VERSION));
     EffectType type = new EffectType(buffer, offset + 8, 4);
     addField(type);
-    List<StructEntry> list = new ArrayList<StructEntry>();
+    final List<StructEntry> list = new ArrayList<>();
     offset = type.readAttributes(buffer, offset + 12, list);
-    addToList(getList().size() - 1, list);
+    addFields(getFields().size() - 1, list);
 
     list.clear();
     offset = readCommon(list, buffer, offset);
-    addToList(getList().size() - 1, list);
+    addFields(getFields().size() - 1, list);
 
     return offset;
   }
 
   /**
    * Creates a copy of the current structure, optionally converted to the EFF V1.0 format.
-   * @param asV2 {@code true} if result should be of {@link Effect} type.
+   * @param asV1 {@code true} if result should be of {@link Effect} type.
    * @return A copy of the current instance.
    * @throws Exception
    */
@@ -206,4 +206,3 @@ public final class Effect2 extends AbstractStruct implements AddRemovable
     return retVal;
   }
 }
-

--- a/src/org/infinity/resource/EffectFactory.java
+++ b/src/org/infinity/resource/EffectFactory.java
@@ -450,7 +450,7 @@ public final class EffectFactory
         EnumMap<EffectEntry, Integer> map = new EnumMap<>(EffectEntry.class);
         boolean isV1 = (effType.getSize() == 2);
         int ofsOpcode = effType.getOffset();
-        int idxOpcode = struct.getList().indexOf(struct.getAttribute(ofsOpcode));
+        int idxOpcode = struct.getFields().indexOf(struct.getAttribute(ofsOpcode));
         if (isV1 && struct.getSize() >= 0x30) {
           // EFF V1.0
           map.put(EffectEntry.IDX_OPCODE, idxOpcode);
@@ -610,7 +610,7 @@ public final class EffectFactory
   public static StructEntry getEntryByIndex(AbstractStruct struct, int entryIndex) throws Exception
   {
     if (struct != null) {
-      return struct.getList().get(entryIndex);
+      return struct.getFields().get(entryIndex);
     } else
       throw new Exception("Invalid arguments specified");
   }
@@ -645,8 +645,8 @@ public final class EffectFactory
         EnumMap<EffectEntry, Integer> map = getEffectStructure(struct);
         if (map != null && map.containsKey(id)) {
           int idx = map.get(id);
-          if (idx >= 0 && idx < struct.getList().size()) {
-            return getEntryData(struct.getList().get(idx));
+          if (idx >= 0 && idx < struct.getFields().size()) {
+            return getEntryData(struct.getFields().get(idx));
           }
         }
       } catch (Exception e) {
@@ -671,7 +671,7 @@ public final class EffectFactory
         map != null && map.containsKey(index) && map.containsKey(offset)) {
       int idx = map.get(index);
       int ofs = map.get(offset);
-      final List<StructEntry> list = struct.getList();
+      final List<StructEntry> list = struct.getFields();
       if (idx >= 0 && idx < list.size() &&
           ofs >= struct.getOffset() && ofs < struct.getOffset() + struct.getSize()) {
         newEntry.setOffset(ofs);

--- a/src/org/infinity/resource/EffectFactory.java
+++ b/src/org/infinity/resource/EffectFactory.java
@@ -447,10 +447,10 @@ public final class EffectFactory
     if (struct != null) {
       EffectType effType = (EffectType)struct.getAttribute(EffectType.EFFECT_TYPE);
       if (effType != null) {
-        EnumMap<EffectEntry, Integer> map = new EnumMap<EffectFactory.EffectEntry, Integer>(EffectEntry.class);
+        EnumMap<EffectEntry, Integer> map = new EnumMap<>(EffectEntry.class);
         boolean isV1 = (effType.getSize() == 2);
         int ofsOpcode = effType.getOffset();
-        int idxOpcode = struct.getIndexOf(struct.getAttribute(ofsOpcode));
+        int idxOpcode = struct.getList().indexOf(struct.getAttribute(ofsOpcode));
         if (isV1 && struct.getSize() >= 0x30) {
           // EFF V1.0
           map.put(EffectEntry.IDX_OPCODE, idxOpcode);
@@ -610,10 +610,7 @@ public final class EffectFactory
   public static StructEntry getEntryByIndex(AbstractStruct struct, int entryIndex) throws Exception
   {
     if (struct != null) {
-      if (entryIndex >= 0 && entryIndex < struct.getList().size()) {
-        return struct.getList().get(entryIndex);
-      } else
-        throw new Exception("Index out of bounds");
+      return struct.getList().get(entryIndex);
     } else
       throw new Exception("Invalid arguments specified");
   }
@@ -674,9 +671,8 @@ public final class EffectFactory
         map != null && map.containsKey(index) && map.containsKey(offset)) {
       int idx = map.get(index);
       int ofs = map.get(offset);
-      List<StructEntry> list = struct.getList();
-      if (list != null &&
-          idx >= 0 && idx < list.size() &&
+      final List<StructEntry> list = struct.getList();
+      if (idx >= 0 && idx < list.size() &&
           ofs >= struct.getOffset() && ofs < struct.getOffset() + struct.getSize()) {
         newEntry.setOffset(ofs);
         list.set(idx, newEntry);

--- a/src/org/infinity/resource/StructEntry.java
+++ b/src/org/infinity/resource/StructEntry.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource;
@@ -23,7 +23,7 @@ public interface StructEntry extends Comparable<StructEntry>, Cloneable, Writeab
   int getOffset();
 
   /** Returns entry which owns this entry or {@code null} if this entry on top of hierarchy. */
-  StructEntry getParent();
+  AbstractStruct getParent();
 
   /**
    * Returns byte count of serialized value of this object.
@@ -40,6 +40,5 @@ public interface StructEntry extends Comparable<StructEntry>, Cloneable, Writeab
 
   void setOffset(int newoffset);
 
-  void setParent(StructEntry parent);
+  void setParent(AbstractStruct parent);
 }
-

--- a/src/org/infinity/resource/are/Actor.java
+++ b/src/org/infinity/resource/are/Actor.java
@@ -180,7 +180,7 @@ public final class Actor extends AbstractStruct implements AddRemovable, HasView
 
   void updateCREOffset()
   {
-    StructEntry entry = getField(getFieldCount() - 1);
+    final StructEntry entry = getList().get(getList().size() - 1);
     if (entry instanceof CreResource)
       ((HexNumber)getAttribute(ARE_ACTOR_OFFSET_CRE_STRUCTURE)).setValue(entry.getOffset());
   }

--- a/src/org/infinity/resource/are/Actor.java
+++ b/src/org/infinity/resource/are/Actor.java
@@ -180,7 +180,7 @@ public final class Actor extends AbstractStruct implements AddRemovable, HasView
 
   void updateCREOffset()
   {
-    final StructEntry entry = getList().get(getList().size() - 1);
+    final StructEntry entry = getFields().get(getFields().size() - 1);
     if (entry instanceof CreResource)
       ((HexNumber)getAttribute(ARE_ACTOR_OFFSET_CRE_STRUCTURE)).setValue(entry.getOffset());
   }

--- a/src/org/infinity/resource/are/AreResource.java
+++ b/src/org/infinity/resource/are/AreResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -751,15 +751,13 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     }
 
     offset = offset_items.getValue();
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Container)
         ((Container)o).readItems(buffer, offset);
     }
 
     offset = offset_vertices.getValue();
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof HasVertices)
         ((HasVertices)o).readVertices(buffer, offset);
     }
@@ -772,12 +770,10 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     }
 
     int endoffset = offset;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry instanceof HasVertices) {
         // may contain additional elements
-        for (int j = 0, count = ((AbstractStruct)entry).getFieldCount(); j < count; j++) {
-          StructEntry subEntry = ((AbstractStruct)entry).getField(j);
+        for (final StructEntry subEntry : ((AbstractStruct)entry).getList()) {
           endoffset = Math.max(endoffset, subEntry.getOffset() + subEntry.getSize());
         }
       } else {
@@ -791,8 +787,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
 
   private void updateActorCREOffsets()
   {
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Actor) {
         ((Actor)o).updateCREOffset();
       }
@@ -804,8 +799,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     // Assumes items offset is correct
     int offset = ((HexNumber)getAttribute(ARE_OFFSET_ITEMS)).getValue();
     int count = 0;
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Container) {
         Container container = (Container)o;
         int itemNum = container.updateItems(offset, count);
@@ -821,8 +815,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     // Assumes vertices offset is correct
     int offset = ((HexNumber)getAttribute(ARE_OFFSET_VERTICES)).getValue();
     int count = 0;
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof HasVertices) {
         HasVertices vert = (HasVertices)o;
         int vertNum = vert.updateVertices(offset, count);
@@ -998,4 +991,3 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     return false;
   }
 }
-

--- a/src/org/infinity/resource/are/AreResource.java
+++ b/src/org/infinity/resource/are/AreResource.java
@@ -359,7 +359,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
   @Override
   public void write(OutputStream os) throws IOException
   {
-    super.writeFlatList(os);
+    super.writeFlatFields(os);
   }
 
 // --------------------- End Interface Writeable ---------------------
@@ -751,13 +751,13 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     }
 
     offset = offset_items.getValue();
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Container)
         ((Container)o).readItems(buffer, offset);
     }
 
     offset = offset_vertices.getValue();
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof HasVertices)
         ((HasVertices)o).readVertices(buffer, offset);
     }
@@ -770,10 +770,10 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     }
 
     int endoffset = offset;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry instanceof HasVertices) {
         // may contain additional elements
-        for (final StructEntry subEntry : ((AbstractStruct)entry).getList()) {
+        for (final StructEntry subEntry : ((AbstractStruct)entry).getFields()) {
           endoffset = Math.max(endoffset, subEntry.getOffset() + subEntry.getSize());
         }
       } else {
@@ -787,7 +787,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
 
   private void updateActorCREOffsets()
   {
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Actor) {
         ((Actor)o).updateCREOffset();
       }
@@ -799,7 +799,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     // Assumes items offset is correct
     int offset = ((HexNumber)getAttribute(ARE_OFFSET_ITEMS)).getValue();
     int count = 0;
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Container) {
         Container container = (Container)o;
         int itemNum = container.updateItems(offset, count);
@@ -815,7 +815,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     // Assumes vertices offset is correct
     int offset = ((HexNumber)getAttribute(ARE_OFFSET_VERTICES)).getValue();
     int count = 0;
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof HasVertices) {
         HasVertices vert = (HasVertices)o;
         int vertNum = vert.updateVertices(offset, count);

--- a/src/org/infinity/resource/are/Container.java
+++ b/src/org/infinity/resource/are/Container.java
@@ -154,7 +154,7 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
   {
     ((DecNumber)getAttribute(ARE_CONTAINER_FIRST_VERTEX_INDEX)).setValue(number);
     int count = 0;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry instanceof Vertex) {
         entry.setOffset(offset);
         ((Vertex)entry).realignStructOffsets();
@@ -202,7 +202,7 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
   {
     ((DecNumber)getAttribute(ARE_CONTAINER_FIRST_ITEM_INDEX)).setValue(number);
     int count = 0;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry instanceof Item) {
         entry.setOffset(offset);
         ((Item)entry).realignStructOffsets();

--- a/src/org/infinity/resource/are/Container.java
+++ b/src/org/infinity/resource/are/Container.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -175,14 +175,14 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
     if (datatype instanceof Vertex) {
       int index = ((DecNumber)getAttribute(ARE_CONTAINER_FIRST_VERTEX_INDEX)).getValue();
       index += ((DecNumber)getAttribute(ARE_CONTAINER_NUM_VERTICES)).getValue();
-      int offset = ((HexNumber)getSuperStruct().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
+      final int offset = ((HexNumber)getParent().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
       datatype.setOffset(offset + 4 * index);
       ((AbstractStruct)datatype).realignStructOffsets();
     }
     else if (datatype instanceof Item) {
       int index = ((DecNumber)getAttribute(ARE_CONTAINER_FIRST_ITEM_INDEX)).getValue();
       index += ((DecNumber)getAttribute(ARE_CONTAINER_NUM_ITEMS)).getValue();
-      int offset = ((HexNumber)getSuperStruct().getAttribute(AreResource.ARE_OFFSET_ITEMS)).getValue();
+      final int offset = ((HexNumber)getParent().getAttribute(AreResource.ARE_OFFSET_ITEMS)).getValue();
       datatype.setOffset(offset + 20 * index);
       ((AbstractStruct)datatype).realignStructOffsets();
     }
@@ -249,4 +249,3 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
     return offset + 192;
   }
 }
-

--- a/src/org/infinity/resource/are/Container.java
+++ b/src/org/infinity/resource/are/Container.java
@@ -154,8 +154,7 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
   {
     ((DecNumber)getAttribute(ARE_CONTAINER_FIRST_VERTEX_INDEX)).setValue(number);
     int count = 0;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry instanceof Vertex) {
         entry.setOffset(offset);
         ((Vertex)entry).realignStructOffsets();
@@ -203,8 +202,7 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
   {
     ((DecNumber)getAttribute(ARE_CONTAINER_FIRST_ITEM_INDEX)).setValue(number);
     int count = 0;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry instanceof Item) {
         entry.setOffset(offset);
         ((Item)entry).realignStructOffsets();

--- a/src/org/infinity/resource/are/Door.java
+++ b/src/org/infinity/resource/are/Door.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -189,7 +189,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
   @Override
   protected void setAddRemovableOffset(AddRemovable datatype)
   {
-    int offset = ((HexNumber)getSuperStruct().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
+    final int offset = ((HexNumber)getParent().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
     if (datatype instanceof OpenVertex) {
       int index = ((DecNumber)getAttribute(ARE_DOOR_FIRST_VERTEX_INDEX_OPEN)).getValue();
       index += ((DecNumber)getAttribute(ARE_DOOR_NUM_VERTICES_OPEN)).getValue();
@@ -270,4 +270,3 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
     return offset + 200;
   }
 }
-

--- a/src/org/infinity/resource/are/Door.java
+++ b/src/org/infinity/resource/are/Door.java
@@ -173,8 +173,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
     ((DecNumber)getAttribute(ARE_DOOR_FIRST_VERTEX_INDEX_IMPEDED_CLOSED)).setValue(number + count);
     count += ((DecNumber)getAttribute(ARE_DOOR_NUM_VERTICES_IMPEDED_CLOSED)).getValue();
 
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry instanceof Vertex) {
         entry.setOffset(offset);
         ((Vertex)entry).realignStructOffsets();

--- a/src/org/infinity/resource/are/Door.java
+++ b/src/org/infinity/resource/are/Door.java
@@ -173,7 +173,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
     ((DecNumber)getAttribute(ARE_DOOR_FIRST_VERTEX_INDEX_IMPEDED_CLOSED)).setValue(number + count);
     count += ((DecNumber)getAttribute(ARE_DOOR_NUM_VERTICES_IMPEDED_CLOSED)).getValue();
 
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry instanceof Vertex) {
         entry.setOffset(offset);
         ((Vertex)entry).realignStructOffsets();

--- a/src/org/infinity/resource/are/ITEPoint.java
+++ b/src/org/infinity/resource/are/ITEPoint.java
@@ -129,8 +129,7 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
   {
     ((DecNumber)getAttribute(ARE_TRIGGER_FIRST_VERTEX_INDEX)).setValue(number);
     int count = 0;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry instanceof Vertex) {
         entry.setOffset(offset);
         ((Vertex)entry).realignStructOffsets();

--- a/src/org/infinity/resource/are/ITEPoint.java
+++ b/src/org/infinity/resource/are/ITEPoint.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -150,7 +150,7 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
     if (datatype instanceof Vertex) {
       int index = ((DecNumber)getAttribute(ARE_TRIGGER_FIRST_VERTEX_INDEX)).getValue();
       index += ((DecNumber)getAttribute(ARE_TRIGGER_NUM_VERTICES)).getValue();
-      int offset = ((HexNumber)getSuperStruct().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
+      final int offset = ((HexNumber)getParent().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
       datatype.setOffset(offset + 4 * index);
       ((AbstractStruct)datatype).realignStructOffsets();
     }
@@ -213,4 +213,3 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
     return offset + 196;
   }
 }
-

--- a/src/org/infinity/resource/are/ITEPoint.java
+++ b/src/org/infinity/resource/are/ITEPoint.java
@@ -129,7 +129,7 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
   {
     ((DecNumber)getAttribute(ARE_TRIGGER_FIRST_VERTEX_INDEX)).setValue(number);
     int count = 0;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry instanceof Vertex) {
         entry.setOffset(offset);
         ((Vertex)entry).realignStructOffsets();

--- a/src/org/infinity/resource/are/ProEffect.java
+++ b/src/org/infinity/resource/are/ProEffect.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -42,13 +42,13 @@ public class ProEffect extends AbstractStruct implements AddRemovable
     addField(new TextString(buffer, offset + 4, 4, COMMON_VERSION));
     EffectType type = new EffectType(buffer, offset + 8, 4);
     addField(type);
-    List<StructEntry> list = new ArrayList<StructEntry>();
+    final List<StructEntry> list = new ArrayList<>();
     offset = type.readAttributes(buffer, offset + 12, list);
-    addToList(getList().size() - 1, list);
+    addFields(getFields().size() - 1, list);
 
     list.clear();
     offset = Effect2.readCommon(list, buffer, offset);
-    addToList(getList().size() - 1, list);
+    addFields(getFields().size() - 1, list);
 
     return offset;
   }

--- a/src/org/infinity/resource/are/Song.java
+++ b/src/org/infinity/resource/are/Song.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -38,9 +38,9 @@ public final class Song extends AbstractStruct // implements AddRemovable
   public static final String ARE_SONGS_AMBIENT_VOLUME_NIGHT = "Main ambient volume (night)";
   public static final String ARE_SONGS_REVERB               = "Reverb";
 
-  Song(AbstractStruct superStruct, ByteBuffer buffer, int offset) throws Exception
+  Song(AreResource are, ByteBuffer buffer, int offset) throws Exception
   {
-    super(superStruct, ARE_SONGS, buffer, offset);
+    super(are, ARE_SONGS, buffer, offset);
   }
 
   @Override
@@ -56,16 +56,13 @@ public final class Song extends AbstractStruct // implements AddRemovable
     addField(new Song2daBitmap(buffer, offset + 28, 4, ARE_SONGS_VICTORY_ALTERNATE));
     addField(new Song2daBitmap(buffer, offset + 32, 4, ARE_SONGS_BATTLE_ALTERNATE));
     addField(new Song2daBitmap(buffer, offset + 36, 4, ARE_SONGS_DEFEAT_ALTERNATE));
-    if (getSuperStruct() != null) {
-      addField(new AreResourceRef(buffer, offset + 40, ARE_SONGS_AMBIENT_DAY_1,
-                                  (AreResource)getSuperStruct()));
-      addField(new AreResourceRef(buffer, offset + 48, ARE_SONGS_AMBIENT_DAY_2,
-                                  (AreResource)getSuperStruct()));
+    final AreResource are = (AreResource)getParent();
+    if (are != null) {
+      addField(new AreResourceRef(buffer, offset + 40, ARE_SONGS_AMBIENT_DAY_1, are));
+      addField(new AreResourceRef(buffer, offset + 48, ARE_SONGS_AMBIENT_DAY_2, are));
       addField(new DecNumber(buffer, offset + 56, 4, ARE_SONGS_AMBIENT_VOLUME_DAY));
-      addField(new AreResourceRef(buffer, offset + 60, ARE_SONGS_AMBIENT_NIGHT_1,
-                                  (AreResource)getSuperStruct()));
-      addField(new AreResourceRef(buffer, offset + 68, ARE_SONGS_AMBIENT_NIGHT_2,
-                                  (AreResource)getSuperStruct()));
+      addField(new AreResourceRef(buffer, offset + 60, ARE_SONGS_AMBIENT_NIGHT_1, are));
+      addField(new AreResourceRef(buffer, offset + 68, ARE_SONGS_AMBIENT_NIGHT_2, are));
       addField(new DecNumber(buffer, offset + 76, 4, ARE_SONGS_AMBIENT_VOLUME_NIGHT));
     }
     else {
@@ -88,4 +85,3 @@ public final class Song extends AbstractStruct // implements AddRemovable
     return offset + 144;
   }
 }
-

--- a/src/org/infinity/resource/are/ViewerActor.java
+++ b/src/org/infinity/resource/are/ViewerActor.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -85,8 +85,8 @@ public final class ViewerActor extends JPanel
 
     ViewerUtil.addLabelFieldPair(fieldPanel, actor.getAttribute(Actor.ARE_ACTOR_ORIENTATION), gbl, gbc, true);
     ViewerUtil.addLabelFieldPair(fieldPanel, actor.getAttribute(Actor.ARE_ACTOR_SCRIPT_OVERRIDE), gbl, gbc, true);
-    if (actor.getSuperStruct() != null &&
-        actor.getSuperStruct().getAttribute(AbstractStruct.COMMON_VERSION).toString().equalsIgnoreCase("V9.1")) {
+    if (actor.getParent() != null &&
+        actor.getParent().getAttribute(AbstractStruct.COMMON_VERSION).toString().equalsIgnoreCase("V9.1")) {
       ViewerUtil.addLabelFieldPair(fieldPanel, actor.getAttribute(Actor.ARE_ACTOR_SCRIPT_SPECIAL_1), gbl, gbc, true);
       ViewerUtil.addLabelFieldPair(fieldPanel, actor.getAttribute(Actor.ARE_ACTOR_SCRIPT_TEAM), gbl, gbc, true);
       ViewerUtil.addLabelFieldPair(fieldPanel, actor.getAttribute(Actor.ARE_ACTOR_SCRIPT_SPECIAL_2), gbl, gbc, true);
@@ -106,4 +106,3 @@ public final class ViewerActor extends JPanel
     return fieldPanel;
   }
 }
-

--- a/src/org/infinity/resource/are/viewer/BasicLayer.java
+++ b/src/org/infinity/resource/are/viewer/BasicLayer.java
@@ -308,7 +308,7 @@ public abstract class BasicLayer<E extends LayerObject, R extends AbstractStruct
   {
     final List<T> fields = new ArrayList<>();
     if (parent != null && baseOfs >= 0 && maxCount >= 0 && type != null) {
-      for (final StructEntry field : parent.getList()) {
+      for (final StructEntry field : parent.getFields()) {
         if (field.getOffset() >= baseOfs && type.isAssignableFrom(field.getClass())) {
           if (maxCount-- < 0) { break; }
 

--- a/src/org/infinity/resource/are/viewer/LayerObject.java
+++ b/src/org/infinity/resource/are/viewer/LayerObject.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -11,7 +11,6 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.util.EventListener;
-import java.util.List;
 
 import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.Flag;
@@ -236,21 +235,20 @@ public abstract class LayerObject
     if (superStruct != null && index >= 0 && count > 0 && type != null) {
       int idx = 0, cnt = 0;
       coords = new Point[count];
-      List<StructEntry> list = superStruct.getList();
-        for (int i = 0, size = list.size(); i < size; i++) {
-          if (list.get(i).getOffset() >= baseOfs && type.isAssignableFrom(list.get(i).getClass())) {
-            if (idx >= index) {
-              Vertex vertex = (Vertex)list.get(i);
-              coords[cnt] = new Point(((DecNumber)vertex.getAttribute(Vertex.VERTEX_X)).getValue(),
-                                      ((DecNumber)vertex.getAttribute(Vertex.VERTEX_Y)).getValue());
-              cnt++;
-              if (cnt >= count) {
-                break;
-              }
+      for (final StructEntry e : superStruct.getFields()) {
+        if (e.getOffset() >= baseOfs && type.isAssignableFrom(e.getClass())) {
+          if (idx >= index) {
+            final Vertex vertex = (Vertex)e;
+            coords[cnt] = new Point(((DecNumber)vertex.getAttribute(Vertex.VERTEX_X)).getValue(),
+                                    ((DecNumber)vertex.getAttribute(Vertex.VERTEX_Y)).getValue());
+            cnt++;
+            if (cnt >= count) {
+              break;
             }
-            idx++;
           }
+          idx++;
         }
+      }
 
       // filling up remaining coordinates with empty values (if any)
       for (int i = cnt; i < coords.length; i++) {

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -8,7 +8,6 @@ import java.awt.Color;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
-import java.util.List;
 
 import org.infinity.datatype.Flag;
 import org.infinity.datatype.HexNumber;
@@ -278,17 +277,16 @@ public class LayerObjectDoorPoly extends LayerObject
     }
   }
 
-  // Returns the specified WED polygon structure
+  /** Returns the specified WED polygon structure. */
   private org.infinity.resource.wed.Polygon getPolygonStructure(AbstractStruct baseStruct, int baseOfs, int index)
   {
 //    WedResource wed = (WedResource)getParentStructure();
     if (baseStruct != null) {
-      List<StructEntry> list = baseStruct.getList();
       int idx = 0;
-      for (int i = 0; i < list.size(); i++) {
-        if (list.get(i).getOffset() >= baseOfs && list.get(i) instanceof org.infinity.resource.wed.Polygon) {
+      for (final StructEntry e : baseStruct.getFields()) {
+        if (e.getOffset() >= baseOfs && e instanceof org.infinity.resource.wed.Polygon) {
           if (idx == index) {
-            return (org.infinity.resource.wed.Polygon)list.get(i);
+            return (org.infinity.resource.wed.Polygon)e;
           }
           idx++;
         }

--- a/src/org/infinity/resource/chu/ChuResource.java
+++ b/src/org/infinity/resource/chu/ChuResource.java
@@ -59,12 +59,12 @@ public final class ChuResource extends AbstractStruct implements Resource, HasVi
   public void write(OutputStream os) throws IOException
   {
     super.write(os);
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Window) {
         ((Window)o).writeControlsTable(os);
       }
     }
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Window) {
         ((Window)o).writeControls(os);
       }

--- a/src/org/infinity/resource/chu/ChuResource.java
+++ b/src/org/infinity/resource/chu/ChuResource.java
@@ -23,6 +23,7 @@ import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Resource;
+import org.infinity.resource.StructEntry;
 import org.infinity.resource.graphics.BamResource;
 import org.infinity.resource.graphics.MosResource;
 import org.infinity.resource.key.ResourceEntry;
@@ -58,14 +59,12 @@ public final class ChuResource extends AbstractStruct implements Resource, HasVi
   public void write(OutputStream os) throws IOException
   {
     super.write(os);
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Window) {
         ((Window)o).writeControlsTable(os);
       }
     }
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Window) {
         ((Window)o).writeControls(os);
       }
@@ -127,7 +126,7 @@ public final class ChuResource extends AbstractStruct implements Resource, HasVi
 
 // --------------------- End Interface HasViewerTabs ---------------------
 
-   // Write 'size' number of zeros to the output stream
+  /** Write 'size' number of zeros to the output stream. */
   void writeGap(OutputStream os, int startOfs, int endOfs) throws IOException
   {
     while (startOfs < endOfs) {
@@ -298,18 +297,17 @@ public final class ChuResource extends AbstractStruct implements Resource, HasVi
     // Adding offset/size pairs for each control
     curOfs = ofsControls;
     if (listControls == null) {
-      listControls = new ArrayList<Pair<Integer>>();
+      listControls = new ArrayList<>();
     }
     int ofs = 0, len = 0;
     for (int i = 0; i < numControls; i++, curOfs += 8) {
       ofs = buffer.getInt(curOfs);
       len = buffer.getInt(curOfs + 4);
-      listControls.add(new Pair<Integer>(Integer.valueOf(ofs), Integer.valueOf(len)));
+      listControls.add(new Pair<>(Integer.valueOf(ofs), Integer.valueOf(len)));
     }
 
     // adding virtual entry for determining the true size of the last control entry
     ofs = Math.max(ofs + len, buffer.limit());
-    listControls.add(new Pair<Integer>(Integer.valueOf(ofs), Integer.valueOf(0)));
+    listControls.add(new Pair<>(Integer.valueOf(ofs), Integer.valueOf(0)));
   }
 }
-

--- a/src/org/infinity/resource/chu/Control.java
+++ b/src/org/infinity/resource/chu/Control.java
@@ -117,8 +117,8 @@ final class Control extends AbstractStruct // implements AddRemovable
   @Override
   public void write(OutputStream os) throws IOException
   {
-    getList().get(0).write(os);
-    getList().get(1).write(os);
+    getFields().get(0).write(os);
+    getFields().get(1).write(os);
   }
   //</editor-fold>
 
@@ -281,7 +281,7 @@ final class Control extends AbstractStruct // implements AddRemovable
 
   public void writeControl(OutputStream os) throws IOException
   {
-    final List<StructEntry> fields = getList();
+    final List<StructEntry> fields = getFields();
     for (int i = 2; i < fields.size(); i++) {
       fields.get(i).write(os);
     }

--- a/src/org/infinity/resource/chu/Control.java
+++ b/src/org/infinity/resource/chu/Control.java
@@ -9,6 +9,7 @@ import java.awt.Point;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.List;
 
 import org.infinity.datatype.Bitmap;
 import org.infinity.datatype.ColorPicker;
@@ -21,6 +22,7 @@ import org.infinity.datatype.TextString;
 import org.infinity.datatype.Unknown;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.Profile;
+import org.infinity.resource.StructEntry;
 
 final class Control extends AbstractStruct // implements AddRemovable
 {
@@ -115,8 +117,8 @@ final class Control extends AbstractStruct // implements AddRemovable
   @Override
   public void write(OutputStream os) throws IOException
   {
-    getField(0).write(os);
-    getField(1).write(os);
+    getList().get(0).write(os);
+    getList().get(1).write(os);
   }
   //</editor-fold>
 
@@ -279,7 +281,9 @@ final class Control extends AbstractStruct // implements AddRemovable
 
   public void writeControl(OutputStream os) throws IOException
   {
-    for (int i = 2; i < getFieldCount(); i++)
-      getField(i).write(os);
+    final List<StructEntry> fields = getList();
+    for (int i = 2; i < fields.size(); i++) {
+      fields.get(i).write(os);
+    }
   }
 }

--- a/src/org/infinity/resource/chu/Window.java
+++ b/src/org/infinity/resource/chu/Window.java
@@ -57,12 +57,11 @@ final class Window extends AbstractStruct // implements AddRemovable
   public void write(OutputStream os) throws IOException
   {
     Collections.sort(getList());
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
-      if (entry instanceof Control)
+    for (final StructEntry entry : getList()) {
+      if (entry instanceof Control) {
         break;
-      else
-        entry.write(os);
+      }
+      entry.write(os);
     }
   }
 
@@ -140,8 +139,7 @@ final class Window extends AbstractStruct // implements AddRemovable
 
   public void writeControls(OutputStream os) throws IOException
   {
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Control) {
         ((Control)o).writeControl(os);
       }
@@ -150,8 +148,7 @@ final class Window extends AbstractStruct // implements AddRemovable
 
   public void writeControlsTable(OutputStream os) throws IOException
   {
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Control) {
         ((Control)o).write(os);
       }

--- a/src/org/infinity/resource/chu/Window.java
+++ b/src/org/infinity/resource/chu/Window.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.chu;
@@ -46,9 +46,9 @@ final class Window extends AbstractStruct // implements AddRemovable
     super(null, CHU_WINDOW_PANEL, StreamUtils.getByteBuffer(36), 0);
   }
 
-  Window(AbstractStruct superStruct, ByteBuffer buffer, int offset, int nr) throws Exception
+  Window(ChuResource chu, ByteBuffer buffer, int offset, int nr) throws Exception
   {
-    super(superStruct, CHU_WINDOW_PANEL + " " + nr, buffer, offset);
+    super(chu, CHU_WINDOW_PANEL + " " + nr, buffer, offset);
   }
 
 // --------------------- Begin Interface Writeable ---------------------
@@ -68,13 +68,10 @@ final class Window extends AbstractStruct // implements AddRemovable
 
 // --------------------- End Interface Writeable ---------------------
 
-  public ChuResource getChu()
+  @Override
+  public ChuResource getParent()
   {
-    if (getSuperStruct() instanceof ChuResource) {
-      return (ChuResource)getSuperStruct();
-    } else {
-      return null;
-    }
+    return (ChuResource)super.getParent();
   }
 
   /** Returns the number of controls associated with this panel. */
@@ -129,10 +126,10 @@ final class Window extends AbstractStruct // implements AddRemovable
   {
     int numctrl = (int)((UnsignDecNumber)getAttribute(CHU_WINDOW_NUM_CONTROLS)).getValue();
     int first = (int)((UnsignDecNumber)getAttribute(CHU_WINDOW_FIRST_CONTROL_INDEX)).getValue();
-    int controlsoffset = getChu().getControlsOffset() + (first*8);
+    int controlsoffset = getParent().getControlsOffset() + (first*8);
     int endoffset = controlsoffset;
     for (int i = 0; i < numctrl; i++) {
-      int size = getChu().getControlOffset(first+i+1) - getChu().getControlOffset(first+i);
+      int size = getParent().getControlOffset(first+i+1) - getParent().getControlOffset(first+i);
       Control control = new Control(this, buffer, controlsoffset, i, size);
       controlsoffset = control.getEndOffset();
       endoffset = control.readControl(buffer);
@@ -164,7 +161,7 @@ final class Window extends AbstractStruct // implements AddRemovable
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
-    if (getChu().getPanelSize() == 36) {
+    if (getParent().getPanelSize() == 36) {
       addField(new TextString(buffer, offset, 8, CHU_WINDOW_NAME), 0);
       offset += 8;
     }
@@ -182,4 +179,3 @@ final class Window extends AbstractStruct // implements AddRemovable
     return offset + 28;
   }
 }
-

--- a/src/org/infinity/resource/chu/Window.java
+++ b/src/org/infinity/resource/chu/Window.java
@@ -56,8 +56,8 @@ final class Window extends AbstractStruct // implements AddRemovable
   @Override
   public void write(OutputStream os) throws IOException
   {
-    Collections.sort(getList());
-    for (final StructEntry entry : getList()) {
+    Collections.sort(getFields());
+    for (final StructEntry entry : getFields()) {
       if (entry instanceof Control) {
         break;
       }
@@ -139,7 +139,7 @@ final class Window extends AbstractStruct // implements AddRemovable
 
   public void writeControls(OutputStream os) throws IOException
   {
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Control) {
         ((Control)o).writeControl(os);
       }
@@ -148,7 +148,7 @@ final class Window extends AbstractStruct // implements AddRemovable
 
   public void writeControlsTable(OutputStream os) throws IOException
   {
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Control) {
         ((Control)o).write(os);
       }

--- a/src/org/infinity/resource/cre/CreResource.java
+++ b/src/org/infinity/resource/cre/CreResource.java
@@ -1033,7 +1033,7 @@ public final class CreResource extends AbstractStruct
     addField(new ColorValue(buffer, offset + 40, 1, CRE_COLOR_LEATHER));
     addField(new ColorValue(buffer, offset + 41, 1, CRE_COLOR_ARMOR));
     addField(new ColorValue(buffer, offset + 42, 1, CRE_COLOR_HAIR));
-    Bitmap effect_version = (Bitmap)addField(new Bitmap(buffer, offset + 43, 1, CRE_EFFECT_VERSION, s_effversion));
+    Bitmap effect_version = addField(new Bitmap(buffer, offset + 43, 1, CRE_EFFECT_VERSION, s_effversion));
     addField(new ResourceRef(buffer, offset + 44, CRE_PORTRAIT_SMALL, "BMP"));
     addField(new ResourceRef(buffer, offset + 52, CRE_PORTRAIT_LARGE, "BMP"));
     addField(new DecNumber(buffer, offset + 60, 1, CRE_REPUTATION));
@@ -1457,7 +1457,7 @@ public final class CreResource extends AbstractStruct
       addField(new ColorValue(buffer, offset + 41, 1, CRE_COLOR_ARMOR));
       addField(new ColorValue(buffer, offset + 42, 1, CRE_COLOR_HAIR));
     }
-    Bitmap effect_version = (Bitmap)addField(new Bitmap(buffer, offset + 43, 1, CRE_EFFECT_VERSION, s_effversion));
+    Bitmap effect_version = addField(new Bitmap(buffer, offset + 43, 1, CRE_EFFECT_VERSION, s_effversion));
     addField(new ResourceRef(buffer, offset + 44, CRE_PORTRAIT_SMALL, "BMP"));
     if (version.equalsIgnoreCase("V1.2") || version.equalsIgnoreCase("V1.1")) {
       addField(new ResourceRef(buffer, offset + 52, CRE_PORTRAIT_LARGE, "BAM"));

--- a/src/org/infinity/resource/cre/CreResource.java
+++ b/src/org/infinity/resource/cre/CreResource.java
@@ -576,8 +576,7 @@ public final class CreResource extends AbstractStruct
 
   private static void adjustEntryOffsets(AbstractStruct struct, int amount)
   {
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      StructEntry structEntry = struct.getField(i);
+    for (final StructEntry structEntry : struct.getList()) {
       structEntry.setOffset(structEntry.getOffset() + amount);
       if (structEntry instanceof AbstractStruct)
         adjustEntryOffsets((AbstractStruct)structEntry, amount);
@@ -594,7 +593,7 @@ public final class CreResource extends AbstractStruct
     if (path != null) {
       try {
         CreResource crefile = (CreResource)ResourceFactory.getResource(resourceEntry);
-        while (!crefile.getField(0).toString().equals("CRE ")) {
+        while (!crefile.getList().get(0).toString().equals("CRE ")) {
           crefile.removeField(0);
         }
         convertToSemiStandard(crefile);
@@ -613,7 +612,8 @@ public final class CreResource extends AbstractStruct
 
   private static void convertToSemiStandard(CreResource crefile)
   {
-    if (!crefile.getField(1).toString().equals("V1.0")) {
+    final List<StructEntry> fields = crefile.getList();
+    if (!fields.get(1).toString().equals("V1.0")) {
       System.err.println("Conversion to semi-standard aborted: Unsupported CRE version");
       return;
     }
@@ -636,42 +636,42 @@ public final class CreResource extends AbstractStruct
     SectionOffset items_offset = (SectionOffset)crefile.getAttribute(CRE_OFFSET_ITEMS);
     SectionOffset effects_offset = (SectionOffset)crefile.getAttribute(CRE_OFFSET_EFFECTS);
 
-    int indexStructs = crefile.getIndexOf(effects_offset) + 3; // Start of non-permanent section
-    List<StructEntry> newlist = new ArrayList<StructEntry>(crefile.getFieldCount());
+    final int indexStructs = fields.indexOf(effects_offset) + 3; // Start of non-permanent section
+    final List<StructEntry> newlist = new ArrayList<>(fields.size());
     for (int i = 0; i < indexStructs; i++)
-      newlist.add(crefile.getField(i));
+      newlist.add(fields.get(i));
 
     int offsetStructs = 0x2d4;
     knownspells_offset.setValue(offsetStructs);
-    offsetStructs = copyStruct(crefile.getList(), newlist, indexStructs, offsetStructs, KnownSpells.class);
+    offsetStructs = copyStruct(fields, newlist, indexStructs, offsetStructs, KnownSpells.class);
 
     memspellinfo_offset.setValue(offsetStructs);
-    offsetStructs = copyStruct(crefile.getList(), newlist, indexStructs, offsetStructs, SpellMemorization.class);
+    offsetStructs = copyStruct(fields, newlist, indexStructs, offsetStructs, SpellMemorization.class);
 
     memspells_offset.setValue(offsetStructs);
     // XXX: mem spells are not directly stored in crefile.list
     // and added by addFlatList on the Spell Memorization entries
     // (but the offsets are wrong, so we need to realign them with copyStruct)
-    List<StructEntry> trashlist = new ArrayList<StructEntry>();
-    for (int i = indexStructs; i < crefile.getFieldCount(); i++) {
-      StructEntry entry = crefile.getField(i);
+    List<StructEntry> trashlist = new ArrayList<>();
+    for (int i = indexStructs; i < fields.size(); i++) {
+      StructEntry entry = fields.get(i);
       if (entry instanceof SpellMemorization) {
         offsetStructs = copyStruct(((SpellMemorization)entry).getList(), trashlist, 0, offsetStructs, MemorizedSpells.class);
       }
     }
 
     effects_offset.setValue(offsetStructs);
-    offsetStructs =
-    copyStruct(crefile.getList(), newlist, indexStructs, offsetStructs, effects_offset.getSection());
+    offsetStructs = copyStruct(fields, newlist, indexStructs, offsetStructs, effects_offset.getSection());
 
     items_offset.setValue(offsetStructs);
-    offsetStructs = copyStruct(crefile.getList(), newlist, indexStructs, offsetStructs, Item.class);
+    offsetStructs = copyStruct(fields, newlist, indexStructs, offsetStructs, Item.class);
 
     itemslots_offset.setValue(offsetStructs);
-    offsetStructs = copyStruct(crefile.getList(), newlist, indexStructs, offsetStructs, DecNumber.class);
-    copyStruct(crefile.getList(), newlist, indexStructs, offsetStructs, Unknown.class);
+    offsetStructs = copyStruct(fields, newlist, indexStructs, offsetStructs, DecNumber.class);
+    copyStruct(fields, newlist, indexStructs, offsetStructs, Unknown.class);
 
-    crefile.setList(newlist);
+    fields.clear();
+    fields.addAll(newlist);
   }
 
   private static int copyStruct(List<StructEntry> oldlist, List<StructEntry> newlist,
@@ -1416,8 +1416,7 @@ public final class CreResource extends AbstractStruct
     addField(new DecNumber(buffer, offset + 102, 2, CRE_SELECTED_WEAPON_ABILITY));
 
     int endoffset = offset;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry.getOffset() + entry.getSize() > endoffset) {
         endoffset = entry.getOffset() + entry.getSize();
       }
@@ -1916,8 +1915,7 @@ public final class CreResource extends AbstractStruct
       }
     }
     int endoffset = offset;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry.getOffset() + entry.getSize() > endoffset) {
         endoffset = entry.getOffset() + entry.getSize();
       }
@@ -1930,8 +1928,7 @@ public final class CreResource extends AbstractStruct
     // Assumes memorized spells offset is correct
     int offset = ((HexNumber)getAttribute(CRE_OFFSET_MEMORIZED_SPELLS)).getValue() + getExtraOffset();
     int count = 0;
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof SpellMemorization) {
         SpellMemorization info = (SpellMemorization)o;
         int numSpells = info.updateSpells(offset, count);
@@ -1944,7 +1941,7 @@ public final class CreResource extends AbstractStruct
 
   private void updateOffsets(AddRemovable datatype, int size)
   {
-    if (getField(0).toString().equalsIgnoreCase("CHR "))
+    if (getList().get(0).toString().equalsIgnoreCase("CHR "))
       ((HexNumber)getAttribute(CHR_CRE_SIZE)).incValue(size);
 //    if (!(datatype instanceof MemorizedSpells)) {
 //      HexNumber offsetMemSpells = (HexNumber)getAttribute("Memorized spells offset");

--- a/src/org/infinity/resource/cre/CreResource.java
+++ b/src/org/infinity/resource/cre/CreResource.java
@@ -576,7 +576,7 @@ public final class CreResource extends AbstractStruct
 
   private static void adjustEntryOffsets(AbstractStruct struct, int amount)
   {
-    for (final StructEntry structEntry : struct.getList()) {
+    for (final StructEntry structEntry : struct.getFields()) {
       structEntry.setOffset(structEntry.getOffset() + amount);
       if (structEntry instanceof AbstractStruct)
         adjustEntryOffsets((AbstractStruct)structEntry, amount);
@@ -593,7 +593,7 @@ public final class CreResource extends AbstractStruct
     if (path != null) {
       try {
         CreResource crefile = (CreResource)ResourceFactory.getResource(resourceEntry);
-        while (!crefile.getList().get(0).toString().equals("CRE ")) {
+        while (!crefile.getFields().get(0).toString().equals("CRE ")) {
           crefile.removeField(0);
         }
         convertToSemiStandard(crefile);
@@ -612,7 +612,7 @@ public final class CreResource extends AbstractStruct
 
   private static void convertToSemiStandard(CreResource crefile)
   {
-    final List<StructEntry> fields = crefile.getList();
+    final List<StructEntry> fields = crefile.getFields();
     if (!fields.get(1).toString().equals("V1.0")) {
       System.err.println("Conversion to semi-standard aborted: Unsupported CRE version");
       return;
@@ -656,7 +656,7 @@ public final class CreResource extends AbstractStruct
     for (int i = indexStructs; i < fields.size(); i++) {
       StructEntry entry = fields.get(i);
       if (entry instanceof SpellMemorization) {
-        offsetStructs = copyStruct(((SpellMemorization)entry).getList(), trashlist, 0, offsetStructs, MemorizedSpells.class);
+        offsetStructs = copyStruct(((SpellMemorization)entry).getFields(), trashlist, 0, offsetStructs, MemorizedSpells.class);
       }
     }
 
@@ -836,7 +836,7 @@ public final class CreResource extends AbstractStruct
   @Override
   public void write(OutputStream os) throws IOException
   {
-    super.writeFlatList(os);
+    super.writeFlatFields(os);
   }
 
 
@@ -1416,7 +1416,7 @@ public final class CreResource extends AbstractStruct
     addField(new DecNumber(buffer, offset + 102, 2, CRE_SELECTED_WEAPON_ABILITY));
 
     int endoffset = offset;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry.getOffset() + entry.getSize() > endoffset) {
         endoffset = entry.getOffset() + entry.getSize();
       }
@@ -1915,7 +1915,7 @@ public final class CreResource extends AbstractStruct
       }
     }
     int endoffset = offset;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry.getOffset() + entry.getSize() > endoffset) {
         endoffset = entry.getOffset() + entry.getSize();
       }
@@ -1928,7 +1928,7 @@ public final class CreResource extends AbstractStruct
     // Assumes memorized spells offset is correct
     int offset = ((HexNumber)getAttribute(CRE_OFFSET_MEMORIZED_SPELLS)).getValue() + getExtraOffset();
     int count = 0;
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof SpellMemorization) {
         SpellMemorization info = (SpellMemorization)o;
         int numSpells = info.updateSpells(offset, count);
@@ -1941,7 +1941,7 @@ public final class CreResource extends AbstractStruct
 
   private void updateOffsets(AddRemovable datatype, int size)
   {
-    if (getList().get(0).toString().equalsIgnoreCase("CHR "))
+    if (getFields().get(0).toString().equalsIgnoreCase("CHR "))
       ((HexNumber)getAttribute(CHR_CRE_SIZE)).incValue(size);
 //    if (!(datatype instanceof MemorizedSpells)) {
 //      HexNumber offsetMemSpells = (HexNumber)getAttribute("Memorized spells offset");

--- a/src/org/infinity/resource/cre/Iwd2Struct.java
+++ b/src/org/infinity/resource/cre/Iwd2Struct.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.cre;
@@ -98,7 +98,7 @@ public final class Iwd2Struct extends AbstractStruct implements HasAddRemovable
   }
 
   @Override
-  protected int getAddedPosition()
+  protected int getInsertPosition()
   {
     return count.getValue();
   }
@@ -109,4 +109,3 @@ public final class Iwd2Struct extends AbstractStruct implements HasAddRemovable
     return -1;
   }
 }
-

--- a/src/org/infinity/resource/cre/SpellMemorization.java
+++ b/src/org/infinity/resource/cre/SpellMemorization.java
@@ -110,7 +110,7 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
   {
     ((DecNumber)getAttribute(CRE_MEMORIZATION_SPELL_TABLE_INDEX)).setValue(startIndex);
     int count = 0;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry instanceof MemorizedSpells) {
         entry.setOffset(offset);
         ((AbstractStruct)entry).realignStructOffsets();

--- a/src/org/infinity/resource/cre/SpellMemorization.java
+++ b/src/org/infinity/resource/cre/SpellMemorization.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.cre;
@@ -33,9 +33,9 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
     super(null, CRE_MEMORIZATION, StreamUtils.getByteBuffer(16), 0);
   }
 
-  SpellMemorization(AbstractStruct superStruct, ByteBuffer buffer, int offset, int nr) throws Exception
+  SpellMemorization(CreResource cre, ByteBuffer buffer, int offset, int nr) throws Exception
   {
-    super(superStruct, CRE_MEMORIZATION + " " + nr, buffer, offset);
+    super(cre, CRE_MEMORIZATION + " " + nr, buffer, offset);
   }
 
 //--------------------- Begin Interface AddRemovable ---------------------
@@ -77,7 +77,7 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
     if (datatype instanceof MemorizedSpells) {
       int index = ((DecNumber)getAttribute(CRE_MEMORIZATION_SPELL_TABLE_INDEX)).getValue();
       index += ((DecNumber)getAttribute(CRE_MEMORIZATION_SPELL_COUNT)).getValue();
-      CreResource cre = (CreResource)getSuperStruct();
+      final CreResource cre = (CreResource)getParent();
       int offset = ((HexNumber)cre.getAttribute(CreResource.CRE_OFFSET_MEMORIZED_SPELLS)).getValue() +
                    cre.getExtraOffset();
       datatype.setOffset(offset + 12 * index);
@@ -123,4 +123,3 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
     return count;
   }
 }
-

--- a/src/org/infinity/resource/cre/SpellMemorization.java
+++ b/src/org/infinity/resource/cre/SpellMemorization.java
@@ -110,8 +110,7 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
   {
     ((DecNumber)getAttribute(CRE_MEMORIZATION_SPELL_TABLE_INDEX)).setValue(startIndex);
     int count = 0;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry instanceof MemorizedSpells) {
         entry.setOffset(offset);
         ((AbstractStruct)entry).realignStructOffsets();

--- a/src/org/infinity/resource/cre/Viewer.java
+++ b/src/org/infinity/resource/cre/Viewer.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.cre;
@@ -409,12 +409,12 @@ public final class Viewer extends JPanel
     {
       if (value instanceof AbstractStruct) {
         AbstractStruct struct = (AbstractStruct)value;
-        return struct.getName() + " (" + (struct.getFieldCount() - 2) + ')';
-      } else if (value != null) {
+        return struct.getName() + " (" + (struct.getList().size() - 2) + ')';
+      }
+      if (value != null) {
         return value.toString();
       }
       return "";
     }
   }
 }
-

--- a/src/org/infinity/resource/cre/Viewer.java
+++ b/src/org/infinity/resource/cre/Viewer.java
@@ -409,7 +409,7 @@ public final class Viewer extends JPanel
     {
       if (value instanceof AbstractStruct) {
         AbstractStruct struct = (AbstractStruct)value;
-        return struct.getName() + " (" + (struct.getList().size() - 2) + ')';
+        return struct.getName() + " (" + (struct.getFields().size() - 2) + ')';
       }
       if (value != null) {
         return value.toString();

--- a/src/org/infinity/resource/cre/ViewerItems.java
+++ b/src/org/infinity/resource/cre/ViewerItems.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.cre;
@@ -41,15 +41,14 @@ final class ViewerItems extends JPanel implements ActionListener, ListSelectionL
   private final InventoryTableModel tableModel = new InventoryTableModel();
   private final JButton bOpen;
   private final JTable table;
-  private final List<StructEntry> slots = new ArrayList<StructEntry>();
+  private final List<StructEntry> slots = new ArrayList<>();
 
   ViewerItems(CreResource cre)
   {
     super(new BorderLayout(0, 3));
-    List<Item> items = new ArrayList<Item>();
+    final List<Item> items = new ArrayList<>();
     HexNumber slots_offset = (HexNumber)cre.getAttribute(CreResource.CRE_OFFSET_ITEM_SLOTS);
-    for (int i = 0; i < cre.getFieldCount(); i++) {
-      StructEntry entry = cre.getField(i);
+    for (final StructEntry entry : cre.getList()) {
       if (entry instanceof Item)
         items.add((Item)entry);
       else if (entry.getOffset() >= slots_offset.getValue() + cre.getOffset() &&
@@ -150,11 +149,10 @@ final class ViewerItems extends JPanel implements ActionListener, ListSelectionL
   {
     if (event.getType() == TableModelEvent.UPDATE) {
       CreResource cre = (CreResource)event.getSource();
-      Object changed = cre.getField(event.getFirstRow());
+      final StructEntry changed = cre.getList().get(event.getFirstRow());
       if (slots.contains(changed)) {
-        List<Item> items = new ArrayList<Item>();
-        for (int i = 0; i < cre.getFieldCount(); i++) {
-          StructEntry entry = cre.getField(i);
+        final List<Item> items = new ArrayList<>();
+        for (final StructEntry entry : cre.getList()) {
           if (entry instanceof Item)
             items.add((Item)entry);
         }
@@ -198,7 +196,7 @@ final class ViewerItems extends JPanel implements ActionListener, ListSelectionL
 
   private static final class InventoryTableModel extends AbstractTableModel
   {
-    private final List<InventoryTableEntry> list = new ArrayList<InventoryTableEntry>();
+    private final List<InventoryTableEntry> list = new ArrayList<>();
 
     private InventoryTableModel()
     {
@@ -252,4 +250,3 @@ final class ViewerItems extends JPanel implements ActionListener, ListSelectionL
     }
   }
 }
-

--- a/src/org/infinity/resource/cre/ViewerItems.java
+++ b/src/org/infinity/resource/cre/ViewerItems.java
@@ -48,7 +48,7 @@ final class ViewerItems extends JPanel implements ActionListener, ListSelectionL
     super(new BorderLayout(0, 3));
     final List<Item> items = new ArrayList<>();
     HexNumber slots_offset = (HexNumber)cre.getAttribute(CreResource.CRE_OFFSET_ITEM_SLOTS);
-    for (final StructEntry entry : cre.getList()) {
+    for (final StructEntry entry : cre.getFields()) {
       if (entry instanceof Item)
         items.add((Item)entry);
       else if (entry.getOffset() >= slots_offset.getValue() + cre.getOffset() &&
@@ -149,10 +149,10 @@ final class ViewerItems extends JPanel implements ActionListener, ListSelectionL
   {
     if (event.getType() == TableModelEvent.UPDATE) {
       CreResource cre = (CreResource)event.getSource();
-      final StructEntry changed = cre.getList().get(event.getFirstRow());
+      final StructEntry changed = cre.getFields().get(event.getFirstRow());
       if (slots.contains(changed)) {
         final List<Item> items = new ArrayList<>();
-        for (final StructEntry entry : cre.getList()) {
+        for (final StructEntry entry : cre.getFields()) {
           if (entry instanceof Item)
             items.add((Item)entry);
         }

--- a/src/org/infinity/resource/cre/ViewerSpells.java
+++ b/src/org/infinity/resource/cre/ViewerSpells.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.cre;
@@ -107,14 +107,12 @@ final class ViewerSpells extends JPanel implements ActionListener
     private void updateTable()
     {
       list.clear();
-      for (int i = 0; i < cre.getFieldCount(); i++) {
-        StructEntry o = cre.getField(i);
+      for (final StructEntry o : cre.getList()) {
         if (o instanceof SpellMemorization) {
           SpellMemorization inf = (SpellMemorization)o;
           int type = ((IsNumeric)inf.getAttribute(SpellMemorization.CRE_MEMORIZATION_TYPE)).getValue();
           int lvl = ((IsNumeric)inf.getAttribute(SpellMemorization.CRE_MEMORIZATION_LEVEL)).getValue();
-          for (int j = 0; j < inf.getFieldCount(); j++) {
-            StructEntry p = inf.getField(j);
+          for (final StructEntry p : inf.getList()) {
             if (p instanceof MemorizedSpells) {
               MemorizedSpells spell = (MemorizedSpells)p;
               addSpell(type, lvl, (ResourceRef)spell.getAttribute(MemorizedSpells.CRE_MEMORIZED_RESREF));
@@ -205,4 +203,3 @@ final class ViewerSpells extends JPanel implements ActionListener
     }
   }
 }
-

--- a/src/org/infinity/resource/cre/ViewerSpells.java
+++ b/src/org/infinity/resource/cre/ViewerSpells.java
@@ -107,12 +107,12 @@ final class ViewerSpells extends JPanel implements ActionListener
     private void updateTable()
     {
       list.clear();
-      for (final StructEntry o : cre.getList()) {
+      for (final StructEntry o : cre.getFields()) {
         if (o instanceof SpellMemorization) {
           SpellMemorization inf = (SpellMemorization)o;
           int type = ((IsNumeric)inf.getAttribute(SpellMemorization.CRE_MEMORIZATION_TYPE)).getValue();
           int lvl = ((IsNumeric)inf.getAttribute(SpellMemorization.CRE_MEMORIZATION_LEVEL)).getValue();
-          for (final StructEntry p : inf.getList()) {
+          for (final StructEntry p : inf.getFields()) {
             if (p instanceof MemorizedSpells) {
               MemorizedSpells spell = (MemorizedSpells)p;
               addSpell(type, lvl, (ResourceRef)spell.getAttribute(MemorizedSpells.CRE_MEMORIZED_RESREF));

--- a/src/org/infinity/resource/dlg/DlgItem.java
+++ b/src/org/infinity/resource/dlg/DlgItem.java
@@ -54,7 +54,7 @@ final class DlgItem extends StateOwnerItem implements Iterable<StateItem>
     final boolean alwaysShow = BrowserMenuBar.getInstance().alwaysShowState0();
     // finding and storing initial states
     int count = 0;
-    for (StructEntry e : dlg.getList()) {
+    for (final StructEntry e : dlg.getFields()) {
       if (e instanceof State) {
         final State s = (State)e;
         // First state always under root, if setting is checked

--- a/src/org/infinity/resource/dlg/DlgResource.java
+++ b/src/org/infinity/resource/dlg/DlgResource.java
@@ -15,6 +15,7 @@ import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Consumer;
 
 import javax.swing.JButton;
@@ -198,24 +199,23 @@ public final class DlgResource extends AbstractStruct
   @Override
   public void write(OutputStream os) throws IOException
   {
+    final List<StructEntry> fields = getList();
     offsetState.setValue(0x30);
-    if (getFieldCount() >= 13 && getField(12).getName().equalsIgnoreCase(DLG_THREAT_RESPONSE))
+    if (fields.size() > 12 && fields.get(12).getName().equalsIgnoreCase(DLG_THREAT_RESPONSE))
       offsetState.setValue(0x34);
     offsetTrans.setValue(offsetState.getValue() + 0x10 * countState.getValue());
     offsetStaTri.setValue(offsetTrans.getValue() + 0x20 * countTrans.getValue());
     offsetTranTri.setValue(offsetStaTri.getValue() + 0x8 * countStaTri.getValue());
     offsetAction.setValue(offsetTranTri.getValue() + 0x8 * countTranTri.getValue());
     int stringoff = offsetAction.getValue() + 0x8 * countAction.getValue();
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : fields) {
       if (o instanceof AbstractCode) {
         stringoff += ((AbstractCode)o).updateOffset(stringoff);
       }
     }
     super.write(os);
 
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : fields) {
       if (o instanceof AbstractCode) {
         ((AbstractCode)o).writeString(os);
       }

--- a/src/org/infinity/resource/dlg/DlgResource.java
+++ b/src/org/infinity/resource/dlg/DlgResource.java
@@ -199,7 +199,7 @@ public final class DlgResource extends AbstractStruct
   @Override
   public void write(OutputStream os) throws IOException
   {
-    final List<StructEntry> fields = getList();
+    final List<StructEntry> fields = getFields();
     offsetState.setValue(0x30);
     if (fields.size() > 12 && fields.get(12).getName().equalsIgnoreCase(DLG_THREAT_RESPONSE))
       offsetState.setValue(0x34);
@@ -436,7 +436,7 @@ public final class DlgResource extends AbstractStruct
     final String name = dlg.getResourceEntry().getResourceName();
 
     boolean found = false;
-    for (final StructEntry e : getList()) {
+    for (final StructEntry e : getFields()) {
       if (!(e instanceof Transition)) continue;
 
       final Transition t = (Transition)e;
@@ -463,7 +463,7 @@ public final class DlgResource extends AbstractStruct
     final int number = trans.getNumber();
 
     boolean found = false;
-    for (final StructEntry e : getList()) {
+    for (final StructEntry e : getFields()) {
       if (!(e instanceof State)) continue;
 
       final State s = (State)e;

--- a/src/org/infinity/resource/dlg/Viewer.java
+++ b/src/org/infinity/resource/dlg/Viewer.java
@@ -579,7 +579,7 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
     staTriList.clear();
     transTriList.clear();
     actionList.clear();
-    for (final StructEntry entry : dlg.getList()) {
+    for (final StructEntry entry : dlg.getFields()) {
       if (entry instanceof State) {
         stateList.add((State)entry);
       } else if (entry instanceof Transition) {

--- a/src/org/infinity/resource/gam/GamResource.java
+++ b/src/org/infinity/resource/gam/GamResource.java
@@ -33,6 +33,7 @@ import org.infinity.resource.HasAddRemovable;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
+import org.infinity.resource.StructEntry;
 import org.infinity.resource.are.AreResource;
 import org.infinity.resource.cre.CreResource;
 import org.infinity.resource.itm.ItmResource;
@@ -527,7 +528,8 @@ public final class GamResource extends AbstractStruct implements Resource, HasAd
     }
 
     if (offset == 0) {
-      offset = getField(getFieldCount() - 1).getOffset() + getField(getFieldCount() - 1).getSize();
+      final StructEntry last = getList().get(getList().size() - 1);
+      offset = last.getOffset() + last.getSize();
     }
 
     return offset;
@@ -535,8 +537,7 @@ public final class GamResource extends AbstractStruct implements Resource, HasAd
 
   private void updateOffsets()
   {
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof PartyNPC) {
         ((PartyNPC)o).updateCREOffset();
       }
@@ -546,4 +547,3 @@ public final class GamResource extends AbstractStruct implements Resource, HasAd
     }
   }
 }
-

--- a/src/org/infinity/resource/gam/GamResource.java
+++ b/src/org/infinity/resource/gam/GamResource.java
@@ -226,7 +226,7 @@ public final class GamResource extends AbstractStruct implements Resource, HasAd
   @Override
   public void write(OutputStream os) throws IOException
   {
-    super.writeFlatList(os);
+    super.writeFlatFields(os);
   }
 
 // --------------------- End Interface Writeable ---------------------
@@ -528,7 +528,7 @@ public final class GamResource extends AbstractStruct implements Resource, HasAd
     }
 
     if (offset == 0) {
-      final StructEntry last = getList().get(getList().size() - 1);
+      final StructEntry last = getFields().get(getFields().size() - 1);
       offset = last.getOffset() + last.getSize();
     }
 
@@ -537,7 +537,7 @@ public final class GamResource extends AbstractStruct implements Resource, HasAd
 
   private void updateOffsets()
   {
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof PartyNPC) {
         ((PartyNPC)o).updateCREOffset();
       }

--- a/src/org/infinity/resource/gam/PartyNPC.java
+++ b/src/org/infinity/resource/gam/PartyNPC.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.gam;
@@ -184,7 +184,8 @@ public class PartyNPC extends AbstractStruct implements HasViewerTabs, HasAddRem
   @Override
   protected void datatypeAddedInChild(AbstractStruct child, AddRemovable datatype)
   {
-    ((DecNumber)getAttribute(GAM_NPC_CRE_SIZE)).setValue(getField(getFieldCount() - 1).getSize());
+    final StructEntry last = getList().get(getList().size() - 1);
+    ((DecNumber)getAttribute(GAM_NPC_CRE_SIZE)).setValue(last.getSize());
     super.datatypeAddedInChild(child, datatype);
   }
 
@@ -200,13 +201,14 @@ public class PartyNPC extends AbstractStruct implements HasViewerTabs, HasAddRem
   @Override
   protected void datatypeRemovedInChild(AbstractStruct child, AddRemovable datatype)
   {
-    ((DecNumber)getAttribute(GAM_NPC_CRE_SIZE)).setValue(getField(getFieldCount() - 1).getSize());
+    final StructEntry last = getList().get(getList().size() - 1);
+    ((DecNumber)getAttribute(GAM_NPC_CRE_SIZE)).setValue(last.getSize());
     super.datatypeRemovedInChild(child, datatype);
   }
 
   void updateCREOffset()
   {
-    StructEntry entry = getField(getFieldCount() - 1);
+    final StructEntry entry = getList().get(getList().size() - 1);
     if (entry instanceof CreResource)
       ((HexNumber)getAttribute(GAM_NPC_OFFSET_CRE)).setValue(entry.getOffset());
   }
@@ -474,4 +476,3 @@ public class PartyNPC extends AbstractStruct implements HasViewerTabs, HasAddRem
     return StreamUtils.getByteBuffer(size);
   }
 }
-

--- a/src/org/infinity/resource/gam/PartyNPC.java
+++ b/src/org/infinity/resource/gam/PartyNPC.java
@@ -184,7 +184,7 @@ public class PartyNPC extends AbstractStruct implements HasViewerTabs, HasAddRem
   @Override
   protected void datatypeAddedInChild(AbstractStruct child, AddRemovable datatype)
   {
-    final StructEntry last = getList().get(getList().size() - 1);
+    final StructEntry last = getFields().get(getFields().size() - 1);
     ((DecNumber)getAttribute(GAM_NPC_CRE_SIZE)).setValue(last.getSize());
     super.datatypeAddedInChild(child, datatype);
   }
@@ -201,14 +201,14 @@ public class PartyNPC extends AbstractStruct implements HasViewerTabs, HasAddRem
   @Override
   protected void datatypeRemovedInChild(AbstractStruct child, AddRemovable datatype)
   {
-    final StructEntry last = getList().get(getList().size() - 1);
+    final StructEntry last = getFields().get(getFields().size() - 1);
     ((DecNumber)getAttribute(GAM_NPC_CRE_SIZE)).setValue(last.getSize());
     super.datatypeRemovedInChild(child, datatype);
   }
 
   void updateCREOffset()
   {
-    final StructEntry entry = getList().get(getList().size() - 1);
+    final StructEntry entry = getFields().get(getFields().size() - 1);
     if (entry instanceof CreResource)
       ((HexNumber)getAttribute(GAM_NPC_OFFSET_CRE)).setValue(entry.getOffset());
   }

--- a/src/org/infinity/resource/itm/ItmResource.java
+++ b/src/org/infinity/resource/itm/ItmResource.java
@@ -302,7 +302,7 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
   public void write(OutputStream os) throws IOException
   {
     super.write(os);
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Ability) {
         Ability a = (Ability)o;
         a.writeEffects(os);
@@ -322,14 +322,14 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
   protected void datatypeAdded(AddRemovable datatype)
   {
     if (datatype instanceof Effect) {
-      for (final StructEntry o : getList()) {
+      for (final StructEntry o : getFields()) {
         if (o instanceof Ability)
           ((Ability)o).incEffectsIndex(1);
       }
     }
     else if (datatype instanceof Ability) {
       int effect_count = ((SectionCount)getAttribute(ITM_NUM_GLOBAL_EFFECTS)).getValue();
-      for (final StructEntry o : getList()) {
+      for (final StructEntry o : getFields()) {
         if (o instanceof Ability) {
           Ability ability = (Ability)o;
           ability.setEffectsIndex(effect_count);
@@ -353,14 +353,14 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
   protected void datatypeRemoved(AddRemovable datatype)
   {
     if (datatype instanceof Effect) {
-      for (final StructEntry o : getList()) {
+      for (final StructEntry o : getFields()) {
         if (o instanceof Ability)
           ((Ability)o).incEffectsIndex(-1);
       }
     }
     else if (datatype instanceof Ability) {
       int effect_count = ((SectionCount)getAttribute(ITM_NUM_GLOBAL_EFFECTS)).getValue();
-      for (final StructEntry o : getList()) {
+      for (final StructEntry o : getFields()) {
         if (o instanceof Ability) {
           Ability ability = (Ability)o;
           ability.setEffectsIndex(effect_count);
@@ -500,7 +500,7 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
   private void incAbilityEffects(StructEntry child, AddRemovable datatype, int value)
   {
     if (child instanceof Ability && datatype instanceof Effect) {
-      final List<StructEntry> fields = getList();
+      final List<StructEntry> fields = getFields();
       final ListIterator<StructEntry> it = fields.listIterator(fields.indexOf(child) + 1);
       while (it.hasNext()) {
         final StructEntry se = it.next();

--- a/src/org/infinity/resource/itm/ViewerAbility.java
+++ b/src/org/infinity/resource/itm/ViewerAbility.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.itm;
@@ -20,7 +20,6 @@ import org.infinity.datatype.Flag;
 import org.infinity.datatype.ResourceRef;
 import org.infinity.gui.ViewerUtil;
 import org.infinity.resource.AbstractAbility;
-import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.Effect;
 import org.infinity.resource.StructEntry;
 import org.infinity.util.StringTable;
@@ -113,10 +112,7 @@ final class ViewerAbility extends JPanel
     Table2da table = Table2daCache.get("tooltip.2da");
     if (table != null) {
       // getting parent item resref
-      String resref = null;
-      if (ability.getParent() instanceof AbstractStruct) {
-        resref = ((AbstractStruct)ability.getParent()).getResourceEntry().getResourceName();
-      }
+      String resref = ability.getParent().getResourceEntry().getResourceName();
       if (resref.lastIndexOf('.') > 0) {
         resref = resref.substring(0, resref.lastIndexOf('.'));
       }
@@ -156,4 +152,3 @@ final class ViewerAbility extends JPanel
     return retVal;
   }
 }
-

--- a/src/org/infinity/resource/other/EffResource.java
+++ b/src/org/infinity/resource/other/EffResource.java
@@ -59,11 +59,11 @@ public final class EffResource extends AbstractStruct implements Resource, HasVi
     addField(type);
     List<StructEntry> list = new ArrayList<>();
     offset = type.readAttributes(buffer, offset + 20, list);
-    addToList(getList().size() - 1, list);
+    addFields(getFields().size() - 1, list);
 
     list.clear();
     Effect2.readCommon(list, buffer, offset);
-    addToList(getList().size() - 1, list);
+    addFields(getFields().size() - 1, list);
 
     return offset + 216;
   }

--- a/src/org/infinity/resource/pro/ProResource.java
+++ b/src/org/infinity/resource/pro/ProResource.java
@@ -153,36 +153,36 @@ public final class ProResource extends AbstractStruct implements Resource, HasAd
       // add/remove extended sections in the parent structure depending on the current value
       if (struct instanceof Resource && struct instanceof HasAddRemovable) {
         if (proType.getValue() == 3L) {         // area of effect
-          StructEntry entry = struct.getList().get(struct.getList().size() - 1);
+          StructEntry entry = struct.getFields().get(struct.getFields().size() - 1);
           try {
             if (!(entry instanceof ProSingleType) && !(entry instanceof ProAreaType))
-              struct.addDatatype(new ProSingleType(), struct.getList().size());
-            entry = struct.getList().get(struct.getList().size() - 1);
+              struct.addDatatype(new ProSingleType(), struct.getFields().size());
+            entry = struct.getFields().get(struct.getFields().size() - 1);
             if (!(entry instanceof ProAreaType))
-              struct.addDatatype(new ProAreaType(), struct.getList().size());
+              struct.addDatatype(new ProAreaType(), struct.getFields().size());
           } catch (Exception e) {
             e.printStackTrace();
             return false;
           }
         } else if (proType.getValue() == 2L) {  // single target
-          StructEntry entry = struct.getList().get(struct.getList().size() - 1);
+          StructEntry entry = struct.getFields().get(struct.getFields().size() - 1);
           if (entry instanceof ProAreaType)
             struct.removeDatatype((AddRemovable)entry, false);
-          entry = struct.getList().get(struct.getList().size() - 1);
+          entry = struct.getFields().get(struct.getFields().size() - 1);
           if (!(entry instanceof ProSingleType)) {
             try {
-              struct.addDatatype(new ProSingleType(), struct.getList().size());
+              struct.addDatatype(new ProSingleType(), struct.getFields().size());
             } catch (Exception e) {
               e.printStackTrace();
               return false;
             }
           }
         } else if (proType.getValue() == 1L) {  // no bam
-          if (struct.getList().size() > 2) {
-            StructEntry entry = struct.getList().get(struct.getList().size() - 1);
+          if (struct.getFields().size() > 2) {
+            StructEntry entry = struct.getFields().get(struct.getFields().size() - 1);
             if (entry instanceof ProAreaType)
               struct.removeDatatype((AddRemovable)entry, false);
-            entry = struct.getList().get(struct.getList().size() - 1);
+            entry = struct.getFields().get(struct.getFields().size() - 1);
             if (entry instanceof ProSingleType)
               struct.removeDatatype((AddRemovable)entry, false);
           }
@@ -360,8 +360,8 @@ public final class ProResource extends AbstractStruct implements Resource, HasAd
         final StructEntry newValue = newType.createCreatureValueFromType(valueBuffer, 0);
         newValue.setOffset(offset);
 
-        replaceEntry(newValue);
-        replaceEntry(newType);
+        replaceField(newValue);
+        replaceField(newType);
         return true;
       }
     }
@@ -382,8 +382,8 @@ public final class ProResource extends AbstractStruct implements Resource, HasAd
         final StructEntry newValue = newType.createIdsValueFromType(valueBuffer, 0);
         newValue.setOffset(offset);
 
-        replaceEntry(newValue);
-        replaceEntry(newType);
+        replaceField(newValue);
+        replaceField(newType);
         return true;
       }
     }

--- a/src/org/infinity/resource/spl/SplResource.java
+++ b/src/org/infinity/resource/spl/SplResource.java
@@ -9,6 +9,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.List;
+import java.util.ListIterator;
 
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
@@ -231,8 +233,7 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   public void write(OutputStream os) throws IOException
   {
     super.write(os);
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Ability) {
         Ability a = (Ability)o;
         a.writeEffects(os);
@@ -276,16 +277,14 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   protected void datatypeAdded(AddRemovable datatype)
   {
     if (datatype instanceof Effect) {
-      for (int i = 0; i < getFieldCount(); i++) {
-        Object o = getField(i);
+      for (final StructEntry o : getList()) {
         if (o instanceof Ability)
           ((Ability)o).incEffectsIndex(1);
       }
     }
     else if (datatype instanceof Ability) {
       int effect_count = ((SectionCount)getAttribute(SPL_NUM_GLOBAL_EFFECTS)).getValue();
-      for (int i = 0; i < getFieldCount(); i++) {
-        Object o = getField(i);
+      for (final StructEntry o : getList()) {
         if (o instanceof Ability) {
           Ability ability = (Ability)o;
           ability.setEffectsIndex(effect_count);
@@ -302,33 +301,21 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   protected void datatypeAddedInChild(AbstractStruct child, AddRemovable datatype)
   {
     super.datatypeAddedInChild(child, datatype);
-    if (child instanceof Ability && datatype instanceof Effect) {
-      int index = getIndexOf(child) + 1;
-      while (index < getFieldCount()) {
-        StructEntry se = getField(index++);
-        if (se instanceof Ability)
-          ((Ability)se).incEffectsIndex(1);
-      }
-    }
-    if (hexViewer != null) {
-      hexViewer.dataModified();
-    }
+    incAbilityEffects(child, datatype, 1);
   }
 
   @Override
   protected void datatypeRemoved(AddRemovable datatype)
   {
     if (datatype instanceof Effect) {
-      for (int i = 0; i < getFieldCount(); i++) {
-        Object o = getField(i);
+      for (final StructEntry o : getList()) {
         if (o instanceof Ability)
           ((Ability)o).incEffectsIndex(-1);
       }
     }
     else if (datatype instanceof Ability) {
       int effect_count = ((SectionCount)getAttribute(SPL_NUM_GLOBAL_EFFECTS)).getValue();
-      for (int i = 0; i < getFieldCount(); i++) {
-        Object o = getField(i);
+      for (final StructEntry o : getList()) {
         if (o instanceof Ability) {
           Ability ability = (Ability)o;
           ability.setEffectsIndex(effect_count);
@@ -345,17 +332,7 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   protected void datatypeRemovedInChild(AbstractStruct child, AddRemovable datatype)
   {
     super.datatypeRemovedInChild(child, datatype);
-    if (child instanceof Ability && datatype instanceof Effect) {
-      int index = getIndexOf(child) + 1;
-      while (index < getFieldCount()) {
-        StructEntry se = getField(index++);
-        if (se instanceof Ability)
-          ((Ability)se).incEffectsIndex(-1);
-      }
-    }
-    if (hexViewer != null) {
-      hexViewer.dataModified();
-    }
+    incAbilityEffects(child, datatype, -1);
   }
 
   @Override
@@ -434,6 +411,22 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
     return Math.max(offset, offset2);
   }
 
+  private void incAbilityEffects(StructEntry child, AddRemovable datatype, int value)
+  {
+    if (child instanceof Ability && datatype instanceof Effect) {
+      final List<StructEntry> fields = getList();
+      final ListIterator<StructEntry> it = fields.listIterator(fields.indexOf(child) + 1);
+      while (it.hasNext()) {
+        final StructEntry se = it.next();
+        if (se instanceof Ability) {
+          ((Ability)se).incEffectsIndex(value);
+        }
+      }
+    }
+    if (hexViewer != null) {
+      hexViewer.dataModified();
+    }
+  }
 
   /**
    * Checks whether the specified resource entry matches all available search options.

--- a/src/org/infinity/resource/spl/SplResource.java
+++ b/src/org/infinity/resource/spl/SplResource.java
@@ -233,7 +233,7 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   public void write(OutputStream os) throws IOException
   {
     super.write(os);
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Ability) {
         Ability a = (Ability)o;
         a.writeEffects(os);
@@ -258,7 +258,7 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
         ByteBuffer b = ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN).putInt(curFlags.getValue());
         Flag newFlags = new Flag(b, 0, size, SPL_EXCLUSION_FLAGS, (type == 2) ? s_exclude_priest : s_exclude);
         newFlags.setOffset(offset);
-        replaceEntry(newFlags);
+        replaceField(newFlags);
         return true;
       }
     }
@@ -277,14 +277,14 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   protected void datatypeAdded(AddRemovable datatype)
   {
     if (datatype instanceof Effect) {
-      for (final StructEntry o : getList()) {
+      for (final StructEntry o : getFields()) {
         if (o instanceof Ability)
           ((Ability)o).incEffectsIndex(1);
       }
     }
     else if (datatype instanceof Ability) {
       int effect_count = ((SectionCount)getAttribute(SPL_NUM_GLOBAL_EFFECTS)).getValue();
-      for (final StructEntry o : getList()) {
+      for (final StructEntry o : getFields()) {
         if (o instanceof Ability) {
           Ability ability = (Ability)o;
           ability.setEffectsIndex(effect_count);
@@ -308,14 +308,14 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   protected void datatypeRemoved(AddRemovable datatype)
   {
     if (datatype instanceof Effect) {
-      for (final StructEntry o : getList()) {
+      for (final StructEntry o : getFields()) {
         if (o instanceof Ability)
           ((Ability)o).incEffectsIndex(-1);
       }
     }
     else if (datatype instanceof Ability) {
       int effect_count = ((SectionCount)getAttribute(SPL_NUM_GLOBAL_EFFECTS)).getValue();
-      for (final StructEntry o : getList()) {
+      for (final StructEntry o : getFields()) {
         if (o instanceof Ability) {
           Ability ability = (Ability)o;
           ability.setEffectsIndex(effect_count);
@@ -414,7 +414,7 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   private void incAbilityEffects(StructEntry child, AddRemovable datatype, int value)
   {
     if (child instanceof Ability && datatype instanceof Effect) {
-      final List<StructEntry> fields = getList();
+      final List<StructEntry> fields = getFields();
       final ListIterator<StructEntry> it = fields.listIterator(fields.indexOf(child) + 1);
       while (it.hasNext()) {
         final StructEntry se = it.next();

--- a/src/org/infinity/resource/sto/StoResource.java
+++ b/src/org/infinity/resource/sto/StoResource.java
@@ -293,8 +293,7 @@ public final class StoResource extends AbstractStruct implements Resource, HasAd
     }
 
     int endoffset = offset;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry.getOffset() + entry.getSize() > endoffset)
         endoffset = entry.getOffset() + entry.getSize();
     }

--- a/src/org/infinity/resource/sto/StoResource.java
+++ b/src/org/infinity/resource/sto/StoResource.java
@@ -293,7 +293,7 @@ public final class StoResource extends AbstractStruct implements Resource, HasAd
     }
 
     int endoffset = offset;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry.getOffset() + entry.getSize() > endoffset)
         endoffset = entry.getOffset() + entry.getSize();
     }

--- a/src/org/infinity/resource/to/TohResource.java
+++ b/src/org/infinity/resource/to/TohResource.java
@@ -108,8 +108,7 @@ public final class TohResource extends AbstractStruct implements Resource
     }
 
     int endoffset = offset;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry.getOffset() + entry.getSize() > endoffset)
         endoffset = entry.getOffset() + entry.getSize();
     }

--- a/src/org/infinity/resource/to/TohResource.java
+++ b/src/org/infinity/resource/to/TohResource.java
@@ -108,7 +108,7 @@ public final class TohResource extends AbstractStruct implements Resource
     }
 
     int endoffset = offset;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry.getOffset() + entry.getSize() > endoffset)
         endoffset = entry.getOffset() + entry.getSize();
     }

--- a/src/org/infinity/resource/to/TotResource.java
+++ b/src/org/infinity/resource/to/TotResource.java
@@ -55,8 +55,7 @@ public final class TotResource extends AbstractStruct implements Resource
     }
 
     int endoffset = offset;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry.getOffset() + entry.getSize() > endoffset)
         endoffset = entry.getOffset() + entry.getSize();
     }

--- a/src/org/infinity/resource/to/TotResource.java
+++ b/src/org/infinity/resource/to/TotResource.java
@@ -55,7 +55,7 @@ public final class TotResource extends AbstractStruct implements Resource
     }
 
     int endoffset = offset;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry.getOffset() + entry.getSize() > endoffset)
         endoffset = entry.getOffset() + entry.getSize();
     }

--- a/src/org/infinity/resource/vef/AbstractComponent.java
+++ b/src/org/infinity/resource/vef/AbstractComponent.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.vef;
@@ -56,7 +56,7 @@ public class AbstractComponent extends AbstractStruct implements AddRemovable
 
     List<StructEntry> list = new ArrayList<StructEntry>();
     offset = type.readAttributes(buffer, offset + 16, list);
-    addToList(getList().size() - 1, list);
+    addFields(getFields().size() - 1, list);
 
     addField(new Bitmap(buffer, offset, 4, VEF_COMP_CONTINUOUS, s_noyes));
     addField(new Unknown(buffer, offset + 4, 196));

--- a/src/org/infinity/resource/vef/VefResource.java
+++ b/src/org/infinity/resource/vef/VefResource.java
@@ -135,7 +135,7 @@ public final class VefResource extends AbstractStruct implements Resource, HasAd
     }
 
     int endoffset = offset;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry.getOffset() + entry.getSize() > endoffset)
         endoffset = entry.getOffset() + entry.getSize();
     }

--- a/src/org/infinity/resource/vef/VefResource.java
+++ b/src/org/infinity/resource/vef/VefResource.java
@@ -135,8 +135,7 @@ public final class VefResource extends AbstractStruct implements Resource, HasAd
     }
 
     int endoffset = offset;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry.getOffset() + entry.getSize() > endoffset)
         endoffset = entry.getOffset() + entry.getSize();
     }

--- a/src/org/infinity/resource/vef/VefType.java
+++ b/src/org/infinity/resource/vef/VefType.java
@@ -42,7 +42,7 @@ public final class VefType extends Bitmap
         StructEntry entry = list.get(i);
         entry.setOffset(entry.getOffset() + getOffset() + getSize());
       }
-      struct.addToList(this, list);
+      struct.addFields(this, list);
       return true;
     } catch (IOException e) {
       e.printStackTrace();

--- a/src/org/infinity/resource/wed/Door.java
+++ b/src/org/infinity/resource/wed/Door.java
@@ -16,6 +16,7 @@ import org.infinity.datatype.TextString;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.StructEntry;
 import org.infinity.util.io.StreamUtils;
 
 public final class Door extends AbstractStruct implements AddRemovable, HasAddRemovable
@@ -94,8 +95,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
 
   public void readVertices(ByteBuffer buffer, int offset) throws Exception
   {
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Polygon)
         ((Polygon)o).readVertices(buffer, offset);
     }
@@ -104,8 +104,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
   public void updatePolygonsOffset(int offset)
   {
     int polyOffset = Integer.MAX_VALUE;
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Polygon) {
         polyOffset = Math.min(polyOffset, ((Polygon)o).getOffset());
       }
@@ -114,14 +113,14 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
       offset = polyOffset;
     }
     ((SectionOffset)getAttribute(WED_DOOR_OFFSET_POLYGONS_OPEN)).setValue(offset);
-    for (int i = 0; i < getFieldCount(); i++) {
-      if (getField(i) instanceof OpenPolygon) {
+    for (final StructEntry o : getList()) {
+      if (o instanceof OpenPolygon) {
         offset += 18;
       }
     }
     ((SectionOffset)getAttribute(WED_DOOR_OFFSET_POLYGONS_CLOSED)).setValue(offset);
-    for (int i = 0; i < getFieldCount(); i++) {
-      if (getField(i) instanceof ClosedPolygon) {
+    for (final StructEntry o : getList()) {
+      if (o instanceof ClosedPolygon) {
         offset += 18;
       }
     }

--- a/src/org/infinity/resource/wed/Door.java
+++ b/src/org/infinity/resource/wed/Door.java
@@ -95,7 +95,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
 
   public void readVertices(ByteBuffer buffer, int offset) throws Exception
   {
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Polygon)
         ((Polygon)o).readVertices(buffer, offset);
     }
@@ -104,7 +104,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
   public void updatePolygonsOffset(int offset)
   {
     int polyOffset = Integer.MAX_VALUE;
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Polygon) {
         polyOffset = Math.min(polyOffset, ((Polygon)o).getOffset());
       }
@@ -113,13 +113,13 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
       offset = polyOffset;
     }
     ((SectionOffset)getAttribute(WED_DOOR_OFFSET_POLYGONS_OPEN)).setValue(offset);
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof OpenPolygon) {
         offset += 18;
       }
     }
     ((SectionOffset)getAttribute(WED_DOOR_OFFSET_POLYGONS_CLOSED)).setValue(offset);
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof ClosedPolygon) {
         offset += 18;
       }

--- a/src/org/infinity/resource/wed/Door.java
+++ b/src/org/infinity/resource/wed/Door.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.wed;
@@ -81,7 +81,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
   protected void setAddRemovableOffset(AddRemovable datatype)
   {
     if (datatype instanceof RemovableDecNumber) {
-      int offset = ((HexNumber)getSuperStruct().getAttribute(WedResource.WED_OFFSET_DOOR_TILEMAP_LOOKUP)).getValue();
+      final int offset = ((HexNumber)getParent().getAttribute(WedResource.WED_OFFSET_DOOR_TILEMAP_LOOKUP)).getValue();
       int index = getTilemapIndex().getValue();
       datatype.setOffset(offset + index * 2);
     }
@@ -157,8 +157,8 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
       addField(new ClosedPolygon(this, buffer, offsetClosed.getValue() + 18 * i, i));
     }
 
-    if (getSuperStruct() != null) {
-      HexNumber offsetTileCell = (HexNumber)getSuperStruct().getAttribute(WedResource.WED_OFFSET_DOOR_TILEMAP_LOOKUP);
+    if (getParent() != null) {
+      final HexNumber offsetTileCell = (HexNumber)getParent().getAttribute(WedResource.WED_OFFSET_DOOR_TILEMAP_LOOKUP);
       for (int i = 0; i < countTileCell.getValue(); i++) {
         addField(new RemovableDecNumber(buffer, offsetTileCell.getValue() +
                                                 2 * (indexTileCell.getValue() + i), 2,
@@ -168,4 +168,3 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
     return offset + 26;
   }
 }
-

--- a/src/org/infinity/resource/wed/Polygon.java
+++ b/src/org/infinity/resource/wed/Polygon.java
@@ -98,8 +98,7 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
   {
     ((DecNumber)getAttribute(WED_POLY_VERTEX_INDEX)).setValue(startIndex);
     int count = 0;
-    for (int i = 0; i < getFieldCount(); i++) {
-      StructEntry entry = getField(i);
+    for (final StructEntry entry : getList()) {
       if (entry instanceof Vertex) {
         entry.setOffset(offset);
         ((AbstractStruct)entry).realignStructOffsets();

--- a/src/org/infinity/resource/wed/Polygon.java
+++ b/src/org/infinity/resource/wed/Polygon.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.wed;
@@ -76,9 +76,9 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
     if (datatype instanceof Vertex) {
       int index = ((DecNumber)getAttribute(WED_POLY_VERTEX_INDEX)).getValue();
       index += ((DecNumber)getAttribute(WED_POLY_NUM_VERTICES)).getValue();
-      AbstractStruct superStruct = getSuperStruct();
-      while (superStruct.getSuperStruct() != null)
-        superStruct = superStruct.getSuperStruct();
+      AbstractStruct superStruct = getParent();
+      while (superStruct.getParent() != null)
+        superStruct = superStruct.getParent();
       int offset = ((HexNumber)superStruct.getAttribute(WedResource.WED_OFFSET_VERTICES)).getValue();
       datatype.setOffset(offset + 4 * index);
       ((AbstractStruct)datatype).realignStructOffsets();
@@ -125,4 +125,3 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
     return offset + 18;
   }
 }
-

--- a/src/org/infinity/resource/wed/Polygon.java
+++ b/src/org/infinity/resource/wed/Polygon.java
@@ -98,7 +98,7 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
   {
     ((DecNumber)getAttribute(WED_POLY_VERTEX_INDEX)).setValue(startIndex);
     int count = 0;
-    for (final StructEntry entry : getList()) {
+    for (final StructEntry entry : getFields()) {
       if (entry instanceof Vertex) {
         entry.setOffset(offset);
         ((AbstractStruct)entry).realignStructOffsets();

--- a/src/org/infinity/resource/wed/WedResource.java
+++ b/src/org/infinity/resource/wed/WedResource.java
@@ -172,8 +172,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     else if (datatype instanceof RemovableDecNumber && child instanceof Door) {
       Door childDoor = (Door)child;
       int childIndex = childDoor.getTilemapIndex().getValue();
-      for (int i = 0; i < getFieldCount(); i++) {
-        Object o = getField(i);
+      for (final StructEntry o : getList()) {
         if (o instanceof Door && o != childDoor) {
           DecNumber tilemapIndex = ((Door)o).getTilemapIndex();
           if (tilemapIndex.getValue() >= childIndex)
@@ -204,8 +203,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     else if (datatype instanceof RemovableDecNumber && child instanceof Door) {
       Door childDoor = (Door)child;
       int childIndex = childDoor.getTilemapIndex().getValue();
-      for (int i = 0; i < getFieldCount(); i++) {
-        Object o = getField(i);
+      for (final StructEntry o : getList()) {
         if (o instanceof Door && o != childDoor) {
           DecNumber tilemapIndex = ((Door)o).getTilemapIndex();
           if (tilemapIndex.getValue() > childIndex)
@@ -338,8 +336,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
       }
     }
 
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Overlay) {
         ((Overlay)o).updateOffsets(datatype.getOffset(), size);
       }
@@ -348,8 +345,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     // Assumes polygon offset is correct
     int offset = ((SectionOffset)getAttribute(WED_OFFSET_WALL_POLYGONS)).getValue();
     offset += ((SectionCount)getAttribute(WED_NUM_WALL_POLYGONS)).getValue() * 18;
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Door) {
         ((Door)o).updatePolygonsOffset(offset);
       }
@@ -361,8 +357,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     // Assumes vertices offset is correct
     int offset = ((HexNumber)getAttribute(WED_OFFSET_VERTICES)).getValue();
     int count = 0;
-    for (int i = 0; i < getFieldCount(); i++) {
-      Object o = getField(i);
+    for (final StructEntry o : getList()) {
       if (o instanceof Polygon) {
         Polygon polygon = (Polygon)o;
         int vertNum = polygon.updateVertices(offset, count);
@@ -371,8 +366,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
       }
       else if (o instanceof Door) {
         Door door = (Door)o;
-        for (int j = 0; j < door.getFieldCount(); j++) {
-          StructEntry q = door.getField(j);
+        for (final StructEntry q : door.getList()) {
           if (q instanceof Polygon) {
             Polygon polygon = (Polygon)q;
             int vertNum = polygon.updateVertices(offset, count);

--- a/src/org/infinity/resource/wed/WedResource.java
+++ b/src/org/infinity/resource/wed/WedResource.java
@@ -112,7 +112,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
   @Override
   public void write(OutputStream os) throws IOException
   {
-    super.writeFlatList(os);
+    super.writeFlatFields(os);
   }
 
 // --------------------- End Interface Writeable ---------------------
@@ -172,7 +172,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     else if (datatype instanceof RemovableDecNumber && child instanceof Door) {
       Door childDoor = (Door)child;
       int childIndex = childDoor.getTilemapIndex().getValue();
-      for (final StructEntry o : getList()) {
+      for (final StructEntry o : getFields()) {
         if (o instanceof Door && o != childDoor) {
           DecNumber tilemapIndex = ((Door)o).getTilemapIndex();
           if (tilemapIndex.getValue() >= childIndex)
@@ -203,7 +203,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     else if (datatype instanceof RemovableDecNumber && child instanceof Door) {
       Door childDoor = (Door)child;
       int childIndex = childDoor.getTilemapIndex().getValue();
-      for (final StructEntry o : getList()) {
+      for (final StructEntry o : getFields()) {
         if (o instanceof Door && o != childDoor) {
           DecNumber tilemapIndex = ((Door)o).getTilemapIndex();
           if (tilemapIndex.getValue() > childIndex)
@@ -311,9 +311,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     }
 
     int endoffset = offset;
-    List<StructEntry> flatList = getFlatList();
-    for (int i = 0; i < flatList.size(); i++) {
-      StructEntry entry = flatList.get(i);
+    for (final StructEntry entry : getFlatFields()) {
       if (entry.getOffset() + entry.getSize() > endoffset) {
         endoffset = entry.getOffset() + entry.getSize();
       }
@@ -336,7 +334,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
       }
     }
 
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Overlay) {
         ((Overlay)o).updateOffsets(datatype.getOffset(), size);
       }
@@ -345,7 +343,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     // Assumes polygon offset is correct
     int offset = ((SectionOffset)getAttribute(WED_OFFSET_WALL_POLYGONS)).getValue();
     offset += ((SectionCount)getAttribute(WED_NUM_WALL_POLYGONS)).getValue() * 18;
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Door) {
         ((Door)o).updatePolygonsOffset(offset);
       }
@@ -357,7 +355,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     // Assumes vertices offset is correct
     int offset = ((HexNumber)getAttribute(WED_OFFSET_VERTICES)).getValue();
     int count = 0;
-    for (final StructEntry o : getList()) {
+    for (final StructEntry o : getFields()) {
       if (o instanceof Polygon) {
         Polygon polygon = (Polygon)o;
         int vertNum = polygon.updateVertices(offset, count);
@@ -366,7 +364,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
       }
       else if (o instanceof Door) {
         Door door = (Door)o;
-        for (final StructEntry q : door.getList()) {
+        for (final StructEntry q : door.getFields()) {
           if (q instanceof Polygon) {
             Polygon polygon = (Polygon)q;
             int vertNum = polygon.updateVertices(offset, count);

--- a/src/org/infinity/resource/wmp/ViewerArea.java
+++ b/src/org/infinity/resource/wmp/ViewerArea.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.wmp;
@@ -47,7 +47,7 @@ final class ViewerArea extends JPanel implements ActionListener
     JPanel flagPanel = ViewerUtil.makeCheckPanel((Flag)areaEntry.getAttribute(AreaEntry.WMP_AREA_FLAGS), 1);
     JPanel infoPane = makeInfoPanel(areaEntry);
     JComponent icon = ViewerUtil.makeBamPanel(
-            (ResourceRef)areaEntry.getSuperStruct().getAttribute(MapEntry.WMP_MAP_ICONS),
+            (ResourceRef)areaEntry.getParent().getAttribute(MapEntry.WMP_MAP_ICONS),
             ((DecNumber)areaEntry.getAttribute(AreaEntry.WMP_AREA_ICON_INDEX)).getValue(),
             0);
     JPanel linkPanelN = ViewerUtil.makeListPanel("North links", areaEntry, AreaLinkNorth.class, AreaLink.WMP_LINK_TARGET_ENTRANCE);
@@ -99,4 +99,3 @@ final class ViewerArea extends JPanel implements ActionListener
 
 // --------------------- End Interface ActionListener ---------------------
 }
-

--- a/src/org/infinity/resource/wmp/ViewerMap.java
+++ b/src/org/infinity/resource/wmp/ViewerMap.java
@@ -645,7 +645,7 @@ public class ViewerMap extends JPanel
           WindowBlocker.blockWindow(wnd, false);
         }
         if (bRet) {
-          final ResourceEntry entry = ((AbstractStruct)getEntry().getParent()).getResourceEntry();
+          final ResourceEntry entry = getEntry().getParent().getResourceEntry();
           final String fileName = StreamUtils.replaceFileExtension(entry.getResourceName(), "PNG");
           ResourceFactory.exportResource(entry, StreamUtils.getByteBuffer(os.toByteArray()), fileName, wnd);
         } else {

--- a/src/org/infinity/resource/wmp/WmpResource.java
+++ b/src/org/infinity/resource/wmp/WmpResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.wmp;
@@ -114,7 +114,7 @@ public final class WmpResource extends AbstractStruct implements Resource, HasVi
   @Override
   public void write(OutputStream os) throws IOException
   {
-    super.writeFlatList(os);
+    super.writeFlatFields(os);
   }
 
 // --------------------- End Interface Writeable ---------------------
@@ -177,4 +177,3 @@ public final class WmpResource extends AbstractStruct implements Resource, HasVi
     }
   }
 }
-

--- a/src/org/infinity/search/AttributeSearcher.java
+++ b/src/org/infinity/search/AttributeSearcher.java
@@ -235,7 +235,7 @@ public final class AttributeSearcher extends AbstractSearcher implements Runnabl
       final Resource resource = ResourceFactory.getResource(entry);
       if (resource instanceof AbstractStruct) {
         final AbstractStruct struct = (AbstractStruct)resource;
-        for (StructEntry searchEntry : struct.getFlatList()) {
+        for (final StructEntry searchEntry : struct.getFlatFields()) {
           // skipping fields located in different parent structures
           if (structEntry.getParent().getClass() != searchEntry.getParent().getClass()) {
             continue;

--- a/src/org/infinity/search/AttributeSearcher.java
+++ b/src/org/infinity/search/AttributeSearcher.java
@@ -60,8 +60,8 @@ public final class AttributeSearcher extends AbstractSearcher implements Runnabl
   {
     super(SEARCH_ONE_TYPE_FORMAT, parent);
     this.structEntry = structEntry;
-    while (struct.getSuperStruct() != null)
-      struct = struct.getSuperStruct();
+    while (struct.getParent() != null)
+      struct = struct.getParent();
     files = ResourceFactory.getResources(struct.getResourceEntry().getExtension());
     inputFrame = new ChildFrame("Find: " + structEntry.getName(), true);
     inputFrame.setIconImage(Icons.getIcon(Icons.ICON_FIND_16).getImage());
@@ -264,10 +264,10 @@ public final class AttributeSearcher extends AbstractSearcher implements Runnabl
                 // creating a path of structures
                 final ArrayList<String> list = new ArrayList<>();
                 while (superStruct != null) {
-                  if (superStruct.getSuperStruct() != null) {
+                  if (superStruct.getParent() != null) {
                     list.add(0, superStruct.getName());
                   }
-                  superStruct = superStruct.getSuperStruct();
+                  superStruct = superStruct.getParent();
                 }
                 list.add(0, entry.getSearchString());
 

--- a/src/org/infinity/search/DialogItemRefSearcher.java
+++ b/src/org/infinity/search/DialogItemRefSearcher.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.search;
@@ -37,7 +37,7 @@ public class DialogItemRefSearcher implements Runnable {
 
   @Override
   public void run() {
-    List<StructEntry> searchItems = dlg.getList();
+    final List<StructEntry> searchItems = dlg.getFields();
     ProgressMonitor progress = new ProgressMonitor(parent, "Searching...", null, 0, searchItems.size());
     progress.setMillisToDecideToPopup(100);
     long startTime = System.currentTimeMillis();

--- a/src/org/infinity/search/DialogSearcher.java
+++ b/src/org/infinity/search/DialogSearcher.java
@@ -225,7 +225,7 @@ public final class DialogSearcher extends AbstractSearcher implements Runnable, 
   private Map<StructEntry, StructEntry> makeSearchMap(AbstractStruct struct)
   {
     final SortedMap<StructEntry, StructEntry> map = new TreeMap<>();
-    for (final StructEntry entry : struct.getList()) {
+    for (final StructEntry entry : struct.getFields()) {
       if (entry instanceof AbstractStruct)
         map.putAll(makeSearchMap((AbstractStruct)entry));
       else if (cbsearchcode.isSelected() && entry instanceof AbstractCode)

--- a/src/org/infinity/search/DialogSearcher.java
+++ b/src/org/infinity/search/DialogSearcher.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.search;
@@ -225,8 +225,7 @@ public final class DialogSearcher extends AbstractSearcher implements Runnable, 
   private Map<StructEntry, StructEntry> makeSearchMap(AbstractStruct struct)
   {
     final SortedMap<StructEntry, StructEntry> map = new TreeMap<>();
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      final StructEntry entry = struct.getField(i);
+    for (final StructEntry entry : struct.getList()) {
       if (entry instanceof AbstractStruct)
         map.putAll(makeSearchMap((AbstractStruct)entry));
       else if (cbsearchcode.isSelected() && entry instanceof AbstractCode)

--- a/src/org/infinity/search/ReferenceSearcher.java
+++ b/src/org/infinity/search/ReferenceSearcher.java
@@ -74,7 +74,7 @@ public final class ReferenceSearcher extends AbstractReferenceSearcher
   private void searchDialog(ResourceEntry entry, AbstractStruct dialog)
   {
     final String targetName = targetEntry.getResourceName();
-    for (final StructEntry o : dialog.getList()) {
+    for (final StructEntry o : dialog.getFields()) {
       if (o instanceof ResourceRef &&
           ((ResourceRef)o).getResourceName().equalsIgnoreCase(targetName)) {
         addHit(entry, entry.getSearchString(), o);
@@ -125,7 +125,7 @@ public final class ReferenceSearcher extends AbstractReferenceSearcher
 
   private void searchSavStruct(ResourceEntry entry, ResourceEntry saventry, AbstractStruct struct)
   {
-    for (final StructEntry o : struct.getList()) {
+    for (final StructEntry o : struct.getFields()) {
       if (o instanceof ResourceRef &&
           ((ResourceRef)o).getResourceName().equalsIgnoreCase(targetEntry.getResourceName()))
         addHit(entry, saventry.toString(), o);
@@ -171,7 +171,7 @@ public final class ReferenceSearcher extends AbstractReferenceSearcher
   private void searchStruct(ResourceEntry entry, AbstractStruct struct)
   {
     final String name = targetEntry.getResourceName();
-    for (final StructEntry o : struct.getList()) {
+    for (final StructEntry o : struct.getFields()) {
       if (o instanceof ResourceRef &&
           ((ResourceRef)o).getResourceName().equalsIgnoreCase(name)) {
         addHit(entry, entry.getSearchString(), o);

--- a/src/org/infinity/search/ReferenceSearcher.java
+++ b/src/org/infinity/search/ReferenceSearcher.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.search;
@@ -74,8 +74,7 @@ public final class ReferenceSearcher extends AbstractReferenceSearcher
   private void searchDialog(ResourceEntry entry, AbstractStruct dialog)
   {
     final String targetName = targetEntry.getResourceName();
-    for (int i = 0; i < dialog.getFieldCount(); i++) {
-      StructEntry o = dialog.getField(i);
+    for (final StructEntry o : dialog.getList()) {
       if (o instanceof ResourceRef &&
           ((ResourceRef)o).getResourceName().equalsIgnoreCase(targetName)) {
         addHit(entry, entry.getSearchString(), o);
@@ -126,8 +125,7 @@ public final class ReferenceSearcher extends AbstractReferenceSearcher
 
   private void searchSavStruct(ResourceEntry entry, ResourceEntry saventry, AbstractStruct struct)
   {
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      StructEntry o = struct.getField(i);
+    for (final StructEntry o : struct.getList()) {
       if (o instanceof ResourceRef &&
           ((ResourceRef)o).getResourceName().equalsIgnoreCase(targetEntry.getResourceName()))
         addHit(entry, saventry.toString(), o);
@@ -139,8 +137,7 @@ public final class ReferenceSearcher extends AbstractReferenceSearcher
   private void searchSave(ResourceEntry entry, SavResource savfile)
   {
     List<? extends ResourceEntry> entries = savfile.getFileHandler().getFileEntries();
-    for (int i = 0; i < entries.size(); i++) {
-      ResourceEntry saventry = entries.get(i);
+    for (final ResourceEntry saventry : entries) {
       Resource resource = ResourceFactory.getResource(saventry);
       if (resource instanceof AbstractStruct)
         searchSavStruct(entry, saventry, (AbstractStruct)resource);
@@ -174,8 +171,7 @@ public final class ReferenceSearcher extends AbstractReferenceSearcher
   private void searchStruct(ResourceEntry entry, AbstractStruct struct)
   {
     final String name = targetEntry.getResourceName();
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      StructEntry o = struct.getField(i);
+    for (final StructEntry o : struct.getList()) {
       if (o instanceof ResourceRef &&
           ((ResourceRef)o).getResourceName().equalsIgnoreCase(name)) {
         addHit(entry, entry.getSearchString(), o);

--- a/src/org/infinity/search/ScriptReferenceSearcher.java
+++ b/src/org/infinity/search/ScriptReferenceSearcher.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.search;
@@ -53,8 +53,7 @@ public final class ScriptReferenceSearcher extends AbstractReferenceSearcher
   private void searchStruct(ResourceEntry entry, AbstractStruct struct)
   {
     final String name = targetEntry.getResourceName();
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      final StructEntry o = struct.getField(i);
+    for (final StructEntry o : struct.getList()) {
       if (o instanceof ResourceRef &&
           ((ResourceRef)o).getResourceName().equalsIgnoreCase(name)) {
         if (struct instanceof CreResource) {

--- a/src/org/infinity/search/ScriptReferenceSearcher.java
+++ b/src/org/infinity/search/ScriptReferenceSearcher.java
@@ -53,7 +53,7 @@ public final class ScriptReferenceSearcher extends AbstractReferenceSearcher
   private void searchStruct(ResourceEntry entry, AbstractStruct struct)
   {
     final String name = targetEntry.getResourceName();
-    for (final StructEntry o : struct.getList()) {
+    for (final StructEntry o : struct.getFields()) {
       if (o instanceof ResourceRef &&
           ((ResourceRef)o).getResourceName().equalsIgnoreCase(name)) {
         if (struct instanceof CreResource) {

--- a/src/org/infinity/search/SearchOptions.java
+++ b/src/org/infinity/search/SearchOptions.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.search;
@@ -620,7 +620,7 @@ public class SearchOptions
         Object value = ((Pair<?>)match).getSecond();
         if (!fieldName.isEmpty() && value != null) {
           boolean bRet = false;
-          List<StructEntry> structList = struct.getFlatList();
+          final List<StructEntry> structList = struct.getFlatFields();
           if (structList != null && !structList.isEmpty()) {
             for (int i = 0; i < structList.size(); i++) {
               StructEntry entry = structList.get(i);

--- a/src/org/infinity/search/SongReferenceSearcher.java
+++ b/src/org/infinity/search/SongReferenceSearcher.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.search;
@@ -114,7 +114,7 @@ public class SongReferenceSearcher extends AbstractReferenceSearcher
   {
     if (pattern == null) { return; }
 
-    for (final StructEntry e : dlg.getList()) {
+    for (final StructEntry e : dlg.getFields()) {
       if (e instanceof AbstractCode) {
         String text = ((AbstractCode)e).getText();
         searchText(entry, e, text);
@@ -140,7 +140,7 @@ public class SongReferenceSearcher extends AbstractReferenceSearcher
 
   private void searchStruct(ResourceEntry entry, AbstractStruct struct)
   {
-    for (final StructEntry e : struct.getFlatList()) {
+    for (final StructEntry e : struct.getFlatFields()) {
       if (e instanceof Song2daBitmap) {
         if (songId == ((Song2daBitmap)e).getLongValue()) {
           addHit(entry, String.format("%s (%d)", targetEntry.getResourceName(), songId), e);

--- a/src/org/infinity/search/StringReferenceSearcher.java
+++ b/src/org/infinity/search/StringReferenceSearcher.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.search;
@@ -74,8 +74,7 @@ public final class StringReferenceSearcher extends AbstractReferenceSearcher
 
   private void searchDialog(ResourceEntry entry, AbstractStruct dialog)
   {
-    for (int i = 0; i < dialog.getFieldCount(); i++) {
-      final StructEntry o = dialog.getField(i);
+    for (final StructEntry o : dialog.getList()) {
       if (o instanceof StringRef && ((StringRef)o).getValue() == searchvalue) {
         addHit(entry, entry.getSearchString(), o);
       } else if (o instanceof AbstractCode) {
@@ -107,8 +106,7 @@ public final class StringReferenceSearcher extends AbstractReferenceSearcher
 
   private void searchSavStruct(ResourceEntry entry, ResourceEntry saventry, AbstractStruct struct)
   {
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      StructEntry o = struct.getField(i);
+    for (final StructEntry o : struct.getList()) {
       if (o instanceof StringRef && ((StringRef)o).getValue() == searchvalue)
         addHit(entry, saventry.toString(), o);
       else if (o instanceof AbstractStruct)
@@ -151,8 +149,7 @@ public final class StringReferenceSearcher extends AbstractReferenceSearcher
    */
   private void searchStruct(ResourceEntry entry, AbstractStruct struct)
   {
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      StructEntry o = struct.getField(i);
+    for (final StructEntry o : struct.getList()) {
       if (o instanceof StringRef && ((StringRef)o).getValue() == searchvalue)
         addHit(entry, entry.getSearchString(), o);
       else if (o instanceof AbstractStruct)
@@ -171,4 +168,3 @@ public final class StringReferenceSearcher extends AbstractReferenceSearcher
     }
   }
 }
-

--- a/src/org/infinity/search/StringReferenceSearcher.java
+++ b/src/org/infinity/search/StringReferenceSearcher.java
@@ -74,7 +74,7 @@ public final class StringReferenceSearcher extends AbstractReferenceSearcher
 
   private void searchDialog(ResourceEntry entry, AbstractStruct dialog)
   {
-    for (final StructEntry o : dialog.getList()) {
+    for (final StructEntry o : dialog.getFields()) {
       if (o instanceof StringRef && ((StringRef)o).getValue() == searchvalue) {
         addHit(entry, entry.getSearchString(), o);
       } else if (o instanceof AbstractCode) {
@@ -106,7 +106,7 @@ public final class StringReferenceSearcher extends AbstractReferenceSearcher
 
   private void searchSavStruct(ResourceEntry entry, ResourceEntry saventry, AbstractStruct struct)
   {
-    for (final StructEntry o : struct.getList()) {
+    for (final StructEntry o : struct.getFields()) {
       if (o instanceof StringRef && ((StringRef)o).getValue() == searchvalue)
         addHit(entry, saventry.toString(), o);
       else if (o instanceof AbstractStruct)
@@ -149,7 +149,7 @@ public final class StringReferenceSearcher extends AbstractReferenceSearcher
    */
   private void searchStruct(ResourceEntry entry, AbstractStruct struct)
   {
-    for (final StructEntry o : struct.getList()) {
+    for (final StructEntry o : struct.getFields()) {
       if (o instanceof StringRef && ((StringRef)o).getValue() == searchvalue)
         addHit(entry, entry.getSearchString(), o);
       else if (o instanceof AbstractStruct)

--- a/src/org/infinity/search/WavReferenceSearcher.java
+++ b/src/org/infinity/search/WavReferenceSearcher.java
@@ -36,8 +36,7 @@ public final class WavReferenceSearcher extends AbstractReferenceSearcher
 
   private void searchStruct(ResourceEntry entry, AbstractStruct struct)
   {
-    for (int i = 0; i < struct.getFieldCount(); i++) {
-      StructEntry o = struct.getField(i);
+    for (final StructEntry o : struct.getList()) {
       if (o instanceof ResourceRef &&
           ((ResourceRef)o).getResourceName().equalsIgnoreCase(targetEntry.getResourceName())) {
         addHit(entry, entry.getSearchString(), o);

--- a/src/org/infinity/search/WavReferenceSearcher.java
+++ b/src/org/infinity/search/WavReferenceSearcher.java
@@ -36,7 +36,7 @@ public final class WavReferenceSearcher extends AbstractReferenceSearcher
 
   private void searchStruct(ResourceEntry entry, AbstractStruct struct)
   {
-    for (final StructEntry o : struct.getList()) {
+    for (final StructEntry o : struct.getFields()) {
       if (o instanceof ResourceRef &&
           ((ResourceRef)o).getResourceName().equalsIgnoreCase(targetEntry.getResourceName())) {
         addHit(entry, entry.getSearchString(), o);

--- a/src/org/infinity/util/MassExporter.java
+++ b/src/org/infinity/util/MassExporter.java
@@ -563,7 +563,7 @@ public final class MassExporter extends ChildFrame implements ActionListener, Li
       return;
     }
     CreResource crefile = new CreResource(entry);
-    final List<StructEntry> flatList = crefile.getFlatList();
+    final List<StructEntry> flatList = crefile.getFlatFields();
     while (!flatList.get(0).toString().equals("CRE ")) {
       flatList.remove(0);
     }

--- a/src/org/infinity/util/StringTable.java
+++ b/src/org/infinity/util/StringTable.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.util;
@@ -1654,7 +1654,7 @@ public class StringTable
 
     public void clearList()
     {
-      if (getFieldCount() > 0) {
+      if (!getList().isEmpty()) {
         clearFields();
       }
     }
@@ -1662,7 +1662,7 @@ public class StringTable
     public void fillList(int index)
     {
       try {
-        if (getFieldCount() == 0) {
+        if (getList().isEmpty()) {
           ByteBuffer buffer = StreamUtils.getByteBuffer(26);
           buffer.position(0);
           buffer.putShort(flags);

--- a/src/org/infinity/util/StringTable.java
+++ b/src/org/infinity/util/StringTable.java
@@ -1654,7 +1654,7 @@ public class StringTable
 
     public void clearList()
     {
-      if (!getList().isEmpty()) {
+      if (!getFields().isEmpty()) {
         clearFields();
       }
     }
@@ -1662,7 +1662,7 @@ public class StringTable
     public void fillList(int index)
     {
       try {
-        if (getList().isEmpty()) {
+        if (getFields().isEmpty()) {
           ByteBuffer buffer = StreamUtils.getByteBuffer(26);
           buffer.position(0);
           buffer.putShort(flags);

--- a/src/org/infinity/util/StructClipboard.java
+++ b/src/org/infinity/util/StructClipboard.java
@@ -106,7 +106,7 @@ public final class StructClipboard
   {
     copy(struct, firstIndex, lastIndex, false);
     for (int i = firstIndex; i <= lastIndex; i++) {
-      struct.removeDatatype((AddRemovable)struct.getList().get(firstIndex), true);
+      struct.removeDatatype((AddRemovable)struct.getFields().get(firstIndex), true);
     }
     fireStateChanged();
   }
@@ -194,7 +194,7 @@ public final class StructClipboard
 
   public int pasteValue(AbstractStruct struct, int index)
   {
-    final List<StructEntry> fields = struct.getList();
+    final List<StructEntry> fields = struct.getFields();
     for (int i = 0; i < contents.size(); i++) {
       final StructEntry oldEntry = fields.get(index + i);
       final StructEntry newEntry = contents.get(i);
@@ -207,7 +207,7 @@ public final class StructClipboard
         final StructEntry oldEntry = fields.get(index + i);
         final StructEntry newEntry = contents.get(i).clone();
         newEntry.copyNameAndOffset(oldEntry);
-        struct.setListEntry(index + i, newEntry);
+        struct.setField(index + i, newEntry);
       }
     } catch (CloneNotSupportedException e) {
       e.printStackTrace();
@@ -227,7 +227,7 @@ public final class StructClipboard
     this.contentsClass = struct.getClass();
     this.hasValues = hasValues;
     try {
-      for (final StructEntry entry : struct.getList().subList(firstIndex, lastIndex + 1)) {
+      for (final StructEntry entry : struct.getFields().subList(firstIndex, lastIndex + 1)) {
         contents.add(entry.clone());
       }
     } catch (CloneNotSupportedException e) {

--- a/src/org/infinity/util/StructClipboard.java
+++ b/src/org/infinity/util/StructClipboard.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.util;
@@ -28,8 +28,8 @@ public final class StructClipboard
   public static final int CLIPBOARD_VALUES = 1;
   public static final int CLIPBOARD_ENTRIES = 2;
   private static StructClipboard clip;
-  private final List<ChangeListener> listeners = new ArrayList<ChangeListener>();
-  private final List<StructEntry> contents = new ArrayList<StructEntry>();
+  private final List<ChangeListener> listeners = new ArrayList<>();
+  private final List<StructEntry> contents = new ArrayList<>();
   private Class<? extends StructEntry> contentsClass;
   private boolean hasValues = true;
 
@@ -63,8 +63,7 @@ public final class StructClipboard
   public String toString()
   {
     final StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < contents.size(); i++) {
-      StructEntry datatype = contents.get(i);
+    for (final StructEntry datatype : contents) {
       sb.append(datatype.getName()).append(": ").append(datatype.toString()).append('\n');
     }
     return sb.toString();
@@ -93,51 +92,22 @@ public final class StructClipboard
 
   public void copy(AbstractStruct struct, int firstIndex, int lastIndex)
   {
-    contents.clear();
-    contentsClass = struct.getClass();
-    try {
-      for (int i = firstIndex; i <= lastIndex; i++) {
-        StructEntry entry = struct.getField(i);
-        contents.add((StructEntry)entry.clone());
-      }
-    } catch (CloneNotSupportedException e) {
-      e.printStackTrace();
-    }
-    hasValues = false;
+    copy(struct, firstIndex, lastIndex, false);
     fireStateChanged();
   }
 
   public void copyValue(AbstractStruct struct, int firstIndex, int lastIndex)
   {
-    contents.clear();
-    hasValues = true;
-    contentsClass = struct.getClass();
-    try {
-      for (int i = firstIndex; i <= lastIndex; i++) {
-        StructEntry entry = struct.getField(i);
-        contents.add((StructEntry)entry.clone());
-      }
-    } catch (CloneNotSupportedException e) {
-      e.printStackTrace();
-    }
+    copy(struct, firstIndex, lastIndex, true);
     fireStateChanged();
   }
 
   public void cut(AbstractStruct struct, int firstIndex, int lastIndex)
   {
-    contents.clear();
-    contentsClass = struct.getClass();
-    try {
-      for (int i = firstIndex; i <= lastIndex; i++) {
-        StructEntry entry = struct.getField(i);
-        contents.add((StructEntry)entry.clone());
-      }
-    } catch (CloneNotSupportedException e) {
-      e.printStackTrace();
+    copy(struct, firstIndex, lastIndex, false);
+    for (int i = firstIndex; i <= lastIndex; i++) {
+      struct.removeDatatype((AddRemovable)struct.getList().get(firstIndex), true);
     }
-    hasValues = false;
-    for (int i = firstIndex; i <= lastIndex; i++)
-      struct.removeDatatype((AddRemovable)struct.getField(firstIndex), true);
     fireStateChanged();
   }
 
@@ -188,8 +158,9 @@ public final class StructClipboard
   {
     int lastIndex = 0;
     try {
-      for (int i = 0; i < contents.size(); i++) {
-        AddRemovable pasteEntry = (AddRemovable)contents.get(i);
+      int i = 0;
+      for (final StructEntry e : contents) {
+        AddRemovable pasteEntry = (AddRemovable)e;
 
         // Convert between effect type 1 and 2 if needed
         if (canConvertToEffectV1(targetStruct, pasteEntry)) {
@@ -213,6 +184,7 @@ public final class StructClipboard
         else {
           lastIndex = targetStruct.addDatatype(pasteEntry, index);
         }
+        ++i;
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -222,17 +194,18 @@ public final class StructClipboard
 
   public int pasteValue(AbstractStruct struct, int index)
   {
+    final List<StructEntry> fields = struct.getList();
     for (int i = 0; i < contents.size(); i++) {
-      StructEntry oldEntry = struct.getField(index + i);
-      StructEntry newEntry = contents.get(i);
+      final StructEntry oldEntry = fields.get(index + i);
+      final StructEntry newEntry = contents.get(i);
       if (oldEntry.getClass() != newEntry.getClass() ||
           oldEntry.getSize() != newEntry.getSize())
         return 0;
     }
     try {
       for (int i = 0; i < contents.size(); i++) {
-        StructEntry oldEntry = struct.getField(index + i);
-        StructEntry newEntry = (StructEntry)contents.get(i).clone();
+        final StructEntry oldEntry = fields.get(index + i);
+        final StructEntry newEntry = contents.get(i).clone();
         newEntry.copyNameAndOffset(oldEntry);
         struct.setListEntry(index + i, newEntry);
       }
@@ -248,7 +221,21 @@ public final class StructClipboard
     listeners.remove(listener);
   }
 
-  // Returns whether "entry" is EFF V2 and can be converted to EFF V1
+  private void copy(AbstractStruct struct, int firstIndex, int lastIndex, boolean hasValues)
+  {
+    this.contents.clear();
+    this.contentsClass = struct.getClass();
+    this.hasValues = hasValues;
+    try {
+      for (final StructEntry entry : struct.getList().subList(firstIndex, lastIndex + 1)) {
+        contents.add(entry.clone());
+      }
+    } catch (CloneNotSupportedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  /** Returns whether "entry" is EFF V2 and can be converted to EFF V1. */
   private boolean canConvertToEffectV1(AbstractStruct target, AddRemovable entry)
   {
     return (entry instanceof Effect2) &&
@@ -260,7 +247,7 @@ public final class StructClipboard
               ((IsNumeric)target.getAttribute(CreResource.CRE_EFFECT_VERSION)).getValue() == 0));
   }
 
-  // Returns whether "entry" is EFF V1 and can be converted to EFF V2
+  /** Returns whether "entry" is EFF V1 and can be converted to EFF V2. */
   private boolean canConvertToEffectV2(AbstractStruct target, AddRemovable entry)
   {
     return (entry instanceof Effect) &&
@@ -276,4 +263,3 @@ public final class StructClipboard
       listeners.get(i).stateChanged(event);
   }
 }
-


### PR DESCRIPTION
Mostly switch from `getFieldCount + getField` to `getFields` (former `getList`) method