### PR TITLE
Viewer for special PS:T resource "quests.ini"

### DIFF
--- a/src/org/infinity/datatype/Bitmap.java
+++ b/src/org/infinity/datatype/Bitmap.java
@@ -10,6 +10,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeEvent;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -53,8 +54,7 @@ public class Bitmap extends Datatype implements Editable, IsNumeric
     read(buffer, offset);
   }
 
-// --------------------- Begin Interface Editable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Editable">
   @Override
   public JComponent edit(final ActionListener container)
   {
@@ -122,22 +122,17 @@ public class Bitmap extends Datatype implements Editable, IsNumeric
 
     return true;
   }
+  //</editor-fold>
 
-// --------------------- End Interface Editable ---------------------
-
-
-// --------------------- Begin Interface Writeable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Writeable">
   @Override
   public void write(OutputStream os) throws IOException
   {
     writeInt(os, value);
   }
+  //</editor-fold>
 
-// --------------------- End Interface Writeable ---------------------
-
-//--------------------- Begin Interface Readable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset)
   {
@@ -158,11 +153,9 @@ public class Bitmap extends Datatype implements Editable, IsNumeric
 
     return offset + getSize();
   }
+  //</editor-fold>
 
-//--------------------- End Interface Readable ---------------------
-
-//--------------------- Begin Interface IsNumeric ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="IsNumeric">
   @Override
   public long getLongValue()
   {
@@ -174,8 +167,7 @@ public class Bitmap extends Datatype implements Editable, IsNumeric
   {
     return value;
   }
-
-//--------------------- End Interface IsNumeric ---------------------
+  //</editor-fold>
 
   @Override
   public String toString()

--- a/src/org/infinity/gui/StructViewer.java
+++ b/src/org/infinity/gui/StructViewer.java
@@ -28,7 +28,6 @@ import java.awt.print.Printable;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 import java.nio.ByteBuffer;
-import java.util.Collection;
 import java.util.HashMap;
 
 import javax.swing.BorderFactory;
@@ -210,11 +209,6 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
   public StructViewer(AbstractStruct struct)
   {
-    this(struct, null);
-  }
-
-  public StructViewer(AbstractStruct struct, Collection<Component> extraComponents)
-  {
     this.struct = struct;
     struct.addTableModelListener(this);
     table.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
@@ -373,11 +367,6 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
     if (struct instanceof Resource && !struct.getFields().isEmpty() && struct.getParent() == null) {
       ((JButton)buttonPanel.addControl(ButtonPanel.Control.EXPORT_BUTTON)).addActionListener(this);
       ((JButton)buttonPanel.addControl(ButtonPanel.Control.SAVE)).addActionListener(this);
-    }
-    if (extraComponents != null) {
-      for (final Component c: extraComponents) {
-        buttonPanel.add(c);
-      }
     }
 
     JScrollPane scrollTable = new JScrollPane(table);

--- a/src/org/infinity/gui/ViewerUtil.java
+++ b/src/org/infinity/gui/ViewerUtil.java
@@ -225,6 +225,17 @@ public final class ViewerUtil
     return new JLabel("No " + imageRef.getName().toLowerCase(Locale.ENGLISH), JLabel.CENTER);
   }
 
+  /**
+   * Creates panel with the name, list control and button for edit selected list
+   * element.
+   *
+   * @param title Name of the panel
+   * @param struct Structure, which attributes must be shown in the returned editor
+   * @param listClass List will contain all attributes of {@code struct} with this class
+   * @param attrName Name of attribute in the {@code listClass}, used to show in the list
+   *
+   * @return Editor for show list of the specified attrubutes
+   */
   public static JPanel makeListPanel(String title, AbstractStruct struct,
                                      Class<? extends StructEntry> listClass, String attrName)
   {

--- a/src/org/infinity/resource/AbstractStruct.java
+++ b/src/org/infinity/resource/AbstractStruct.java
@@ -4,7 +4,6 @@
 
 package org.infinity.resource;
 
-import java.awt.Component;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -12,7 +11,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -74,7 +72,6 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   /** Offset of the last byte in serialized format of this struct. */
   private int endoffset;
   private int extraoffset;
-  private Collection<Component> viewerComponents;
   /**
    * If any {@link PropertyChangeListener}s have been registered,
    * the {@code changeSupport} field describes them.
@@ -375,7 +372,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   public JComponent makeViewer(ViewableContainer container)
   {
     if (viewer == null) {
-      viewer = new StructViewer(this, viewerComponents);
+      viewer = new StructViewer(this);
       viewerInitialized(viewer);
     }
     return viewer;
@@ -968,12 +965,6 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
       sb.append(e.getName()).append(": ").append(e).append('\n');
     }
     return sb.toString();
-  }
-
-  public void setExtraComponents(Collection<Component> list)
-  {
-    // List of components to be added to the bottom panel of the StructView component
-    viewerComponents = list;
   }
 
   /** Returns the SectionOffset entry linked to the specified StructEntry object if available. */

--- a/src/org/infinity/resource/AbstractVariable.java
+++ b/src/org/infinity/resource/AbstractVariable.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource;
@@ -9,6 +9,9 @@ import java.nio.ByteBuffer;
 import org.infinity.datatype.Bitmap;
 import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.FloatNumber;
+import org.infinity.datatype.IsNumeric;
+import org.infinity.datatype.IsTextual;
+import org.infinity.datatype.StringRef;
 import org.infinity.datatype.TextString;
 import org.infinity.util.io.StreamUtils;
 
@@ -18,14 +21,57 @@ public class AbstractVariable extends AbstractStruct implements AddRemovable
   public static final String VAR              = "Variable";
   public static final String VAR_NAME         = "Name";
   public static final String VAR_TYPE         = "Type";
+  /** Attribute name for field with type {@link DecNumber}, representing reference value of this variable. */
   public static final String VAR_REFERENCE    = "Reference value (unused)";
   public static final String VAR_DWORD        = "Dword value (unused)";
+  /** Attribute name for field with type {@link DecNumber}, representing integer value of this variable. */
   public static final String VAR_INT          = "Integer value";
   public static final String VAR_DOUBLE       = "Double value (unused)";
   public static final String VAR_SCRIPT_NAME  = "Script name (unused)";
 
   public static final String s_type[] = {"Integer", "Float", "Script name", "Resource reference",
                                          "String reference", "Double word"};
+
+  /** Type of the variable. */
+  public enum Type
+  {
+    /** {@link #getValue} return value as {@link Integer}. */
+    Integer,
+    /** {@link #getValue} return value as {@link Double}. */
+    Double,
+    /** {@link #getValue} return value as {@link String}. */
+    ScriptName,
+    /** {@link #getValue} return value as {@link Integer}. */
+    ResRef,
+    /** {@link #getValue} return value as {@link StringRef} with name of variable name. */
+    StrRef,
+    /** {@link #getValue} return value as {@link Long}. */
+    Dword;
+
+    /**
+     * Returns value of specified variable according to the type.
+     *
+     * @param var Variable which value need to extract
+     *
+     * @return Value. See enum elements documentation for the returning type
+     */
+    public Object getValue(AbstractVariable var)
+    {
+      switch (this) {
+        case Integer:    return ((IsNumeric)var.getAttribute(VAR_INT, false)).getValue();
+        case Double:     return ((FloatNumber)var.getAttribute(VAR_DOUBLE, false)).getValue();
+        case ScriptName: return ((IsTextual)var.getAttribute(VAR_SCRIPT_NAME, false)).getText();
+        case ResRef:     return ((IsNumeric)var.getAttribute(VAR_REFERENCE, false)).getValue();
+        case StrRef: {
+          final IsTextual name  = (IsTextual)var.getAttribute(VAR_NAME, false);
+          final IsNumeric value = (IsNumeric)var.getAttribute(VAR_REFERENCE, false);
+          return new StringRef(name.getText(), value.getValue());
+        }
+        case Dword:      return ((IsNumeric)var.getAttribute(VAR_DWORD, false)).getLongValue();
+      }
+      throw new InternalError("Unknown enum variant: " + this);
+    }
+  }
 
   protected AbstractVariable() throws Exception
   {
@@ -44,15 +90,13 @@ public class AbstractVariable extends AbstractStruct implements AddRemovable
     super(superStruct, name, buffer, offset);
   }
 
-//--------------------- Begin Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AddRemovable">
   @Override
   public boolean canRemove()
   {
     return true;
   }
-
-//--------------------- End Interface AddRemovable ---------------------
+  //</editor-fold>
 
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
@@ -65,5 +109,34 @@ public class AbstractVariable extends AbstractStruct implements AddRemovable
     addField(new FloatNumber(buffer, offset + 44, 8, VAR_DOUBLE));
     addField(new TextString(buffer, offset + 52, 32, VAR_SCRIPT_NAME));
     return offset + 84;
+  }
+  /**
+   * Returns type of this variable. Currently for all games it is {@link Type#Integer}.
+   *
+   * @return Type of variable
+   */
+  public Type getType()
+  {
+    final Bitmap type = (Bitmap)getAttribute(VAR_TYPE, false);
+    return Type.values()[type.getValue()];
+  }
+  /**
+   * Returns value of this variable. Currently for all games it is {@link Integer}.
+   *
+   * @return Value of variable according to it
+   */
+  public Object getValue() { return getType().getValue(this); }
+  /**
+   * Returns value of the specified type of this variable. If variable have different
+   * type, {@code null} is returned.
+   *
+   * @param type Type of value to get
+   * @return Variable value or {@code null}. See documentation for {@link Type}
+   *         enum values for the concrete returning type
+   */
+  public Object getValue(Type type)
+  {
+    final Bitmap t = (Bitmap)getAttribute(VAR_TYPE, false);
+    return type.ordinal() == t.getValue() ? type.getValue(this) : null;
   }
 }

--- a/src/org/infinity/resource/ResourceFactory.java
+++ b/src/org/infinity/resource/ResourceFactory.java
@@ -75,6 +75,7 @@ import org.infinity.resource.spl.SplResource;
 import org.infinity.resource.src.SrcResource;
 import org.infinity.resource.sto.StoResource;
 import org.infinity.resource.text.PlainTextResource;
+import org.infinity.resource.text.QuestsResource;
 import org.infinity.resource.to.TohResource;
 import org.infinity.resource.to.TotResource;
 import org.infinity.resource.var.VarResource;
@@ -165,7 +166,7 @@ public final class ResourceFactory implements FileWatchListener
         res = new MusResource(entry);
       } else if (ext.equalsIgnoreCase("IDS") || ext.equalsIgnoreCase("2DA") ||
                  ext.equalsIgnoreCase("BIO") || ext.equalsIgnoreCase("RES") ||
-                 ext.equalsIgnoreCase("INI") || ext.equalsIgnoreCase("TXT") ||
+                 ext.equalsIgnoreCase("TXT") ||
                  ext.equalsIgnoreCase("LOG") ||// WeiDU log files
                  (ext.equalsIgnoreCase("SRC") && Profile.getEngine() == Profile.Engine.IWD2) ||
                  (Profile.isEnhancedEdition() && (ext.equalsIgnoreCase("SQL") ||
@@ -174,6 +175,12 @@ public final class ResourceFactory implements FileWatchListener
                                                   ext.equalsIgnoreCase("MENU") ||
                                                   ext.equalsIgnoreCase("GLSL")))) {
         res = new PlainTextResource(entry);
+      } else if (ext.equalsIgnoreCase("INI")) {
+        final boolean isPST = Profile.getEngine() == Profile.Engine.PST;
+
+        res = isPST && QuestsResource.RESOURCE_NAME.equalsIgnoreCase(entry.getResourceName())
+            ? new QuestsResource(entry)
+            : new PlainTextResource(entry);
       } else if (ext.equalsIgnoreCase("MVE")) {
         res = new MveResource(entry);
       } else if (ext.equalsIgnoreCase("WBM")) {
@@ -1338,7 +1345,7 @@ public final class ResourceFactory implements FileWatchListener
       case PST:
         addFileResource(FileManager.query(roots, "autonote.ini"));
         addFileResource(FileManager.query(roots, "beast.ini"));// Bestiary
-        addFileResource(FileManager.query(roots, "quests.ini"));
+        addFileResource(FileManager.query(roots, QuestsResource.RESOURCE_NAME));
         addFileResource(FileManager.query(roots, "VAR.VAR"));
         break;
       default:

--- a/src/org/infinity/resource/text/PlainTextResource.java
+++ b/src/org/infinity/resource/text/PlainTextResource.java
@@ -50,8 +50,8 @@ import org.infinity.util.StaticSimpleXorDecryptor;
 import org.infinity.util.Misc;
 import org.infinity.util.io.StreamUtils;
 
-public final class PlainTextResource implements TextResource, Writeable, ActionListener, ItemListener,
-                                                DocumentListener, Closeable
+public class PlainTextResource implements TextResource, Writeable, ActionListener, ItemListener,
+                                          DocumentListener, Closeable
 {
   private final ResourceEntry entry;
   private final String text;

--- a/src/org/infinity/resource/text/PlainTextResource.java
+++ b/src/org/infinity/resource/text/PlainTextResource.java
@@ -59,7 +59,8 @@ public class PlainTextResource implements TextResource, Writeable, ActionListene
 
   private JMenuItem ifindall, ifindthis;
   private JPanel panel;
-  private InfinityTextArea editor;
+  /** Text editor for editing resource. Created after calling {@link #makeViewer}. */
+  protected InfinityTextArea editor;
   private boolean resourceChanged;
   private int highlightedLine = -1;
 

--- a/src/org/infinity/resource/text/PlainTextResource.java
+++ b/src/org/infinity/resource/text/PlainTextResource.java
@@ -54,7 +54,7 @@ public class PlainTextResource implements TextResource, Writeable, ActionListene
                                           DocumentListener, Closeable
 {
   private final ResourceEntry entry;
-  private final String text;
+  protected final String text;
   private final ButtonPanel buttonPanel = new ButtonPanel();
 
   private JMenuItem ifindall, ifindthis;

--- a/src/org/infinity/resource/text/PlainTextResource.java
+++ b/src/org/infinity/resource/text/PlainTextResource.java
@@ -61,28 +61,22 @@ public final class PlainTextResource implements TextResource, Writeable, ActionL
   private JPanel panel;
   private InfinityTextArea editor;
   private boolean resourceChanged;
-  private int highlightedLine;
+  private int highlightedLine = -1;
 
   public PlainTextResource(ResourceEntry entry) throws Exception
-  {
-    this(entry, -1);
-  }
-
-  public PlainTextResource(ResourceEntry entry, int highlightedLine) throws Exception
   {
     this.entry = entry;
     ByteBuffer buffer = entry.getResourceBuffer();
     if (buffer.limit() > 1 && buffer.getShort(0) == -1) {
       buffer = StaticSimpleXorDecryptor.decrypt(buffer, 2);
     }
-    Charset cs = null;
+    final Charset cs;
     if (BrowserMenuBar.getInstance() != null) {
       cs = Charset.forName(BrowserMenuBar.getInstance().getSelectedCharset());
     } else {
       cs = Misc.CHARSET_DEFAULT;
     }
     text = StreamUtils.readString(buffer, buffer.limit(), cs);
-    this.highlightedLine = highlightedLine;
   }
 
 // --------------------- Begin Interface ActionListener ---------------------

--- a/src/org/infinity/resource/text/QuestsPanel.java
+++ b/src/org/infinity/resource/text/QuestsPanel.java
@@ -19,6 +19,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.border.TitledBorder;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.AbstractTableModel;
@@ -139,9 +141,7 @@ final class QuestsPanel extends JPanel implements ListSelectionListener
   public QuestsPanel(List<Quest> quests)
   {
     super(new BorderLayout());
-    this.quests = new JTable(new QuestsModel(quests));
-    final int size = this.quests.getFontMetrics(this.quests.getFont()).charWidth('w') * 4;
-    this.quests.getColumnModel().getColumn(0).setMaxWidth(size);
+    this.quests = new JTable();
     this.quests.getSelectionModel().addListSelectionListener(this);
 
     final JPanel questInfo = new JPanel();
@@ -154,8 +154,10 @@ final class QuestsPanel extends JPanel implements ListSelectionListener
     panel.add(questInfo, BorderLayout.CENTER);
 
     final JScrollPane scroll = new JScrollPane(this.quests);
-    scroll.setBorder(BorderFactory.createTitledBorder(String.format("Quests (%d)", quests.size())));
+    scroll.setBorder(BorderFactory.createTitledBorder(""));
     add(new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, scroll, panel), BorderLayout.CENTER);
+
+    setQuests(quests);
   }
 
   //<editor-fold defaultstate="collapsed" desc="ListSelectionListener">
@@ -186,6 +188,19 @@ final class QuestsPanel extends JPanel implements ListSelectionListener
     }
   }
   //</editor-fold>
+
+  public void setQuests(List<Quest> quests)
+  {
+    this.quests.setModel(new QuestsModel(quests));
+    final int size = this.quests.getFontMetrics(this.quests.getFont()).charWidth('w') * 4;
+    this.quests.getColumnModel().getColumn(0).setMaxWidth(size);
+    // Direct parent of quests - JViewport
+    final JScrollPane scroll = (JScrollPane)this.quests.getParent().getParent();
+    final TitledBorder border = (TitledBorder)scroll.getBorder();
+    border.setTitle(String.format("Quests (%d)", quests.size()));
+    // To repaint TitledBorder. Swing have a bug and do not doing this automatically
+    scroll.repaint();
+  }
 
   private JPanel createPanel(InfinityTextArea area, JTable checks, String title)
   {

--- a/src/org/infinity/resource/text/QuestsPanel.java
+++ b/src/org/infinity/resource/text/QuestsPanel.java
@@ -1,0 +1,240 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.resource.text;
+
+import java.awt.BorderLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.Collections;
+import java.util.List;
+
+import javax.swing.AbstractListModel;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTable;
+import javax.swing.border.TitledBorder;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.table.AbstractTableModel;
+
+import org.infinity.datatype.StringRef;
+import org.infinity.gui.BrowserMenuBar;
+import org.infinity.gui.InfinityScrollPane;
+import org.infinity.gui.InfinityTextArea;
+import org.infinity.resource.text.QuestsResource.Check;
+import org.infinity.resource.text.QuestsResource.Quest;
+import org.infinity.util.StringTable;
+
+/**
+ * <code><pre>
+ * .-------. [Quest title                   ]
+ * |       |:.--------------..--------------.
+ * | quests|:| descAssigned ||descCompleted |
+ * |       |:'--------------''--------------'
+ * | table |:.--------------..--------------.
+ * |       |:|assignedChecks||completeChecks|
+ * '-------' '--------------''--------------'
+ * </pre></code>
+ * @author Mingun
+ */
+final class QuestsPanel extends JPanel implements ListSelectionListener
+{
+  private static final ConditionModel EMPTY_MODEL = new ConditionModel(Collections.emptyList());
+  private static final String NO_QUEST_SELECTED = "No quest selected";
+  private static final String DESCRIPTION = "Description";
+
+  private final JTable quests;
+  private final JLabel title = new JLabel(NO_QUEST_SELECTED);
+  private final InfinityTextArea descAssigned  = new InfinityTextArea(true);
+  private final InfinityTextArea descCompleted = new InfinityTextArea(true);
+  private final JTable assignedChecks = new JTable();
+  private final JTable completeChecks = new JTable();
+
+  //<editor-fold defaultstate="collapsed" desc="Internal classes">
+  private static final class QuestsModel extends AbstractTableModel
+  {
+    private static final String[] COLUMNS = {
+      "#",
+      "Quest Name",
+    };
+    private final List<Quest> quests;
+
+    QuestsModel(List<Quest> quests) { this.quests = quests; }
+
+    @Override
+    public int getRowCount() { return quests.size(); }
+
+    @Override
+    public int getColumnCount() { return COLUMNS.length; }
+
+    @Override
+    public String getColumnName(int columnIndex) { return COLUMNS[columnIndex]; }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+      switch (columnIndex) {
+        case 0: return Integer.class;
+        case 1: return String.class;
+      }
+      throw new IndexOutOfBoundsException("Invalid column " + columnIndex);
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex)
+    {
+      final Quest quest = quests.get(rowIndex);
+      switch (columnIndex) {
+        case 0: return quest.number;
+        case 1: return quest.toString();
+      }
+      throw new IndexOutOfBoundsException("Invalid column " + columnIndex);
+    }
+  }
+  private static final class ConditionModel extends AbstractTableModel
+  {
+    private static final String[] COLUMNS = {
+      "Variable Name",
+      "Condition",
+      "Value",
+    };
+    private final List<Check> conditions;
+
+    public ConditionModel(List<Check> conditions)
+    {
+      this.conditions = conditions;
+    }
+
+    @Override
+    public int getRowCount() { return conditions.size(); }
+
+    @Override
+    public int getColumnCount() { return COLUMNS.length; }
+
+    @Override
+    public String getColumnName(int columnIndex) { return COLUMNS[columnIndex]; }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) { return String.class; }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex)
+    {
+      final Check cond = conditions.get(rowIndex);
+      switch (columnIndex) {
+        case 0: return cond.var;
+        case 1: return cond.getHumanizedCondition();
+        case 2: return cond.value;
+      }
+      throw new IndexOutOfBoundsException("Invalid column " + columnIndex);
+    }
+  }
+  //</editor-fold>
+
+  public QuestsPanel(List<Quest> quests)
+  {
+    super(new BorderLayout());
+    this.quests = new JTable(new QuestsModel(quests));
+    final int size = this.quests.getFontMetrics(this.quests.getFont()).charWidth('w') * 4;
+    this.quests.getColumnModel().getColumn(0).setMaxWidth(size);
+    this.quests.getSelectionModel().addListSelectionListener(this);
+
+    final JPanel questInfo = new JPanel();
+    questInfo.setLayout(new BoxLayout(questInfo, BoxLayout.X_AXIS));
+    questInfo.add(createPanel(descAssigned , assignedChecks, "Assigned"));
+    questInfo.add(createPanel(descCompleted, completeChecks, "Completed"));
+
+    final JPanel panel = new JPanel(new BorderLayout());
+    panel.add(title, BorderLayout.NORTH);
+    panel.add(questInfo, BorderLayout.CENTER);
+
+    final JScrollPane scroll = new JScrollPane(this.quests);
+    scroll.setBorder(BorderFactory.createTitledBorder(String.format("Quests (%d)", quests.size())));
+    add(new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, scroll, panel), BorderLayout.CENTER);
+  }
+
+  //<editor-fold defaultstate="collapsed" desc="ListSelectionListener">
+  @Override
+  public void valueChanged(ListSelectionEvent e)
+  {
+    final int index = quests.getSelectedRow();
+    if (index >= 0) {
+      final Quest quest = ((QuestsModel)quests.getModel()).quests.get(index);
+
+      final StringTable.Format fmt = BrowserMenuBar.getInstance().showStrrefs() ? StringTable.Format.STRREF_SUFFIX
+                                                                                : StringTable.Format.NONE;
+      title.setText(quest.toString(fmt));
+
+      setText(descAssigned , quest.descAssigned);
+      setText(descCompleted, quest.descCompleted);
+
+      assignedChecks.setModel(new ConditionModel(quest.assignedChecks));
+      completeChecks.setModel(new ConditionModel(quest.completeChecks));
+    } else {
+      title.setText(NO_QUEST_SELECTED);
+
+      setText(descAssigned , null);
+      setText(descCompleted, null);
+
+      assignedChecks.setModel(EMPTY_MODEL);
+      completeChecks.setModel(EMPTY_MODEL);
+    }
+  }
+  //</editor-fold>
+
+  private JPanel createPanel(InfinityTextArea area, JTable checks, String title)
+  {
+    final JPanel panel = new JPanel(new GridBagLayout());
+    panel.setBorder(BorderFactory.createTitledBorder(title));
+
+    final GridBagConstraints gbc = new GridBagConstraints();
+    gbc.fill = GridBagConstraints.BOTH;
+    gbc.weightx = 1;
+
+    gbc.weighty = 2;
+    panel.add(wrap(area, DESCRIPTION), gbc);
+
+    gbc.gridy = 1;
+    gbc.weighty = 1;
+    panel.add(wrap(checks, "Conditions"), gbc);
+
+    return panel;
+  }
+
+  private static JScrollPane wrap(InfinityTextArea area, String title)
+  {
+    area.setLineWrap(true);
+    area.setEditable(false);
+    final InfinityScrollPane scroll = new InfinityScrollPane(area, true);
+    scroll.setBorder(BorderFactory.createTitledBorder(title));
+    return scroll;
+  }
+
+  private static JScrollPane wrap(JTable table, String title)
+  {
+    final JScrollPane scroll = new JScrollPane(table);
+    scroll.setBorder(BorderFactory.createTitledBorder(title));
+    return scroll;
+  }
+
+  private static void setText(InfinityTextArea area, StringRef value)
+  {
+    // Direct parent of area - JViewport
+    final JScrollPane scroll = (JScrollPane)area.getParent().getParent();
+    final TitledBorder border = (TitledBorder)scroll.getBorder();
+    if (value != null) {
+      border.setTitle(StringTable.Format.STRREF_SUFFIX.format(DESCRIPTION, value.getValue()));
+      area.setText(value.getText());
+    } else {
+      border.setTitle(DESCRIPTION);
+      area.setText(null);
+    }
+    // To repaint TitledBorder. Swing have a bug and do not doing this automatically
+    scroll.repaint();
+  }
+}

--- a/src/org/infinity/resource/text/QuestsResource.java
+++ b/src/org/infinity/resource/text/QuestsResource.java
@@ -1,0 +1,163 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.resource.text;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JComponent;
+import javax.swing.JTabbedPane;
+
+import org.infinity.datatype.StringRef;
+import org.infinity.icon.Icons;
+import org.infinity.resource.ViewableContainer;
+import org.infinity.resource.key.ResourceEntry;
+import org.infinity.util.IniMap;
+import org.infinity.util.IniMapSection;
+import org.infinity.util.StringTable;
+
+/**
+ * Resource, that represents PS:T {@code "quests.ini"} file - special resource
+ * with list of quests.
+ *
+ * @author Mingun
+ */
+public class QuestsResource extends PlainTextResource
+{
+  /** Special resource name {@code "quests.ini"}. */
+  public static final String RESOURCE_NAME = "quests.ini";
+
+  //<editor-fold defaultstate="collapsed" desc="Internal classes">
+  /** Represents one quest in the file. */
+  public static final class Quest
+  {
+    /** Positional number of quest in the ini file. */
+    final int number;
+    /** StringRef with name of quest. */
+    final StringRef title;
+    /** StringRef, that displayed in assigned, but not completed quests area. */
+    final StringRef descAssigned;
+    /** StringRef, that displayed in completed (succesfully or not) quests area. */
+    final StringRef descCompleted;
+    /**
+     * List of checks that determines, when this quest must be shown in the
+     * "Assigned" quests page. All checks combined by {@code AND}.
+     */
+    final List<Check> assignedChecks;
+    /**
+     * List of checks that determines, when this quest must be shown in the
+     * "Completed" quests page. All checks combined by {@code AND}.
+     */
+    final List<Check> completeChecks;
+
+    public Quest(IniMapSection section)
+    {
+      number         = Integer.parseInt(section.getName());
+      title          = section.getAsStringRef("title");
+      descAssigned   = section.getAsStringRef("descAssigned");
+      descCompleted  = section.getAsStringRef("descCompleted");
+
+      assignedChecks = readConditions(section, "assignedChecks", 'a');
+      completeChecks = readConditions(section, "completeChecks", 'c');
+    }
+
+    public String toString(StringTable.Format fmt)
+    {
+      return title == null ? "<no title>" : title.toString(fmt);
+    }
+
+    @Override
+    public String toString()
+    {
+      return toString(StringTable.Format.NONE);
+    }
+
+    private static List<Check> readConditions(IniMapSection section, String countVar, char prefix)
+    {
+      final int count = section.getAsInteger(countVar, 0);
+      final ArrayList<Check> result = new ArrayList<>(count);
+      for (int i = 1; i <= count; ++i) {
+        result.add(new Check(section, prefix, i));
+      }
+      return result;
+    }
+  }
+  /** Class, that represent one variable check condition for quest. */
+  public static final class Check
+  {
+    /** Variable to check. */
+    final String var;
+    /** Value to check againist. */
+    final String value;
+    /**
+     * Condition for check. Must be one of the {@link Condition} constants, but
+     * stored as a string to be able to save invalid conditions.
+     */
+    final String condition;
+
+    public Check(IniMapSection section, char prefix, int number)
+    {
+      var       = section.getAsString(prefix + "Var" + number);
+      value     = section.getAsString(prefix + "Value" + number);
+      condition = section.getAsString(prefix + "Condition" + number);
+    }
+
+    public String getHumanizedCondition()
+    {
+      try {
+        return Condition.valueOf(condition).title;
+      } catch (IllegalArgumentException ex) {
+        return condition;
+      }
+    }
+  }
+  public enum Condition
+  {
+    /** Variable must be equal ({@code ==}) to condition constant. */
+    EQ("=="),
+    /** Variable must be unequal ({@code !=}) to condition constant. */
+    NE("!="),
+    /** Variable must be strictly less ({@code <}) then condition constant. */
+    LT("<"),
+    /** Variable must be strictly more ({@code >}) then condition constant. */
+    GT(">");
+
+    /** Humanized name оf condition operator. */
+    final String title;
+
+    private Condition(String title) { this.title = title; }
+  }
+  //</editor-fold>
+
+  public QuestsResource(ResourceEntry entry) throws Exception
+  {
+    super(entry);
+  }
+
+  @Override
+  public JComponent makeViewer(ViewableContainer container)
+  {
+    final JTabbedPane pane = new JTabbedPane();
+    pane.addTab("Quest List", new QuestsPanel(readQuests()));
+    pane.addTab("Text", Icons.getIcon(Icons.ICON_EDIT_16), super.makeViewer(container));
+    return pane;
+  }
+
+  private List<Quest> readQuests()
+  {
+    final IniMap ini = new IniMap(getResourceEntry());
+    final IniMapSection init = ini.getSection("init");
+    final int questCount = init == null ? -1 : init.getAsInteger("questcount", -1);
+    final ArrayList<Quest> quests = new ArrayList<>(questCount < 0 ? ini.getSectionCount() : questCount);
+    for (final IniMapSection quest : ini) {
+      try {
+        quests.add(new Quest(quest));
+      } catch (NumberFormatException ex) {
+        // Skip non-number question name
+      }
+    }
+    return quests;
+  }
+}

--- a/src/org/infinity/resource/text/QuestsResource.java
+++ b/src/org/infinity/resource/text/QuestsResource.java
@@ -16,11 +16,13 @@ import javax.swing.event.DocumentEvent;
 
 import org.infinity.datatype.StringRef;
 import org.infinity.icon.Icons;
+import org.infinity.resource.ResourceFactory;
 import org.infinity.resource.ViewableContainer;
 import org.infinity.resource.key.ResourceEntry;
 import org.infinity.util.IniMap;
 import org.infinity.util.IniMapSection;
 import org.infinity.util.StringTable;
+import org.infinity.util.Variables;
 
 /**
  * Resource, that represents PS:T {@code "quests.ini"} file - special resource
@@ -73,6 +75,27 @@ public class QuestsResource extends PlainTextResource implements ChangeListener
       completeChecks = readConditions(section, "completeChecks", 'c');
     }
 
+    /**
+     * Evaluates execution status of this quest. Firstly checks completed conditions
+     * and return {@link State#Completed} if all conditions met. If not, run
+     * assigned conditions check and return {@link State#Assigned} if all conditions
+     * met. Otherwise return {@link State#Unassigned}.
+     *
+     * @param vars Container with variables, containing the status of quest.
+     *
+     * @return Execution status of the quest
+     */
+    public State evaluate(Variables vars)
+    {
+      if (evaluateAnd(vars, completeChecks)) {
+        return State.Completed;
+      }
+      if (evaluateAnd(vars, assignedChecks)) {
+        return State.Assigned;
+      }
+      return State.Unassigned;
+    }
+
     public String toString(StringTable.Format fmt)
     {
       return title == null ? "<no title>" : title.toString(fmt);
@@ -92,6 +115,24 @@ public class QuestsResource extends PlainTextResource implements ChangeListener
         result.add(new Check(section, prefix, i));
       }
       return result;
+    }
+
+    /**
+     * Evaluate all checks againist specified variables combining results with AND
+     * logical operator.
+     *
+     * @param vars Container with values of variables
+     * @param checks List of checks to run
+     *
+     * @return {@code true} if all checks evaluated to {@code true}, {@code false}
+     *         otherwise
+     */
+    private static boolean evaluateAnd(Variables vars, List<Check> checks)
+    {
+      for (final Check check : checks) {
+        if (!check.evaluate(vars)) return false;
+      }
+      return true;
     }
   }
   /** Class, that represent one variable check condition for quest. */
@@ -122,6 +163,30 @@ public class QuestsResource extends PlainTextResource implements ChangeListener
         return condition;
       }
     }
+
+    /**
+     * Evaluates check condition.
+     *
+     * @param vars Container with values of variables
+     * @return {@code true} if condition met, {@code false} otherwise
+     *
+     * @throws NumberFormatException If condition {@link #value} is not integer number
+     * @throws IllegalArgumentException If {@link #condition} is not one of the
+     *         {@link Condition known conditions}
+     */
+    public boolean evaluate(Variables vars)
+    {
+      final int val = Integer.parseInt(value);
+      final int var = vars.getInt(this.var);
+      final Condition cond = Condition.valueOf(condition);
+      switch (cond) {
+        case EQ: return var == val;
+        case NE: return var != val;
+        case LT: return var <  val;
+        case GT: return var >  val;
+      }
+      throw new InternalError("Unknown enum variant: " + cond);
+    }
   }
   public enum Condition
   {
@@ -139,7 +204,22 @@ public class QuestsResource extends PlainTextResource implements ChangeListener
 
     private Condition(String title) { this.title = title; }
   }
+  /** Quest execution status. */
+  public enum State
+  {
+    /** Quest not yet taken by player and unknown to him. */
+    Unassigned,
+    /** Quest taken by player but not yet completed, active quest. */
+    Assigned,
+    /** Quest is finished. */
+    Completed;
+  }
   //</editor-fold>
+
+  public QuestsResource() throws Exception
+  {
+    this(ResourceFactory.getResourceEntry(RESOURCE_NAME));
+  }
 
   public QuestsResource(ResourceEntry entry) throws Exception
   {
@@ -150,7 +230,7 @@ public class QuestsResource extends PlainTextResource implements ChangeListener
   public JComponent makeViewer(ViewableContainer container)
   {
     final JComponent textPage = super.makeViewer(container);
-    final QuestsPanel details = new QuestsPanel(readQuests());
+    final QuestsPanel details = new QuestsPanel(readQuests(), null);
     final JTabbedPane pane = new JTabbedPane();
     pane.addTab("Quest List", details);
     pane.addTab("Text", Icons.getIcon(Icons.ICON_EDIT_16), textPage);
@@ -194,9 +274,9 @@ public class QuestsResource extends PlainTextResource implements ChangeListener
   }
   //</editor-fold>
 
-  private List<Quest> readQuests()
+  public List<Quest> readQuests()
   {
-    final IniMap ini = new IniMap(editor.getText());
+    final IniMap ini = new IniMap(editor == null ? text : editor.getText());
     final IniMapSection init = ini.getSection("init");
     final int questCount = init == null ? -1 : init.getAsInteger("questcount", -1);
     final ArrayList<Quest> quests = new ArrayList<>(questCount < 0 ? ini.getSectionCount() : questCount);

--- a/src/org/infinity/util/IniMapEntry.java
+++ b/src/org/infinity/util/IniMapEntry.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.util;
@@ -10,6 +10,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import org.infinity.datatype.StringRef;
+
 public class IniMapEntry
 {
   /** Regular expression that can be used to split position values in {@link #splitValues(String, String)}. */
@@ -17,8 +19,10 @@ public class IniMapEntry
   /** Regular expression that can be used to split object values in {@link #splitValues(String, String)}. */
   public static final String REGEX_OBJECT = "\\[(-?\\d+\\.?)+\\]";
 
-  private String key, value;
-  private int line;   // line number of ini entry
+  private final String key;
+  private final String value;
+  /** Line number of ini entry. */
+  private final int line;
 
   public IniMapEntry(String key, String value, int line)
   {
@@ -32,7 +36,13 @@ public class IniMapEntry
 
   public boolean hasValue() { return value != null; }
   public String getValue() { return value; }
+
   public Integer getIntValue() { return value == null ? null : Integer.valueOf(value); }
+  public int getIntValue(int defValue) { return value == null ? defValue : Integer.valueOf(value); }
+
+  public StringRef getStringRefValue() {
+    return value == null ? null : new StringRef(key, Integer.valueOf(value));
+  }
 
   public int getLine() { return line; }
 

--- a/src/org/infinity/util/IniMapSection.java
+++ b/src/org/infinity/util/IniMapSection.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.util;
@@ -8,6 +8,28 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.infinity.datatype.StringRef;
+
+/**
+ * Class, that represents collection of pairs {@code key = value}, grouped together
+ * under some {@link #getName name}. This name appears in brackets before key-value
+ * pairs.
+ * <p>
+ * This class can be iterated in for-loop, and its iterator returns all key-value
+ * paramaters in the same order, in which they was appeared in the ini-file.
+ * <p>
+ * {@link #toString()} method of this class returns standard INI representation
+ * of section, i.e. name in brackets (if section {@link #isUnnamedSection() has name})
+ * followed by all key-value pairs in iteration order, each on own line. Example:
+ * <code><pre>
+ * [name]
+ * key1 = value1
+ * key2 = value2
+ * ...
+ * keyN = valueN
+ * </pre></code>
+ * For unnamed sections {@code [name]} part is skipped.
+ */
 public class IniMapSection implements Iterable<IniMapEntry>
 {
   private final List<IniMapEntry> entries = new ArrayList<>();
@@ -35,7 +57,7 @@ public class IniMapSection implements Iterable<IniMapEntry>
     return name;
   }
 
-  /** Returns the line number of the section header */
+  /** Returns the line number of the section header. */
   public int getLine()
   {
     return line;
@@ -53,18 +75,84 @@ public class IniMapSection implements Iterable<IniMapEntry>
     return entries.size();
   }
 
-  /** Returns the first instance with "key" matching the key value of the entry. */
+  //<editor-fold defaultstate="collapsed" desc="Get values">
+  /**
+   * Returns the first instance with {@code "key"} matching the key value of the
+   * entry. Performs case-insensitive search.
+   *
+   * @param key Name of value in key-value pair. This key must not contain spaces
+   *        because all spaces are cut off during parsing if ini-file, so key with
+   *        leading or trailing spaces never will be found
+   *
+   * @return First key-value pair, which key equals (ignoring case) parameter
+   *         {@code key}, or {@code null}, if no such pair exists
+   */
   public IniMapEntry getEntry(String key)
   {
     if (key != null) {
       for (final IniMapEntry e: entries) {
-        if (e.getKey().equalsIgnoreCase(key)) {
+        if (key.equalsIgnoreCase(e.getKey())) {
           return e;
         }
       }
     }
     return null;
   }
+  /**
+   * Returns value for specified key as string.
+   *
+   * @param key Name of value in key-value pair. This key must not contain spaces
+   *        because all spaces are cut off during parsing if ini-file, so key with
+   *        leading or trailing spaces never will be found
+   *
+   * @return Value of first key-value pair, which key equals (ignoring case) parameter
+   *         {@code key}, or {@code null}, if no such pair exists
+   */
+  public String getAsString(String key)
+  {
+    final IniMapEntry entry = getEntry(key);
+    return entry == null ? null : entry.getValue();
+  }
+  /**
+   * Returns value for specified key as integer or returns default value, if key
+   * or valus is not presented in the file.
+   *
+   * @param key Name of value in key-value pair. This key must not contain spaces
+   *        because all spaces are cut off during parsing if ini-file, so key with
+   *        leading or trailing spaces never will be found
+   * @param defValue Default value that will be returned, if key or value does not exist
+   *
+   * @return Value of first key-value pair, which key equals (ignoring case) parameter
+   *         {@code key}, converted to integer, or {@code defValue}, if no such pair
+   *         exists or value is not defined
+   *
+   * @throws NumberFormatException If value is not an integer
+   */
+  public int getAsInteger(String key, int defValue)
+  {
+    final IniMapEntry entry = getEntry(key);
+    return entry == null ? defValue : entry.getIntValue(defValue);
+  }
+  /**
+   * Returns value for specified key as string reference. {@link StringRef#getName}
+   * will return {@code key} as its name.
+   *
+   * @param key Name of value in key-value pair. This key must not contain spaces
+   *        because all spaces are cut off during parsing if ini-file, so key with
+   *        leading or trailing spaces never will be found
+   *
+   * @return String reference, represented by integer value of first key-value pair,
+   *         which key equals (ignoring case) parameter {@code key}, or {@code null},
+   *         if no such pair exists or value is not defined
+   *
+   * @throws NumberFormatException If value is not an integer
+   */
+  public StringRef getAsStringRef(String key)
+  {
+    final IniMapEntry entry = getEntry(key);
+    return entry == null ? null : entry.getStringRefValue();
+  }
+  //</editor-fold>
 
   @Override
   public Iterator<IniMapEntry> iterator() { return entries.iterator(); }

--- a/src/org/infinity/util/Variables.java
+++ b/src/org/infinity/util/Variables.java
@@ -1,0 +1,78 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.util;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.infinity.datatype.IsTextual;
+import org.infinity.resource.AbstractVariable;
+
+/**
+ * Container with variables, that allows do fast lookup variables by their name.
+ *
+ * @author Mingun
+ */
+public class Variables
+{
+  /** Storage of variables. */
+  private final HashMap<String, AbstractVariable> vars = new HashMap<>();
+
+  /**
+   * Appends specified variable to the variable set. If variable with such
+   * {@link AbstractVariable#VAR_NAME name} already registered, replaces it.
+   *
+   * @param var Variable to add
+   */
+  public void add(AbstractVariable var)
+  {
+    vars.put(name(var), var);
+  }
+  /**
+   * Removes specified variable from the set.
+   *
+   * @param var Variable to remove
+   */
+  public void remove(AbstractVariable var)
+  {
+    vars.remove(name(var));
+  }
+  /**
+   * Returns integer variable value with specified name. If such variable is not
+   * exist or not storing integer value, {@code 0} is returned.
+   *
+   * @param name Name of variable to get
+   * @return Integer variable value
+   */
+  public int getInt(String name)
+  {
+    final AbstractVariable var = vars.get(key(name));
+    if (var != null) {
+      final Integer value = (Integer)var.getValue(AbstractVariable.Type.Integer);
+      if (value != null) {
+        return value.intValue();
+      }
+    }
+    return 0;
+  }
+
+  @Override
+  public String toString()
+  {
+    final StringBuilder sb = new StringBuilder("Variables{\n");
+    for (final Map.Entry<String, AbstractVariable> e : vars.entrySet()) {
+      sb.append("  ").append(e.getKey()).append('=').append(e.getValue().getValue()).append('\n');
+    }
+    return sb.append('}').toString();
+  }
+
+  private static String name(AbstractVariable var)
+  {
+    final IsTextual attr = (IsTextual)var.getAttribute(AbstractVariable.VAR_NAME, false);
+    return key(attr.getText());
+  }
+  private static String key(String name) { return name.toUpperCase(Locale.ENGLISH); }
+}


### PR DESCRIPTION
- Added viever for `quests.ini` special resource:
![quests ini](https://user-images.githubusercontent.com/450131/68076908-bdc5cc80-fddc-11e9-9dba-63c300ce600f.png)
- Added ability to view current quest statuses in savegames:
![save](https://user-images.githubusercontent.com/450131/68076916-da620480-fddc-11e9-935c-41a0c550f58b.png)

@lynxlynxlynx, as the owner of gemrb project, may be you can suggest what happens if the number of quests in the `[init]/questcount` ini-entry does not match what is written in the file? For example, if a `questcount=100` and count of the entries are actually 125 -- would left 25 be ignored? Or if some of the records from the middle will miss (for example, file contains entries 0, 1, 10), how does the game react to this?