### PR TITLE
Refactoring and some improvements in area (ARE resources) viewer

### DIFF
--- a/src/org/infinity/gui/layeritem/AbstractLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AbstractLayerItem.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.gui.layeritem;
@@ -37,45 +37,6 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   private ItemState itemState;
   private Point location;
   private Point center;
-
-  /**
-   * Initialize object with default settings.
-   */
-  public AbstractLayerItem()
-  {
-    this(null);
-  }
-
-  /**
-   * Initialize object with the specified map location.
-   * @param location Map location
-   */
-  public AbstractLayerItem(Point location)
-  {
-    this(location, null);
-  }
-
-  /**
-   * Initialize object with a specific map location and an associated viewable object.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   */
-  public AbstractLayerItem(Point location, Viewable viewable)
-  {
-    this(location, viewable, null);
-  }
-
-  /**
-   * Initialize object with a specified map location, associated viewable object and message for
-   * both info box and quick info.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   * @param message Text message for info box and quick info
-   */
-  public AbstractLayerItem(Point location, Viewable viewable, String message)
-  {
-    this(location, viewable, message, message);
-  }
 
   /**
    * Initialize object with a specific map location, associated Viewable and an additional text message.
@@ -304,8 +265,7 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
     }
   }
 
-//--------------------- Begin Interface MouseListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="MouseListener">
   @Override
   public void mouseClicked(MouseEvent event)
   {
@@ -342,11 +302,9 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
       setItemState(ItemState.NORMAL);
     }
   }
+  //</editor-fold>
 
-//--------------------- End Interface MouseListener ---------------------
-
-//--------------------- Begin Interface MouseMotionListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="MouseMotionListener">
   @Override
   public void mouseDragged(MouseEvent event)
   {
@@ -361,9 +319,9 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
       setItemState(ItemState.NORMAL);
     }
   }
+  //</editor-fold>
 
-//--------------------- End Interface MouseMotionListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="JComponent">
   @Override
   public String getToolTipText(MouseEvent event)
   {
@@ -381,8 +339,9 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
     // Non-visible parts of the component are disregarded by mouse events
     return isMouseOver(new Point(x, y));
   }
+  //</editor-fold>
 
-  // Returns whether the mouse cursor is over the relevant part of the component
+  /** Returns whether the mouse cursor is over the relevant part of the component. */
   protected boolean isMouseOver(Point pt)
   {
     if (pt != null) {
@@ -392,7 +351,7 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
     }
   }
 
-  // Adds an offset to the component's position
+  /** Adds an offset to the component's position. */
   protected void setLocationOffset(Point ofs)
   {
     if (ofs != null) {
@@ -401,7 +360,7 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
     }
   }
 
-  // Returns the offset to the component's position
+  /** Returns the offset to the component's position. */
   protected Point getLocationOffset()
   {
     return center;

--- a/src/org/infinity/gui/layeritem/AbstractLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AbstractLayerItem.java
@@ -34,22 +34,21 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   private Object objData;
   private final String message;
   private ItemState itemState;
-  private final Point location;
   private final Point center;
 
   /**
-   * Initialize object with a specific map location, associated Viewable and an additional text message.
-   * @param location Map location
+   * Initialize object with a associated viewable object and message for
+   * both info box and quick info.
+   *
    * @param viewable Associated Viewable object
    * @param message An arbitrary text message for the info box
    * @param tooltip A short text message shown as tooltip or menu item text
    */
-  public AbstractLayerItem(Point location, Viewable viewable, String message, String tooltip)
+  public AbstractLayerItem(Viewable viewable, String message, String tooltip)
   {
     this.viewable = viewable;
     this.itemState = ItemState.NORMAL;
     this.center = new Point();
-    this.location = location == null ? new Point(0, 0) : location;
     this.message = message == null ? "" : message;
     setToolTipText(tooltip);
     addMouseListener(this);

--- a/src/org/infinity/gui/layeritem/AbstractLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AbstractLayerItem.java
@@ -28,15 +28,15 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
    */
   public enum ItemState { NORMAL, HIGHLIGHTED }
 
-  private Vector<ActionListener> actionListener;
-  private Vector<LayerItemListener> itemStateListener;
-  private String actionCommand;
-  private Viewable viewable;
+  private final Vector<ActionListener> actionListener = new Vector<>();
+  private final Vector<LayerItemListener> itemStateListener = new Vector<>();
+  private final String actionCommand;
+  private final Viewable viewable;
   private Object objData;
-  private String message, tooltip;
+  private final String message;
   private ItemState itemState;
-  private Point location;
-  private Point center;
+  private final Point location;
+  private final Point center;
 
   /**
    * Initialize object with a specific map location, associated Viewable and an additional text message.
@@ -47,31 +47,15 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
    */
   public AbstractLayerItem(Point location, Viewable viewable, String message, String tooltip)
   {
-    this.actionListener = new Vector<ActionListener>();
-    this.itemStateListener = new Vector<LayerItemListener>();
     this.viewable = viewable;
     this.itemState = ItemState.NORMAL;
     this.center = new Point();
-    setMapLocation(location);
-    setMessage(message);
-    setQuickInfo(tooltip);
-    setActionCommand(null);
+    this.location = location == null ? new Point(0, 0) : location;
+    this.message = message == null ? "" : message;
+    setToolTipText(tooltip);
+    this.actionCommand = "";
     addMouseListener(this);
     addMouseMotionListener(this);
-  }
-
-  public String getActionCommand()
-  {
-    return actionCommand;
-  }
-
-  public void setActionCommand(String cmd)
-  {
-    if (cmd != null) {
-      actionCommand = cmd;
-    } else {
-      actionCommand = "";
-    }
   }
 
   public void addActionListener(ActionListener l)
@@ -123,82 +107,12 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   }
 
   /**
-   * Moves this component to the specified location. Takes item-specific corrections into account.
-   * @param p New location
-   */
-  public void setItemLocation(Point p)
-  {
-    if (p == null) {
-      p = new Point(0, 0);
-    }
-
-    setLocation(new Point(p.x - center.x, p.y - center.y));
-  }
-
-  /**
-   * Returns the map location of the item.
-   * @return Map location of the item.
-   */
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  /**
-   * Sets a new map location of the item.
-   * @param location New map location of the item.
-   */
-  public void setMapLocation(Point location)
-  {
-    if (location != null) {
-      this.location = location;
-    } else {
-      this.location = new Point(0, 0);
-    }
-  }
-
-  /**
-   * Set a text message which can be queried at a given time.
-   * @param msg The text message
-   */
-  public void setMessage(String msg)
-  {
-    if (msg != null) {
-      message = msg;
-    } else {
-      message = "";
-    }
-  }
-
-  /**
    * Returns a text message associated with the component.
    * @return A text message.
    */
   public String getMessage()
   {
     return message;
-  }
-
-  /**
-   * Sets a short text message used by tooltips or menu items.
-   * @param info A short text message.
-   */
-  public void setQuickInfo(String info)
-  {
-    if (info != null) {
-      tooltip = info;
-    } else {
-      tooltip = "";
-    }
-  }
-
-  /**
-   * Returns a short text message used by tooltips and menu items.
-   * @return A short text message.
-   */
-  public String getQuickInfo()
-  {
-    return tooltip;
   }
 
   /**
@@ -235,15 +149,6 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   public Object getData()
   {
     return objData;
-  }
-
-  /**
-   * Associates a new Viewable object with the component
-   * @param v The new viewable.
-   */
-  public void setViewable(Viewable v)
-  {
-    viewable = v;
   }
 
   /**
@@ -323,17 +228,6 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
 
   //<editor-fold defaultstate="collapsed" desc="JComponent">
   @Override
-  public String getToolTipText(MouseEvent event)
-  {
-    // Tooltip is only displayed over visible areas of this component
-    if (isMouseOver(event.getPoint())) {
-      return getQuickInfo();
-    } else {
-      return null;
-    }
-  }
-
-  @Override
   public boolean contains(int x, int y)
   {
     // Non-visible parts of the component are disregarded by mouse events
@@ -391,10 +285,6 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
       for (final ActionListener l: actionListener) {
         l.actionPerformed(ae);
       }
-    } else if (button == MouseEvent.BUTTON2) {
-      // processing right mouse click event
-    } else if (button == MouseEvent.BUTTON3) {
-      // processing middle mouse click event
     }
   }
 }

--- a/src/org/infinity/gui/layeritem/AbstractLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AbstractLayerItem.java
@@ -122,11 +122,7 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
 
   public ActionListener[] getActionListeners()
   {
-    ActionListener[] array = new ActionListener[actionListener.size()];
-    for (int i = 0; i < actionListener.size(); i++) {
-      array[i] = actionListener.get(i);
-    }
-    return array;
+    return actionListener.toArray(new ActionListener[actionListener.size()]);
   }
 
   public void removeActionListener(ActionListener l)
@@ -145,11 +141,7 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
 
   public LayerItemListener[] getLayerItemListeners()
   {
-    LayerItemListener[] array = new LayerItemListener[itemStateListener.size()];
-    for (int i = 0; i < itemStateListener.size(); i++) {
-      array[i] = itemStateListener.get(i);
-    }
-    return array;
+    return itemStateListener.toArray(new LayerItemListener[itemStateListener.size()]);
   }
 
   public void removeLayerItemListener(LayerItemListener l)

--- a/src/org/infinity/gui/layeritem/AbstractLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AbstractLayerItem.java
@@ -30,7 +30,6 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
 
   private final Vector<ActionListener> actionListener = new Vector<>();
   private final Vector<LayerItemListener> itemStateListener = new Vector<>();
-  private final String actionCommand;
   private final Viewable viewable;
   private Object objData;
   private final String message;
@@ -53,7 +52,6 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
     this.location = location == null ? new Point(0, 0) : location;
     this.message = message == null ? "" : message;
     setToolTipText(tooltip);
-    this.actionCommand = "";
     addMouseListener(this);
     addMouseMotionListener(this);
   }
@@ -265,7 +263,7 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
     if (itemState != newState) {
       itemState = newState;
       if (!itemStateListener.isEmpty()) {
-        LayerItemEvent ise = new LayerItemEvent(this, actionCommand);
+        final LayerItemEvent ise = new LayerItemEvent(this, "");
         for (final LayerItemListener l: itemStateListener)
           l.layerItemChanged(ise);
       }
@@ -281,7 +279,7 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   {
     if ((button == MouseEvent.BUTTON1) && !actionListener.isEmpty()) {
       // processing left mouse click event
-      ActionEvent ae = new ActionEvent(this, ActionEvent.ACTION_PERFORMED, actionCommand);
+      final ActionEvent ae = new ActionEvent(this, ActionEvent.ACTION_PERFORMED, "");
       for (final ActionListener l: actionListener) {
         l.actionPerformed(ae);
       }

--- a/src/org/infinity/gui/layeritem/AbstractLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AbstractLayerItem.java
@@ -16,6 +16,7 @@ import java.util.Vector;
 import javax.swing.JComponent;
 
 import org.infinity.gui.ViewFrame;
+import org.infinity.resource.StructEntry;
 import org.infinity.resource.Viewable;
 
 /**
@@ -32,7 +33,6 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   private final Vector<LayerItemListener> itemStateListener = new Vector<>();
   private final Viewable viewable;
   private Object objData;
-  private final String message;
   private ItemState itemState;
   private final Point center;
 
@@ -41,16 +41,18 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
    * both info box and quick info.
    *
    * @param viewable Associated Viewable object
-   * @param message An arbitrary text message for the info box
    * @param tooltip A short text message shown as tooltip or menu item text
    */
-  public AbstractLayerItem(Viewable viewable, String message, String tooltip)
+  public AbstractLayerItem(Viewable viewable, String tooltip)
   {
     this.viewable = viewable;
     this.itemState = ItemState.NORMAL;
     this.center = new Point();
-    this.message = message == null ? "" : message;
-    setToolTipText(tooltip);
+    if (viewable instanceof StructEntry) {
+      setToolTipText(((StructEntry) viewable).getName() + ": " + tooltip);
+    } else {
+      setToolTipText(tooltip);
+    }
     addMouseListener(this);
     addMouseMotionListener(this);
   }
@@ -104,21 +106,12 @@ public abstract class AbstractLayerItem extends JComponent implements MouseListe
   }
 
   /**
-   * Returns a text message associated with the component.
-   * @return A text message.
-   */
-  public String getMessage()
-  {
-    return message;
-  }
-
-  /**
    * Returns a String representation of this object.
    */
   @Override
   public String toString()
   {
-    return getMessage();
+    return getToolTipText();
   }
 
   /**

--- a/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
@@ -52,14 +52,12 @@ public class AnimatedLayerItem extends AbstractLayerItem
    * and an array of Frame object containing graphics data and frame centers.
    *
    * @param viewable Associated Viewable object
-   * @param message An arbitrary text message for the info box.
    * @param tooltip A short text message shown as tooltip or menu item text
    * @param anim An array of Frame objects defining the animation for this layer item
    */
-  public AnimatedLayerItem(Viewable viewable, String message, String tooltip,
-                           BasicAnimationProvider anim)
+  public AnimatedLayerItem(Viewable viewable, String tooltip, BasicAnimationProvider anim)
   {
-    super(viewable, message, tooltip);
+    super(viewable, tooltip);
     init();
     initAnimation(anim);
   }

--- a/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
@@ -459,8 +459,8 @@ public class AnimatedLayerItem extends AbstractLayerItem
     if (anim != null) {
       animation = anim;
     } else {
-      if (!(animation != null && animation instanceof DefaultAnimationProvider)) {
-        this.animation = new DefaultAnimationProvider();
+      if (!(animation instanceof DefaultAnimationProvider)) {
+        animation = new DefaultAnimationProvider();
       }
     }
 
@@ -625,7 +625,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
 
 
   /** A pseudo animation provider that always returns a transparent image of 16x16 size. */
-  private class DefaultAnimationProvider implements BasicAnimationProvider
+  private static final class DefaultAnimationProvider implements BasicAnimationProvider
   {
     private final BufferedImage image;
 

--- a/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.gui.layeritem;
@@ -46,56 +46,6 @@ public class AnimatedLayerItem extends AbstractLayerItem
   private Rectangle frameBounds;    // Point(x,y) defines the point of origin for the animation graphics
   private RenderCanvas rcCanvas;    // Renders both the animation graphics and an optional frame
   private SwingWorker<Void, Void> workerAnimate;
-
-  /**
-   * Initialize object with default settings.
-   */
-  public AnimatedLayerItem()
-  {
-    this(null);
-  }
-
-  /**
-   * Initialize object with the specified map location.
-   * @param location Map location
-   */
-  public AnimatedLayerItem(Point location)
-  {
-    this(location, null);
-  }
-
-  /**
-   * Initialize object with a specific map location and an associated viewable object.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   */
-  public AnimatedLayerItem(Point location, Viewable viewable)
-  {
-    this(location, viewable, null);
-  }
-
-  /**
-   * Initialize object with a specific map location, associated Viewable and an additional text message.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   * @param message An arbitrary text message
-   */
-  public AnimatedLayerItem(Point location, Viewable viewable, String message)
-  {
-    this(location, viewable, message, message);
-  }
-
-  /**
-   * Initialize object with a specific map location, associated Viewable and an additional text message.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   * @param message An arbitrary text message
-   * @param tooltip A short text message shown as tooltip or menu item text
-   */
-  public AnimatedLayerItem(Point location, Viewable viewable, String message, String tooltip)
-  {
-    this(location, viewable, message, tooltip, null);
-  }
 
   /**
    * Initialize object with a specific map location, associated Viewable, an additional text message
@@ -402,8 +352,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
     super.setVisible(aFlag);
   }
 
-//--------------------- Begin Interface LayerItemListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="LayerItemListener">
   @Override
   public void layerItemChanged(LayerItemEvent event)
   {
@@ -411,11 +360,9 @@ public class AnimatedLayerItem extends AbstractLayerItem
       updateDisplay(false);
     }
   }
+  //</editor-fold>
 
-//--------------------- End Interface LayerItemListener ---------------------
-
-//--------------------- Begin Interface ActionListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="ActionListener">
   @Override
   public void actionPerformed(ActionEvent event)
   {
@@ -444,24 +391,21 @@ public class AnimatedLayerItem extends AbstractLayerItem
       }
     }
   }
+  //</editor-fold>
 
-//--------------------- End Interface ActionListener ---------------------
-
-//--------------------- Begin Interface PropertyChangeListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="PropertyChangeListener">
   @Override
   public void propertyChange(PropertyChangeEvent event)
   {
     if (event.getSource() == workerAnimate) {
       if ("state".equals(event.getPropertyName()) &&
-          SwingWorker.StateValue.DONE == event.getNewValue()) {
+              SwingWorker.StateValue.DONE == event.getNewValue()) {
         // Important: making sure that only ONE instance is running at a time to avoid GUI freezes
         workerAnimate = null;
       }
     }
   }
-
-//--------------------- End Interface PropertyChangeListener ---------------------
+  //</editor-fold>
 
   @Override
   public void repaint()
@@ -478,8 +422,10 @@ public class AnimatedLayerItem extends AbstractLayerItem
     return r.contains(pt);
   }
 
-  // Calculates a rectangle big enough to fit the current frame image and border into.
-  // Returns whether the canvas size changed.
+  /**
+   * Calculates a rectangle big enough to fit the current frame image and border into.
+   * Returns whether the canvas size changed.
+   */
   private void updateCanvasSize()
   {
     int strokeWidth = (int)Math.max(getFrameInfo(false).getStroke().getLineWidth(),
@@ -517,13 +463,13 @@ public class AnimatedLayerItem extends AbstractLayerItem
     }
   }
 
-  // Returns the FrameInfo object of the specified state
+  /** Returns the FrameInfo object of the specified state. */
   private FrameInfo getFrameInfo(boolean highlighted)
   {
     return highlighted ? frameInfos[1] : frameInfos[0];
   }
 
-  // First-time initializations
+  /** First-time initializations. */
   private void init()
   {
     setLayout(new BorderLayout());
@@ -547,7 +493,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
     addLayerItemListener(this);
   }
 
-  // Animation-related initializations (requires this.frame to be initialized)
+  /** Animation-related initializations (requires this.frame to be initialized). */
   private void initAnimation(BasicAnimationProvider anim)
   {
     boolean isPlaying = isPlaying();
@@ -568,7 +514,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
     }
   }
 
-  // Call whenever the behavior of the current animation changes
+  /** Call whenever the behavior of the current animation changes. */
   private void updateAnimation()
   {
     boolean isPlaying = isPlaying();
@@ -583,7 +529,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
     }
   }
 
-  // Updates the display if needed
+  /** Updates the display if needed. */
   private void updateDisplay(boolean force)
   {
     if (!isPlaying() || force) {
@@ -591,7 +537,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
     }
   }
 
-  // Updates both frame content and position.
+  /** Updates both frame content and position. */
   private void updateFrame()
   {
     updateSize();
@@ -599,7 +545,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
     repaint();
   }
 
-  // Draws the current frame onto the canvas
+  /** Draws the current frame onto the canvas. */
   private synchronized void updateCanvas()
   {
     boolean isHighlighted = (getItemState() == ItemState.HIGHLIGHTED);
@@ -651,7 +597,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
     }
   }
 
-  // Updates the component position based on the current frame's center. Takes zoom factor into account.
+  /** Updates the component position based on the current frame's center. Takes zoom factor into account. */
   private void updatePosition()
   {
     Rectangle bounds = getCanvasBounds(true);
@@ -669,7 +615,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
 
 //----------------------------- INNER CLASSES -----------------------------
 
-  // Stores information about frames around the item
+  /** Stores information about frames around the item. */
   private static class FrameInfo
   {
     private static Color DefaultColor = new Color(0, true);
@@ -721,7 +667,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
   }
 
 
-  // A pseudo animation provider that always returns a transparent image of 16x16 size.
+  /** A pseudo animation provider that always returns a transparent image of 16x16 size. */
   private class DefaultAnimationProvider implements BasicAnimationProvider
   {
     private final BufferedImage image;

--- a/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
@@ -251,14 +251,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
    */
   public boolean isFrameEnabled(ItemState state)
   {
-    switch (state) {
-      case NORMAL:
-        return frameInfos[0].isEnabled();
-      case HIGHLIGHTED:
-        return frameInfos[0].isEnabled();
-      default:
-        return false;
-    }
+    return frameInfos[state.ordinal()].isEnabled();
   }
 
   /**
@@ -266,14 +259,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
    */
   public void setFrameEnabled(ItemState state, boolean enabled)
   {
-    switch (state) {
-      case NORMAL:
-        frameInfos[0].setEnabled(enabled);
-        break;
-      case HIGHLIGHTED:
-        frameInfos[1].setEnabled(enabled);
-        break;
-    }
+    frameInfos[state.ordinal()].setEnabled(enabled);
     updateFrame();
   }
 
@@ -282,14 +268,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
    */
   public int getFrameWidth(ItemState state)
   {
-    switch (state) {
-      case NORMAL:
-        return (int)frameInfos[0].getStroke().getLineWidth();
-      case HIGHLIGHTED:
-        return (int)frameInfos[1].getStroke().getLineWidth();
-      default:
-        return 0;
-    }
+    return (int)frameInfos[state.ordinal()].getStroke().getLineWidth();
   }
 
   /**
@@ -297,15 +276,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
    */
   public void setFrameWidth(ItemState state, int width)
   {
-    if (width < 1) width = 1;
-    switch (state) {
-      case NORMAL:
-        frameInfos[0].setStroke(new BasicStroke((float)width));
-        break;
-      case HIGHLIGHTED:
-        frameInfos[1].setStroke(new BasicStroke((float)width));
-        break;
-    }
+    frameInfos[state.ordinal()].setStroke(new BasicStroke(width < 1 ? 1 : width));
     updateFrame();
   }
 
@@ -314,14 +285,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
    */
   public Color getFrameColor(ItemState state)
   {
-    switch (state) {
-      case NORMAL:
-        return frameInfos[0].getColor();
-      case HIGHLIGHTED:
-        return frameInfos[1].getColor();
-      default:
-        return FrameInfo.DefaultColor;
-    }
+    return frameInfos[state.ordinal()].getColor();
   }
 
   /**
@@ -329,14 +293,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
    */
   public void setFrameColor(ItemState state, Color color)
   {
-    switch (state) {
-      case NORMAL:
-        frameInfos[0].setColor(color);
-        break;
-      case HIGHLIGHTED:
-        frameInfos[1].setColor(color);
-        break;
-    }
+    frameInfos[state.ordinal()].setColor(color);
     updateFrame();
   }
 

--- a/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
@@ -33,7 +33,7 @@ import org.infinity.resource.graphics.ColorConvert;
 public class AnimatedLayerItem extends AbstractLayerItem
     implements LayerItemListener, ActionListener, PropertyChangeListener
 {
-  private static final Color TransparentColor = new Color(0, true);
+  private static final Color TRANSPARENT_COLOR = new Color(0, true);
 
   private final FrameInfo[] frameInfos = {new FrameInfo(), new FrameInfo()};
 
@@ -553,7 +553,7 @@ public class AnimatedLayerItem extends AbstractLayerItem
     Graphics2D g2 = (Graphics2D)rcCanvas.getImage().getGraphics();
     try {
       g2.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC));
-      g2.setColor(TransparentColor);
+      g2.setColor(TRANSPARENT_COLOR);
       g2.fillRect(0, 0, rcCanvas.getImage().getWidth(null), rcCanvas.getImage().getHeight(null));
 
       // drawing animation graphics

--- a/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/AnimatedLayerItem.java
@@ -48,18 +48,18 @@ public class AnimatedLayerItem extends AbstractLayerItem
   private SwingWorker<Void, Void> workerAnimate;
 
   /**
-   * Initialize object with a specific map location, associated Viewable, an additional text message
+   * Initialize object with an associated Viewable, an additional text message
    * and an array of Frame object containing graphics data and frame centers.
-   * @param location Map location
+   *
    * @param viewable Associated Viewable object
    * @param message An arbitrary text message for the info box.
    * @param tooltip A short text message shown as tooltip or menu item text
    * @param anim An array of Frame objects defining the animation for this layer item
    */
-  public AnimatedLayerItem(Point location, Viewable viewable, String message, String tooltip,
+  public AnimatedLayerItem(Viewable viewable, String message, String tooltip,
                            BasicAnimationProvider anim)
   {
-    super(location, viewable, message, tooltip);
+    super(viewable, message, tooltip);
     init();
     initAnimation(anim);
   }

--- a/src/org/infinity/gui/layeritem/IconLayerItem.java
+++ b/src/org/infinity/gui/layeritem/IconLayerItem.java
@@ -107,15 +107,7 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
     if (state == null) {
       state = ItemState.NORMAL;
     }
-    switch (state) {
-      case HIGHLIGHTED:
-        if (images.containsKey(ItemState.HIGHLIGHTED))
-          return images.get(ItemState.HIGHLIGHTED);
-      case NORMAL:
-        if (images.containsKey(ItemState.NORMAL))
-          return images.get(ItemState.NORMAL);
-    }
-    return DEFAULT_IMAGE;
+    return images.containsKey(state) ? images.get(state) : DEFAULT_IMAGE;
   }
 
   /**

--- a/src/org/infinity/gui/layeritem/IconLayerItem.java
+++ b/src/org/infinity/gui/layeritem/IconLayerItem.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.gui.layeritem;
@@ -39,33 +39,6 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
   private JLabel label;
 
   /**
-   * Initialize object with default settings.
-   */
-  public IconLayerItem()
-  {
-    this(null);
-  }
-
-  /**
-   * Initialize object with the specified map location.
-   * @param location Map location
-   */
-  public IconLayerItem(Point location)
-  {
-    this(location, null);
-  }
-
-  /**
-   * Initialize object with a specific map location and an associated viewable object.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   */
-  public IconLayerItem(Point location, Viewable viewable)
-  {
-    this(location, viewable, null);
-  }
-
-  /**
    * Initialize object with a specific map location, associated Viewable and an additional text message.
    * @param location Map location
    * @param viewable Associated Viewable object
@@ -73,34 +46,7 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
    */
   public IconLayerItem(Point location, Viewable viewable, String message)
   {
-    this(location, viewable, message, message);
-  }
-
-  /**
-   * Initialize object with a specific map location, associated Viewable, an additional text message
-   * and an image for the visual representation.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   * @param message An arbitrary text message
-   * @param tooltip A short text message shown as tooltip or menu item text
-   */
-  public IconLayerItem(Point location, Viewable viewable, String message, String tooltip)
-  {
-    this(location, viewable, message, tooltip, null);
-  }
-
-  /**
-   * Initialize object with a specific map location, associated Viewable, an additional text message
-   * and an image for the visual representation.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   * @param message An arbitrary text message
-   * @param tooltip A short text message shown as tooltip or menu item text
-   * @param image The image to display
-   */
-  public IconLayerItem(Point location, Viewable viewable, String message, String tooltip, Image image)
-  {
-    this(location, viewable, message, tooltip, image, null);
+    this(location, viewable, message, message, null, null);
   }
 
   /**
@@ -313,8 +259,7 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
     validate();
   }
 
-//--------------------- Begin Interface LayerItemListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="LayerItemListener">
   @Override
   public void layerItemChanged(LayerItemEvent event)
   {
@@ -322,10 +267,9 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
       setCurrentImage(getItemState());
     }
   }
+  //</editor-fold>
 
-//--------------------- End Interface LayerItemListener ---------------------
-
-  // Returns whether the mouse cursor is over the relevant part of the component
+  /** Returns whether the mouse cursor is over the relevant part of the component. */
   @Override
   protected boolean isMouseOver(Point pt)
   {
@@ -402,7 +346,7 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
 
 //----------------------------- INNER CLASSES -----------------------------
 
-  // Extended JLabel to add the feature to show a frame around the component
+  /** Extended JLabel to add the feature to show a frame around the component. */
   private static class FrameCanvas extends RenderCanvas
   {
     private final IconLayerItem parent;
@@ -431,7 +375,7 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
     }
   }
 
-  // Stores information required to draw a customized frame around the component
+  /** Stores information required to draw a customized frame around the component. */
   private static class FrameInfo
   {
     private boolean enabled;
@@ -492,5 +436,4 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
       return stroke;
     }
   }
-
 }

--- a/src/org/infinity/gui/layeritem/IconLayerItem.java
+++ b/src/org/infinity/gui/layeritem/IconLayerItem.java
@@ -39,30 +39,30 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
   private JLabel label;
 
   /**
-   * Initialize object with a specific map location, associated Viewable and an additional text message.
-   * @param location Map location
+   * Initialize object with an associated Viewable and an additional text message.
+   *
    * @param viewable Associated Viewable object
    * @param message An arbitrary text message
    */
-  public IconLayerItem(Point location, Viewable viewable, String message)
+  public IconLayerItem(Viewable viewable, String message)
   {
-    this(location, viewable, message, message, null, null);
+    this(viewable, message, message, null, null);
   }
 
   /**
-   * Initialize object with a specific map location, associated Viewable, an additional text message,
+   * Initialize object with an associated Viewable, an additional text message,
    * an image for the visual representation and a locical center position within the icon.
-   * @param location Map location
+   *
    * @param viewable Associated Viewable object
    * @param message An arbitrary text message
    * @param tooltip A short text message shown as tooltip or menu item text
    * @param image The image to display
    * @param center Logical center position within the icon
    */
-  public IconLayerItem(Point location, Viewable viewable, String message, String tooltip,
+  public IconLayerItem(Viewable viewable, String message, String tooltip,
                        Image image, Point center)
   {
-    super(location, viewable, message, tooltip);
+    super(viewable, message, tooltip);
     setLayout(new BorderLayout());
     // preparing icon
     rcCanvas = new FrameCanvas(this);

--- a/src/org/infinity/gui/layeritem/IconLayerItem.java
+++ b/src/org/infinity/gui/layeritem/IconLayerItem.java
@@ -46,7 +46,7 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
    */
   public IconLayerItem(Viewable viewable, String message)
   {
-    this(viewable, message, message, null, null);
+    this(viewable, message, null, null);
   }
 
   /**
@@ -54,15 +54,14 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
    * an image for the visual representation and a locical center position within the icon.
    *
    * @param viewable Associated Viewable object
-   * @param message An arbitrary text message
    * @param tooltip A short text message shown as tooltip or menu item text
    * @param image The image to display
    * @param center Logical center position within the icon
    */
-  public IconLayerItem(Viewable viewable, String message, String tooltip,
+  public IconLayerItem(Viewable viewable, String tooltip,
                        Image image, Point center)
   {
-    super(viewable, message, tooltip);
+    super(viewable, tooltip);
     setLayout(new BorderLayout());
     // preparing icon
     rcCanvas = new FrameCanvas(this);
@@ -71,9 +70,7 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
     rcCanvas.setVerticalAlignment(SwingConstants.CENTER);
     add(rcCanvas, BorderLayout.CENTER);
     // preparing icon label
-    String msg = (tooltip != null && !tooltip.isEmpty()) ? tooltip : message;
-    if (msg == null) { msg = ""; }
-    label = new JLabel(msg);
+    label = new JLabel(tooltip);
     label.setHorizontalAlignment(SwingConstants.CENTER);
     label.setVerticalAlignment(SwingConstants.CENTER);
     label.setIconTextGap(2);

--- a/src/org/infinity/gui/layeritem/IconLayerItem.java
+++ b/src/org/infinity/gui/layeritem/IconLayerItem.java
@@ -29,12 +29,12 @@ import org.infinity.resource.graphics.ColorConvert;
  */
 public class IconLayerItem extends AbstractLayerItem implements LayerItemListener
 {
-  private static final Image DefaultImage = ColorConvert.createCompatibleImage(1, 1, true);
+  private static final Image DEFAULT_IMAGE = ColorConvert.createCompatibleImage(1, 1, true);
   private static final Color COLOR_BG_NORMAL = new Color(0x80ffffff, true);
   private static final Color COLOR_BG_HIGHLIGHTED = new Color(0xc0ffffff, true);
 
-  private EnumMap<ItemState, Image> images;
-  private EnumMap<ItemState, FrameInfo> frames;
+  private final EnumMap<ItemState, Image> images = new EnumMap<>(ItemState.class);
+  private final EnumMap<ItemState, FrameInfo> frames = new EnumMap<>(ItemState.class);
   private RenderCanvas rcCanvas;
   private JLabel label;
 
@@ -65,8 +65,6 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
     super(location, viewable, message, tooltip);
     setLayout(new BorderLayout());
     // preparing icon
-    images = new EnumMap<ItemState, Image>(ItemState.class);
-    frames = new EnumMap<ItemState, FrameInfo>(ItemState.class);
     rcCanvas = new FrameCanvas(this);
 //    rcCanvas.setBorder(BorderFactory.createLineBorder(Color.RED));  // DEBUG
     rcCanvas.setHorizontalAlignment(SwingConstants.CENTER);
@@ -117,7 +115,7 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
         if (images.containsKey(ItemState.NORMAL))
           return images.get(ItemState.NORMAL);
     }
-    return DefaultImage;
+    return DEFAULT_IMAGE;
   }
 
   /**
@@ -221,15 +219,6 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
 
   /**
    * Sets the logical center of the icon.
-   * @return The logical center of the icon.
-   */
-  public Point getCenterPosition()
-  {
-    return getLocationOffset();
-  }
-
-  /**
-   * Sets the logical center of the icon.
    * @param center The center position within the icon.
    */
   public void setCenterPosition(Point center)
@@ -246,11 +235,6 @@ public class IconLayerItem extends AbstractLayerItem implements LayerItemListene
       setLocation(loc.x + distance.x, loc.y + distance.y);
       validate();
     }
-  }
-
-  public boolean isLabelEnabled()
-  {
-    return label.isVisible();
   }
 
   public void setLabelEnabled(boolean set)

--- a/src/org/infinity/gui/layeritem/ShapedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/ShapedLayerItem.java
@@ -112,15 +112,7 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
     if (state == null) {
       state = ItemState.NORMAL;
     }
-    switch (state) {
-      case HIGHLIGHTED:
-        if (strokeColors.containsKey(ItemState.HIGHLIGHTED))
-          return strokeColors.get(ItemState.HIGHLIGHTED);
-      case NORMAL:
-        if (strokeColors.containsKey(ItemState.NORMAL))
-          return strokeColors.get(ItemState.NORMAL);
-    }
-    return DEFAULT_COLOR;
+    return strokeColors.containsKey(state) ? strokeColors.get(state) : DEFAULT_COLOR;
   }
 
   /**
@@ -181,15 +173,7 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
     if (state == null) {
       state = ItemState.NORMAL;
     }
-    switch (state) {
-      case HIGHLIGHTED:
-        if (fillColors.containsKey(ItemState.HIGHLIGHTED))
-          return fillColors.get(ItemState.HIGHLIGHTED);
-      case NORMAL:
-        if (fillColors.containsKey(ItemState.NORMAL))
-          return fillColors.get(ItemState.NORMAL);
-    }
-    return DEFAULT_COLOR;
+    return fillColors.containsKey(state) ? fillColors.get(state) : DEFAULT_COLOR;
   }
 
   /**

--- a/src/org/infinity/gui/layeritem/ShapedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/ShapedLayerItem.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.gui.layeritem;
@@ -33,57 +33,6 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
   private EnumMap<ItemState, Color> fillColors;
   private JLabel label;
   private boolean stroked, filled;
-
-  /**
-   * Initialize object with default settings.
-   */
-  public ShapedLayerItem()
-  {
-    this(null);
-  }
-
-  /**
-   * Initialize object with the specified map location.
-   * @param location Map location
-   */
-  public ShapedLayerItem(Point location)
-  {
-    this(location, null);
-  }
-
-  /**
-   * Initialize object with a specific map location and an associated viewable object.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   */
-  public ShapedLayerItem(Point location, Viewable viewable)
-  {
-    this(location, viewable, null);
-  }
-
-  /**
-   * Initialize object with a specific map location, associated Viewable and an additional text message.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   * @param message An arbitrary text message
-   */
-  public ShapedLayerItem(Point location, Viewable viewable, String message)
-  {
-    this(location, viewable, message, message);
-  }
-
-  /**
-   * Initialize object with a specific map location, associated Viewable, an additional text message
-   * and a shape for the visual representation.
-   * @param location Map location
-   * @param viewable Associated Viewable object
-   * @param message An arbitrary text message
-   * @param tooltip A short text message shown as tooltip or menu item text
-   */
-  public ShapedLayerItem(Point location, Viewable viewable, String message, String tooltip)
-  {
-    this(location, viewable, message, tooltip, null);
-  }
 
   /**
    * Initialize object with a specific map location, associated Viewable, an additional text message
@@ -314,7 +263,7 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
   }
 
 
-  // Returns whether the mouse cursor is over the relevant part of the component
+  /** Returns whether the mouse cursor is over the relevant part of the component. */
   @Override
   protected boolean isMouseOver(Point pt)
   {
@@ -336,14 +285,13 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
     }
   }
 
-  // Recreates polygons
+  /** Recreates polygons. */
   private void updateShape()
   {
     label.repaint();
   }
 
-//--------------------- Begin Interface LayerItemListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="LayerItemListener">
   @Override
   public void layerItemChanged(LayerItemEvent event)
   {
@@ -351,12 +299,11 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
       updateShape();
     }
   }
-
-//--------------------- End Interface LayerItemListener ---------------------
+  //</editor-fold>
 
 //----------------------------- INNER CLASSES -----------------------------
 
-  // Extended JLabel to draw shapes on the fly
+  /** Extended JLabel to draw shapes on the fly. */
   private static class ShapeLabel extends JLabel
   {
     private final ShapedLayerItem parent;

--- a/src/org/infinity/gui/layeritem/ShapedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/ShapedLayerItem.java
@@ -35,33 +35,33 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
   private boolean stroked, filled;
 
   /**
-   * Initialize object with a specific map location, associated Viewable, an additional text message
+   * Initialize object with an associated Viewable, an additional text message
    * and a shape for the visual representation.
-   * @param location Map location
+   *
    * @param viewable Associated Viewable object
    * @param message An arbitrary text message
    * @param tooltip A short text message shown as tooltip or menu item text
    * @param shape The shape to display
    */
-  public ShapedLayerItem(Point location, Viewable viewable, String message, String tooltip, Shape shape)
+  public ShapedLayerItem(Viewable viewable, String message, String tooltip, Shape shape)
   {
-    this(location, viewable, message, tooltip, shape, null);
+    this(viewable, message, tooltip, shape, null);
   }
 
   /**
-   * Initialize object with a specific map location, associated Viewable, an additional text message,
+   * Initialize object with an associated Viewable, an additional text message,
    * a shape for the visual representation and a locical center position within the shape.
-   * @param location Map location
+   *
    * @param viewable Associated Viewable object
    * @param message An arbitrary text message
    * @param tooltip A short text message shown as tooltip or menu item text
    * @param shape The shape to display
    * @param center Logical center position within the shape
    */
-  public ShapedLayerItem(Point location, Viewable viewable, String message, String tooltip,
+  public ShapedLayerItem(Viewable viewable, String message, String tooltip,
                          Shape shape, Point center)
   {
-    super(location, viewable, message, tooltip);
+    super(viewable, message, tooltip);
     setLayout(new BorderLayout());
     label = new ShapeLabel(this);
     label.setHorizontalAlignment(SwingConstants.CENTER);

--- a/src/org/infinity/gui/layeritem/ShapedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/ShapedLayerItem.java
@@ -31,7 +31,7 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
   private final EnumMap<ItemState, Color> strokeColors = new EnumMap<>(ItemState.class);
   private final EnumMap<ItemState, BasicStroke> strokePen = new EnumMap<>(ItemState.class);
   private final EnumMap<ItemState, Color> fillColors = new EnumMap<>(ItemState.class);
-  private JLabel label;
+  private final JLabel label;
   private boolean stroked, filled;
 
   /**
@@ -39,36 +39,19 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
    * and a shape for the visual representation.
    *
    * @param viewable Associated Viewable object
-   * @param message An arbitrary text message
    * @param tooltip A short text message shown as tooltip or menu item text
    * @param shape The shape to display
    */
-  public ShapedLayerItem(Viewable viewable, String message, String tooltip, Shape shape)
+  public ShapedLayerItem(Viewable viewable, String tooltip, Shape shape)
   {
-    this(viewable, message, tooltip, shape, null);
-  }
-
-  /**
-   * Initialize object with an associated Viewable, an additional text message,
-   * a shape for the visual representation and a locical center position within the shape.
-   *
-   * @param viewable Associated Viewable object
-   * @param message An arbitrary text message
-   * @param tooltip A short text message shown as tooltip or menu item text
-   * @param shape The shape to display
-   * @param center Logical center position within the shape
-   */
-  public ShapedLayerItem(Viewable viewable, String message, String tooltip,
-                         Shape shape, Point center)
-  {
-    super(viewable, message, tooltip);
+    super(viewable, tooltip);
     setLayout(new BorderLayout());
     label = new ShapeLabel(this);
     label.setHorizontalAlignment(SwingConstants.CENTER);
     label.setVerticalAlignment(SwingConstants.CENTER);
     add(label, BorderLayout.CENTER);
     setShape(shape);
-    setCenterPosition(center);
+    setCenterPosition(null);
     addLayerItemListener(this);
   }
 

--- a/src/org/infinity/gui/layeritem/ShapedLayerItem.java
+++ b/src/org/infinity/gui/layeritem/ShapedLayerItem.java
@@ -25,12 +25,12 @@ import org.infinity.resource.Viewable;
  */
 public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListener
 {
-  private static final Color DefaultColor = Color.BLACK;
+  private static final Color DEFAULT_COLOR = Color.BLACK;
 
   private Shape shape;
-  private EnumMap<ItemState, Color> strokeColors;
-  private EnumMap<ItemState, BasicStroke> strokePen;
-  private EnumMap<ItemState, Color> fillColors;
+  private final EnumMap<ItemState, Color> strokeColors = new EnumMap<>(ItemState.class);
+  private final EnumMap<ItemState, BasicStroke> strokePen = new EnumMap<>(ItemState.class);
+  private final EnumMap<ItemState, Color> fillColors = new EnumMap<>(ItemState.class);
   private JLabel label;
   private boolean stroked, filled;
 
@@ -62,9 +62,6 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
                          Shape shape, Point center)
   {
     super(location, viewable, message, tooltip);
-    strokeColors = new EnumMap<ItemState, Color>(ItemState.class);
-    strokePen = new EnumMap<ItemState, BasicStroke>(ItemState.class);
-    fillColors = new EnumMap<ItemState, Color>(ItemState.class);
     setLayout(new BorderLayout());
     label = new ShapeLabel(this);
     label.setHorizontalAlignment(SwingConstants.CENTER);
@@ -73,15 +70,6 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
     setShape(shape);
     setCenterPosition(center);
     addLayerItemListener(this);
-  }
-
-  /**
-   * Returns the associated shape object.
-   * @return The associated shape object.
-   */
-  public Shape getShape()
-  {
-    return shape;
   }
 
   /**
@@ -132,7 +120,7 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
         if (strokeColors.containsKey(ItemState.NORMAL))
           return strokeColors.get(ItemState.NORMAL);
     }
-    return DefaultColor;
+    return DEFAULT_COLOR;
   }
 
   /**
@@ -201,7 +189,7 @@ public class ShapedLayerItem extends AbstractLayerItem implements LayerItemListe
         if (fillColors.containsKey(ItemState.NORMAL))
           return fillColors.get(ItemState.NORMAL);
     }
-    return DefaultColor;
+    return DEFAULT_COLOR;
   }
 
   /**

--- a/src/org/infinity/resource/are/viewer/AreaViewer.java
+++ b/src/org/infinity/resource/are/viewer/AreaViewer.java
@@ -2696,7 +2696,7 @@ public class AreaViewer extends ChildFrame
             }
 
             if (wed[ViewerConstants.AREA_DAY] != null) {
-              wedItem[ViewerConstants.AREA_DAY] = new IconLayerItem(new Point(), wed[ViewerConstants.AREA_DAY],
+              wedItem[ViewerConstants.AREA_DAY] = new IconLayerItem(wed[ViewerConstants.AREA_DAY],
                                                                     wed[ViewerConstants.AREA_DAY].getName());
               wedItem[ViewerConstants.AREA_DAY].setVisible(false);
             }
@@ -2719,7 +2719,7 @@ public class AreaViewer extends ChildFrame
             }
 
             if (wed[ViewerConstants.AREA_NIGHT] != null) {
-              wedItem[ViewerConstants.AREA_NIGHT] = new IconLayerItem(new Point(), wed[ViewerConstants.AREA_NIGHT],
+              wedItem[ViewerConstants.AREA_NIGHT] = new IconLayerItem(wed[ViewerConstants.AREA_NIGHT],
                                                                       wed[ViewerConstants.AREA_NIGHT].getName());
               wedItem[ViewerConstants.AREA_NIGHT].setVisible(false);
             }
@@ -2833,18 +2833,18 @@ public class AreaViewer extends ChildFrame
         }
 
         // initializing pseudo layer items
-        areItem = new IconLayerItem(new Point(), are, are.getName());
+        areItem = new IconLayerItem(are, are.getName());
         areItem.setVisible(false);
 
         Song song = (Song)are.getAttribute(Song.ARE_SONGS);
         if (song != null) {
-          songItem = new IconLayerItem(new Point(), song, "");
+          songItem = new IconLayerItem(song, "");
           songItem.setVisible(false);
         }
 
         RestSpawn rest = (RestSpawn)are.getAttribute(RestSpawn.ARE_RESTSPAWN);
         if (rest != null) {
-          restItem = new IconLayerItem(new Point(), rest, "");
+          restItem = new IconLayerItem(rest, "");
         }
 
         // getting associated WED resources

--- a/src/org/infinity/resource/are/viewer/AreaViewer.java
+++ b/src/org/infinity/resource/are/viewer/AreaViewer.java
@@ -2365,7 +2365,7 @@ public class AreaViewer extends ChildFrame
       if (event.getSource() instanceof AbstractLayerItem) {
         AbstractLayerItem item = (AbstractLayerItem)event.getSource();
         if (event.isHighlighted()) {
-          setInfoText(item.getMessage());
+          setInfoText(item.getToolTipText());
         } else {
           setInfoText(null);
         }

--- a/src/org/infinity/resource/are/viewer/AreaViewer.java
+++ b/src/org/infinity/resource/are/viewer/AreaViewer.java
@@ -1186,8 +1186,8 @@ public class AreaViewer extends ChildFrame
     Rectangle view = spCanvas.getViewport().getViewRect();
     vpMapCenter.x = (view.width > mapWidth) ? mapWidth / 2 : view.x + (view.width / 2);
     vpMapCenter.y = (view.height > mapHeight) ? mapHeight / 2 : view.y + (view.height / 2);
-    vpMapCenter.x = (int)((double)vpMapCenter.x / getZoomFactor());
-    vpMapCenter.y = (int)((double)vpMapCenter.y / getZoomFactor());
+    vpMapCenter.x = (int)(vpMapCenter.x / getZoomFactor());
+    vpMapCenter.y = (int)(vpMapCenter.y / getZoomFactor());
   }
 
   /** Attempts to re-center the last known center coordinate in the current viewport. */
@@ -1196,8 +1196,8 @@ public class AreaViewer extends ChildFrame
     if (vpMapCenter != null) {
       int mapWidth = rcCanvas.getMapWidth(true);
       int mapHeight = rcCanvas.getMapHeight(true);
-      int centerX = (int)((double)vpMapCenter.x * getZoomFactor());
-      int centerY = (int)((double)vpMapCenter.y * getZoomFactor());
+      final int centerX = (int)(vpMapCenter.x * getZoomFactor());
+      final int centerY = (int)(vpMapCenter.y * getZoomFactor());
       JViewport vp = spCanvas.getViewport();
       Rectangle view = vp.getViewRect();
       Point newView = new Point(view.getLocation());
@@ -1221,8 +1221,8 @@ public class AreaViewer extends ChildFrame
   private Point canvasToMapCoordinates(Point coords)
   {
     if (coords != null) {
-      coords.x = (int)((double)coords.x / getZoomFactor());
-      coords.y = (int)((double)coords.y / getZoomFactor());
+      coords.x = (int)(coords.x / getZoomFactor());
+      coords.y = (int)(coords.y / getZoomFactor());
     }
     return coords;
   }
@@ -1469,13 +1469,13 @@ public class AreaViewer extends ChildFrame
   private Window getViewerWindow(AbstractStruct as)
   {
     if (as != null) {
-      if (as.getViewer() != null && as.getViewer().getParent() != null) {
+      final StructViewer sv = as.getViewer();
+      if (sv != null && sv.getParent() != null) {
         // Determining whether the structure is associated with any open NearInfinity window
-        StructViewer sv = as.getViewer();
         Component[] list = sv.getParent().getComponents();
         if (list != null) {
-          for (int i = 0; i < list.length; i++) {
-            if (list[i] == sv) {
+          for (final Component comp : list) {
+            if (comp == sv) {
               Component c = sv.getParent();
               while (c != null) {
                 if (c instanceof Window) {
@@ -1559,9 +1559,8 @@ public class AreaViewer extends ChildFrame
     if (layerManager != null) {
       List<? extends LayerObject> list = layerManager.getLayerObjects(LayerType.ANIMATION);
       if (list != null) {
-        for (int i = 0, size = list.size(); i < size; i++) {
-          LayerObjectAnimation obj = (LayerObjectAnimation)list.get(i);
-          obj.setLighting(visualState);
+        for (final LayerObject obj : list) {
+          ((LayerObjectAnimation)obj).setLighting(visualState);
         }
       }
     }
@@ -1682,8 +1681,8 @@ public class AreaViewer extends ChildFrame
     if (layer != null && layerManager != null) {
       List<? extends LayerObject> list = layerManager.getLayerObjects(Settings.stackingToLayer(layer));
       if (list != null) {
-        for (int i = 0, size = list.size(); i < size; i++) {
-          removeLayerItem(layer, list.get(i));
+        for (final LayerObject obj : list) {
+          removeLayerItem(layer, obj);
         }
       }
     }
@@ -1749,8 +1748,8 @@ public class AreaViewer extends ChildFrame
   /** Updates all items of all available layers. */
   private void updateLayerItems()
   {
-    for (int i = 0, lloSize = Settings.ListLayerOrder.size(); i < lloSize; i++) {
-      updateLayerItems(Settings.ListLayerOrder.get(i));
+    for (final LayerStackingType type : Settings.ListLayerOrder) {
+      updateLayerItems(type);
     }
   }
 
@@ -1760,8 +1759,8 @@ public class AreaViewer extends ChildFrame
     if (layer != null && layerManager != null) {
       List<? extends LayerObject> list = layerManager.getLayerObjects(Settings.stackingToLayer(layer));
       if (list != null) {
-        for (int i = 0, size = list.size(); i < size; i++) {
-          updateLayerItem(list.get(i));
+        for (final LayerObject obj : list) {
+          updateLayerItem(obj);
         }
       }
     }
@@ -1865,7 +1864,6 @@ public class AreaViewer extends ChildFrame
     if (vs.settingsChanged()) {
       applySettings();
     }
-    vs = null;
   }
 
   /** Applies current global area viewer settings. */
@@ -2607,7 +2605,7 @@ public class AreaViewer extends ChildFrame
                                                     optionType, JOptionPane.WARNING_MESSAGE, null,
                                                     options[optionIndex], options[optionIndex][0]);
           if (result == 0) {
-            ResourceFactory.saveResource((Resource)wed[dayNight], parent);
+            ResourceFactory.saveResource(wed[dayNight], parent);
           }
           if (result != 2) {
             wed[dayNight].setStructChanged(false);
@@ -2810,7 +2808,7 @@ public class AreaViewer extends ChildFrame
   /** Defines a panel providing controls for setting day times (either by hour or by general day time). */
   private static final class DayTimePanel extends JPanel implements ActionListener, ChangeListener
   {
-    private final List<ChangeListener> listeners = new ArrayList<ChangeListener>();
+    private final List<ChangeListener> listeners = new ArrayList<>();
     private final JRadioButton[] rbDayTime = new JRadioButton[3];
     private final ButtonPopupWindow bpwDayTime;
 
@@ -2883,15 +2881,10 @@ public class AreaViewer extends ChildFrame
     @SuppressWarnings("unused")
     public ChangeListener[] getChangeListeners()
     {
-      ChangeListener[] retVal = new ChangeListener[listeners.size()];
-      for (int i = 0, size = listeners.size(); i < size; i++) {
-        retVal[i] = listeners.get(i);
-      }
-      return retVal;
+      return listeners.toArray(new ChangeListener[listeners.size()]);
     }
 
-    // --------------------- Begin Interface ActionListener ---------------------
-
+    //<editor-fold defaultstate="collapsed" desc="ActionListener">
     @Override
     public void actionPerformed(ActionEvent event)
     {
@@ -2905,11 +2898,9 @@ public class AreaViewer extends ChildFrame
         }
       }
     }
+    //</editor-fold>
 
-    // --------------------- End Interface ActionListener ---------------------
-
-    // --------------------- Begin Interface ChangeListener ---------------------
-
+    //<editor-fold defaultstate="collapsed" desc="ChangeListener">
     @Override
     public void stateChanged(ChangeEvent event)
     {
@@ -2924,15 +2915,14 @@ public class AreaViewer extends ChildFrame
         }
       }
     }
-
-    // --------------------- End Interface ChangeListener ---------------------
+    //</editor-fold>
 
     /** Fires a stateChanged event for all registered listeners. */
     private void fireStateChanged()
     {
       ChangeEvent event = new ChangeEvent(this);
-      for (int i = 0, size = listeners.size(); i < size; i++) {
-        listeners.get(i).stateChanged(event);
+      for (final ChangeListener l : listeners) {
+        l.stateChanged(event);
       }
     }
 
@@ -2964,9 +2954,9 @@ public class AreaViewer extends ChildFrame
       rbDayTime[ViewerConstants.LIGHTING_NIGHT].addActionListener(this);
       bg.add(rbDayTime[ViewerConstants.LIGHTING_NIGHT]);
 
-      Hashtable<Integer, JLabel> table = new Hashtable<Integer, JLabel>();
+      final Hashtable<Integer, JLabel> table = new Hashtable<>();
       for (int i = 0; i < 24; i += 4) {
-        table.put(Integer.valueOf(i), new JLabel(String.format("%02d:00", i)));
+        table.put(i, new JLabel(String.format("%02d:00", i)));
       }
       sHours = new JSlider(0, 23, hour);
       sHours.addChangeListener(this);
@@ -3017,13 +3007,6 @@ public class AreaViewer extends ChildFrame
   /** Adds support for visual components in JTree instances. */
   private static class ComponentTreeCellRenderer extends DefaultTreeCellRenderer
   {
-    public ComponentTreeCellRenderer()
-    {
-      super();
-    }
-
-    // --------------------- Begin Interface TreeCellRenderer ---------------------
-
     @Override
     public Component getTreeCellRendererComponent(JTree tree, Object value, boolean selected,
                                                   boolean expanded, boolean leaf, int row,
@@ -3031,16 +3014,11 @@ public class AreaViewer extends ChildFrame
       if (value instanceof DefaultMutableTreeNode) {
         value = ((DefaultMutableTreeNode)value).getUserObject();
       }
-      Component c = null;
       if (value instanceof Component) {
-        c = (Component)value;
-      } else {
-        c = new JLabel((value != null) ? value.toString() : "");
+        return (Component)value;
       }
-      return c;
+      return new JLabel((value != null) ? value.toString() : "");
     }
-
-    // --------------------- End Interface TreeCellRenderer ---------------------
   }
 
 
@@ -3051,8 +3029,6 @@ public class AreaViewer extends ChildFrame
     {
       super(tree, renderer);
     }
-
-    // --------------------- Begin Interface TreeCellEditor ---------------------
 
     @Override
     public boolean isCellEditable(EventObject event)
@@ -3066,7 +3042,5 @@ public class AreaViewer extends ChildFrame
     {
       return renderer.getTreeCellRendererComponent(tree, value, isSelected, expanded, leaf, row, true);
     }
-
-    // --------------------- End Interface TreeCellEditor ---------------------
   }
 }

--- a/src/org/infinity/resource/are/viewer/AreaViewer.java
+++ b/src/org/infinity/resource/are/viewer/AreaViewer.java
@@ -192,14 +192,14 @@ public class AreaViewer extends ChildFrame
     return false;
   }
 
-  // Returns the general day time (day/twilight/night)
+  /** Returns the general day time (day/twilight/night). */
   private static int getDayTime()
   {
     return ViewerConstants.getDayTime(Settings.TimeOfDay);
   }
 
 
-  // Returns the currently selected day time in hours
+  /** Returns the currently selected day time in hours. */
   private static int getHour()
   {
     return Settings.TimeOfDay;
@@ -282,7 +282,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // initialize GUI and structures
+  /** initialize GUI and structures. */
   private void init()
   {
     initialized = false;
@@ -685,14 +685,14 @@ public class AreaViewer extends ChildFrame
     initialized = true;
   }
 
-  // Returns whether area viewer is still being initialized
+  /** Returns whether area viewer is still being initialized. */
   private boolean isInitialized()
   {
     return initialized;
   }
 
 
-  // Sets the state of all GUI components and their associated actions
+  /** Sets the state of all GUI components and their associated actions. */
   private void initGuiSettings()
   {
     Settings.loadSettings(false);
@@ -788,7 +788,7 @@ public class AreaViewer extends ChildFrame
     applySettings();
   }
 
-  // Updates the window title
+  /** Updates the window title. */
   private void updateWindowTitle()
   {
     int zoom = (int)Math.round(getZoomFactor()*100.0);
@@ -824,7 +824,7 @@ public class AreaViewer extends ChildFrame
                            windowTitle, getHour(), dayNight, scheduleState, doorState, overlayState, gridState, zoom));
   }
 
-  // Sets day time to a specific hour (0..23).
+  /** Sets day time to a specific hour (0..23). */
   private void setHour(int hour)
   {
     while (hour < 0) { hour += 24; }
@@ -840,7 +840,7 @@ public class AreaViewer extends ChildFrame
     updateScheduledItems();
   }
 
-  // Returns the currently selected ARE resource
+  /** Returns the currently selected ARE resource. */
   private AreResource getCurrentAre()
   {
     if (map != null) {
@@ -850,7 +850,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Returns the currently selected WED resource (day/night)
+  /** Returns the currently selected WED resource (day/night). */
   private WedResource getCurrentWed()
   {
     if (map != null) {
@@ -859,7 +859,7 @@ public class AreaViewer extends ChildFrame
     return null;
   }
 
-  // Returns the currently selected WED resource (day/night)
+  /** Returns the currently selected WED resource (day/night). */
   private int getCurrentWedIndex()
   {
     if (map != null) {
@@ -870,13 +870,13 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Returns the currently selected visual state (day/twilight/night)
+  /** Returns the currently selected visual state (day/twilight/night). */
   private int getVisualState()
   {
     return getDayTime();
   }
 
-  // Set the lighting condition of the current map (day/twilight/night) and real background animations
+  /** Set the lighting condition of the current map (day/twilight/night) and real background animations. */
   private synchronized void setVisualState(int hour)
   {
     while (hour < 0) { hour += 24; }
@@ -934,7 +934,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Returns whether map dragging is enabled; updates current and previous mouse positions
+  /** Returns whether map dragging is enabled; updates current and previous mouse positions. */
   private boolean isMapDragging(Point mousePos)
   {
     if (bMapDragging && mousePos != null && !mapDraggingPos.equals(mousePos)) {
@@ -944,7 +944,7 @@ public class AreaViewer extends ChildFrame
     return bMapDragging;
   }
 
-  // Enables/disables map dragging mode (set mouse cursor, global state and current mouse position)
+  /** Enables/disables map dragging mode (set mouse cursor, global state and current mouse position). */
   private void setMapDraggingEnabled(boolean enable, Point mousePos)
   {
     if (bMapDragging != enable) {
@@ -959,7 +959,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Returns the current or previous mouse position
+  /** Returns the current or previous mouse position. */
   private Point getMapDraggingDistance()
   {
     Point pDelta = new Point();
@@ -970,7 +970,7 @@ public class AreaViewer extends ChildFrame
     return pDelta;
   }
 
-  // Updates the map portion displayed in the viewport
+  /** Updates the map portion displayed in the viewport. */
   private void moveMapViewport()
   {
     if (!mapDraggingPosStart.equals(mapDraggingPos)) {
@@ -995,13 +995,13 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Returns whether closed door state is active
+  /** Returns whether closed door state is active. */
   private boolean isDoorStateClosed()
   {
     return Settings.DrawClosed;
   }
 
-  // Draw opened/closed state of doors (affects map tiles, door layer and door poly layer)
+  /** Draw opened/closed state of doors (affects map tiles, door layer and door poly layer). */
   private void setDoorState(boolean closed)
   {
     Settings.DrawClosed = closed;
@@ -1010,7 +1010,7 @@ public class AreaViewer extends ChildFrame
     updateWindowTitle();
   }
 
-  // Called by setDoorState(): sets door state map tiles
+  /** Called by setDoorState(): sets door state map tiles. */
   private void setDoorStateMap(boolean closed)
   {
     if (rcCanvas != null) {
@@ -1018,7 +1018,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Called by setDoorState(): sets door state in door layer and door poly layer
+  /** Called by setDoorState(): sets door state in door layer and door poly layer. */
   private void setDoorStateLayers(boolean closed)
   {
     if (layerManager != null) {
@@ -1027,13 +1027,13 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Returns whether tile grid on map has been enabled
+  /** Returns whether tile grid on map has been enabled. */
   private boolean isTileGridEnabled()
   {
     return Settings.DrawGrid;
   }
 
-  // Enable/disable tile grid on map
+  /** Enable/disable tile grid on map. */
   private void setTileGridEnabled(boolean enable)
   {
     Settings.DrawGrid = enable;
@@ -1044,13 +1044,13 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Returns whether overlays are enabled (considers both internal overlay flag and whether the map contains overlays)
+  /** Returns whether overlays are enabled (considers both internal overlay flag and whether the map contains overlays). */
   private boolean isOverlaysEnabled()
   {
     return Settings.DrawOverlays;
   }
 
-  // Enable/disable overlays
+  /** Enable/disable overlays. */
   private void setOverlaysEnabled(boolean enable)
   {
     Settings.DrawOverlays = enable;
@@ -1061,7 +1061,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Returns whether overlays are animated
+  /** Returns whether overlays are animated. */
   private boolean isOverlaysAnimated()
   {
     if (timerOverlays != null) {
@@ -1071,7 +1071,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Activate/deactivate overlay animations
+  /** Activate/deactivate overlay animations. */
   private void setOverlaysAnimated(boolean animate)
   {
     if (timerOverlays != null) {
@@ -1084,7 +1084,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Advances animated overlays by one frame
+  /** Advances animated overlays by one frame. */
   private synchronized void advanceOverlayAnimation()
   {
     if (rcCanvas != null) {
@@ -1093,14 +1093,14 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Returns whether layer items should be included when exporting map as graphics
+  /** Returns whether layer items should be included when exporting map as graphics. */
   private boolean isExportLayersEnabled()
   {
     return Settings.ExportLayers;
   }
 
 
-  // Returns the currently used zoom factor of the canvas map
+  /** Returns the currently used zoom factor of the canvas map. */
   private double getZoomFactor()
   {
     if (rcCanvas != null) {
@@ -1110,7 +1110,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Sets a new zoom level to the map and associated structures
+  /** Sets a new zoom level to the map and associated structures. */
   private void setZoomFactor(double zoomFactor, double fallbackZoomFactor)
   {
     updateViewpointCenter();
@@ -1164,7 +1164,7 @@ public class AreaViewer extends ChildFrame
     updateWindowTitle();
   }
 
-  // Handles manual input of zoom factor (in percent)
+  /** Handles manual input of zoom factor (in percent). */
   private double getCustomZoomFactor(double defaultZoom)
   {
     String defInput = Integer.toString((int)Math.round(defaultZoom * 100.0));
@@ -1193,14 +1193,14 @@ public class AreaViewer extends ChildFrame
     return defaultZoom;
   }
 
-  // Returns whether auto-fit has been selected
+  /** Returns whether auto-fit has been selected. */
   private boolean isAutoZoom()
   {
     return (Settings.ZoomFactor == Settings.ZoomFactorAuto);
   }
 
 
-  // Updates the map coordinate at the center of the current viewport
+  /** Updates the map coordinate at the center of the current viewport. */
   private void updateViewpointCenter()
   {
     if (vpMapCenter == null) {
@@ -1215,7 +1215,7 @@ public class AreaViewer extends ChildFrame
     vpMapCenter.y = (int)((double)vpMapCenter.y / getZoomFactor());
   }
 
-  // Attempts to re-center the last known center coordinate in the current viewport
+  /** Attempts to re-center the last known center coordinate in the current viewport. */
   private void setViewpointCenter()
   {
     if (vpMapCenter != null) {
@@ -1242,7 +1242,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Converts canvas coordinates into actual map coordinates
+  /** Converts canvas coordinates into actual map coordinates. */
   private Point canvasToMapCoordinates(Point coords)
   {
     if (coords != null) {
@@ -1252,7 +1252,7 @@ public class AreaViewer extends ChildFrame
     return coords;
   }
 
-  // Updates the map coordinates pointed to by the current cursor position
+  /** Updates the map coordinates pointed to by the current cursor position. */
   private void showMapCoordinates(Point coords)
   {
     if (coords != null) {
@@ -1269,7 +1269,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Shows a description in the info box
+  /** Shows a description in the info box. */
   private void setInfoText(String text)
   {
     if (taInfo != null) {
@@ -1282,7 +1282,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Creates and displays a popup menu containing the items located at the specified location
+  /** Creates and displays a popup menu containing the items located at the specified location. */
   private boolean updateItemPopup(Point canvasCoords)
   {
     final int MaxLen = 32;    // max. length of a menuitem text
@@ -1365,7 +1365,7 @@ public class AreaViewer extends ChildFrame
     return false;
   }
 
-  // Shows a popup menu containing layer items located at the current position if available
+  /** Shows a popup menu containing layer items located at the current position if available. */
   private void showItemPopup(MouseEvent event)
   {
     if (event != null && event.isPopupTrigger()) {
@@ -1388,7 +1388,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Updates all available layer items
+  /** Updates all available layer items. */
   private void reloadLayers()
   {
     rcCanvas.reload(true);
@@ -1397,7 +1397,7 @@ public class AreaViewer extends ChildFrame
     applySettings();
   }
 
-  // Updates ARE-related layer items
+  /** Updates ARE-related layer items. */
   private void reloadAreLayers(boolean order)
   {
     if (layerManager != null) {
@@ -1424,7 +1424,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Updates WED-related layer items
+  /** Updates WED-related layer items. */
   private void reloadWedLayers(boolean order)
   {
     if (layerManager != null) {
@@ -1446,7 +1446,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Returns the identifier of the specified layer checkbox, or null on error
+  /** Returns the identifier of the specified layer checkbox, or null on error. */
   private LayerType getLayerType(JCheckBox cb)
   {
     if (cb != null) {
@@ -1459,7 +1459,7 @@ public class AreaViewer extends ChildFrame
     return null;
   }
 
-  // Returns whether the specified layer is visible (by layer)
+  /** Returns whether the specified layer is visible (by layer). */
   private boolean isLayerEnabled(LayerType layer)
   {
     if (layer != null) {
@@ -1469,13 +1469,13 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Returns whether the specified layer is visible (by stacked layer)
+  /** Returns whether the specified layer is visible (by stacked layer). */
   private boolean isLayerEnabled(LayerStackingType layer)
   {
     return isLayerEnabled(Settings.stackingToLayer(layer));
   }
 
-  // Opens a viewable instance associated with the specified layer item
+  /** Opens a viewable instance associated with the specified layer item. */
   private void showTable(AbstractLayerItem item)
   {
     if (item != null) {
@@ -1490,9 +1490,12 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Attempts to find the Window instance containing the viewer of the specified AbstractStruct object
-  // If it cannot find one, it creates and returns a new one.
-  // If all fails, it returns the NearInfinity instance.
+  /**
+   * Attempts to find the Window instance containing the viewer of the specified
+   * AbstractStruct object.
+   * If it cannot find one, it creates and returns a new one.
+   * If all fails, it returns the NearInfinity instance.
+   */
   private Window getViewerWindow(AbstractStruct as)
   {
     if (as != null) {
@@ -1522,7 +1525,7 @@ public class AreaViewer extends ChildFrame
     return NearInfinity.getInstance();
   }
 
-  // Updates the visibility state of minimaps (search/height/light maps)
+  /** Updates the visibility state of minimaps (search/height/light maps). */
   private void updateMiniMap()
   {
     if (map != null) {
@@ -1544,7 +1547,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Sets visibility state of scheduled layer items depending on current day time
+  /** Sets visibility state of scheduled layer items depending on current day time. */
   private void updateScheduledItems()
   {
     if (layerManager != null) {
@@ -1555,14 +1558,14 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Applying time schedule settings to layer items
+  /** Applying time schedule settings to layer items. */
   private void updateTimeSchedules()
   {
     layerManager.setScheduleEnabled(Settings.EnableSchedules);
     updateWindowTitle();
   }
 
-  // Updates the state of the ambient sound range checkbox and associated functionality
+  /** Updates the state of the ambient sound range checkbox and associated functionality. */
   private void updateAmbientRange()
   {
     if (layerManager != null) {
@@ -1582,7 +1585,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Applies the specified lighting condition to real animation items
+  /** Applies the specified lighting condition to real animation items. */
   private void updateRealAnimationsLighting(int visualState)
   {
     if (layerManager != null) {
@@ -1596,7 +1599,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Updates the state of real animation checkboxes and their associated functionality
+  /** Updates the state of real animation checkboxes and their associated functionality. */
   private void updateRealAnimation()
   {
     if (layerManager != null) {
@@ -1636,7 +1639,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Show/hide items of the specified layer
+  /** Show/hide items of the specified layer. */
   private void showLayer(LayerType layer, boolean visible)
   {
     if (layer != null && layerManager != null) {
@@ -1652,7 +1655,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Adds items of all available layers to the map canvas.
+  /** Adds items of all available layers to the map canvas. */
   private void addLayerItems()
   {
     for (int i = 0, lloSize = Settings.ListLayerOrder.size(); i < lloSize; i++) {
@@ -1660,7 +1663,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Adds items of the specified layer to the map canvas.
+  /** Adds items of the specified layer to the map canvas. */
   private void addLayerItems(LayerStackingType layer)
   {
     if (layer != null && layerManager != null) {
@@ -1673,7 +1676,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Adds items of a single layer object to the map canvas.
+  /** Adds items of a single layer object to the map canvas. */
   private void addLayerItem(LayerStackingType layer, LayerObject object)
   {
     if (object != null) {
@@ -1700,7 +1703,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Removes all items of all available layers.
+  /** Removes all items of all available layers. */
   private void removeLayerItems()
   {
     for (int i = 0, lloSize = Settings.ListLayerOrder.size(); i < lloSize; i++) {
@@ -1708,7 +1711,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Removes all items of the specified layer.
+  /** Removes all items of the specified layer. */
   private void removeLayerItems(LayerStackingType layer)
   {
     if (layer != null && layerManager != null) {
@@ -1721,7 +1724,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Removes items of a single layer object from the map canvas.
+  /** Removes items of a single layer object from the map canvas. */
   private void removeLayerItem(LayerStackingType layer, LayerObject object)
   {
     if (object != null) {
@@ -1745,7 +1748,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Re-orders layer items on the map using listLayer for determining priorities.
+  /** Re-orders layer items on the map using listLayer for determining priorities. */
   private void orderLayerItems()
   {
     if (layerManager != null) {
@@ -1786,7 +1789,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Updates all items of all available layers.
+  /** Updates all items of all available layers. */
   private void updateLayerItems()
   {
     for (int i = 0, lloSize = Settings.ListLayerOrder.size(); i < lloSize; i++) {
@@ -1794,7 +1797,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Updates the map locations of the items in the specified layer.
+  /** Updates the map locations of the items in the specified layer. */
   private void updateLayerItems(LayerStackingType layer)
   {
     if (layer != null && layerManager != null) {
@@ -1807,7 +1810,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Updates the map locations of the items in the specified layer object.
+  /** Updates the map locations of the items in the specified layer object. */
   private void updateLayerItem(LayerObject object)
   {
     if (object != null) {
@@ -1815,13 +1818,13 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Update toolbar-related stuff
+  /** Update toolbar-related stuff. */
   private void updateToolBarButtons()
   {
     tbWed.setToolTipText(String.format("Edit WED structure (%s)", getCurrentWed().getName()));
   }
 
-  // Initializes a new progress monitor instance
+  /** Initializes a new progress monitor instance. */
   private void initProgressMonitor(Component parent, String msg, String note, int maxProgress,
                                    int msDecide, int msWait)
   {
@@ -1837,7 +1840,7 @@ public class AreaViewer extends ChildFrame
     progress.setProgress(pmCur);
   }
 
-  // Closes the current progress monitor
+  /** Closes the current progress monitor. */
   private void releaseProgressMonitor()
   {
     if (progress != null) {
@@ -1846,7 +1849,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Advances the current progress monitor by one and adds the specified note
+  /** Advances the current progress monitor by one and adds the specified note. */
   private void advanceProgressMonitor(String note)
   {
     if (progress != null) {
@@ -1860,14 +1863,14 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Returns whether a progress monitor is currently active
+  /** Returns whether a progress monitor is currently active. */
   private boolean isProgressMonitorActive()
   {
     return progress != null;
   }
 
 
-  // Updates the tree node containing the specified component
+  /** Updates the tree node containing the specified component. */
   private void updateTreeNode(Component c)
   {
     if (treeControls != null) {
@@ -1881,7 +1884,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Recursive function to find the node containing c
+  /** Recursive function to find the node containing c. */
   private TreeNode getTreeNodeOf(TreeNode node, Component c)
   {
     if (node != null && node instanceof DefaultMutableTreeNode && c != null) {
@@ -1898,7 +1901,7 @@ public class AreaViewer extends ChildFrame
     return null;
   }
 
-  // Shows settings dialog and updates respective controls if needed
+  /** Shows settings dialog and updates respective controls if needed. */
   private void viewSettings()
   {
     SettingsDialog vs = new SettingsDialog(this);
@@ -1908,7 +1911,7 @@ public class AreaViewer extends ChildFrame
     vs = null;
   }
 
-  // Applies current global area viewer settings
+  /** Applies current global area viewer settings. */
   private void applySettings()
   {
     // applying layer stacking order
@@ -1966,7 +1969,7 @@ public class AreaViewer extends ChildFrame
     }
   }
 
-  // Exports the current map state to PNG
+  /** Exports the current map state to PNG. */
   private void exportMap()
   {
     WindowBlocker.blockWindow(this, true);
@@ -2026,7 +2029,7 @@ public class AreaViewer extends ChildFrame
 
 //----------------------------- INNER CLASSES -----------------------------
 
-  // Handles all events of the viewer
+  /** Handles all events of the viewer. */
   private class Listeners implements ActionListener, MouseListener, MouseMotionListener, MouseWheelListener,
                                      ChangeListener, TilesetChangeListener, PropertyChangeListener,
                                      LayerItemListener, ComponentListener, TreeExpansionListener
@@ -2541,7 +2544,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Handles map-specific properties
+  /** Handles map-specific properties. */
   private static class Map
   {
     private final Window parent;
@@ -2773,13 +2776,13 @@ public class AreaViewer extends ChildFrame
       }
     }
 
-    // Returns the pseudo layer item for the AreResource structure
+    /** Returns the pseudo layer item for the AreResource structure. */
     public AbstractLayerItem getAreItem()
     {
       return areItem;
     }
 
-    // Returns the pseudo layer item for the WedResource structure of the selected day time
+    /** Returns the pseudo layer item for the WedResource structure of the selected day time. */
     public AbstractLayerItem getWedItem(int dayNight)
     {
       if (dayNight == ViewerConstants.AREA_NIGHT) {
@@ -2789,25 +2792,25 @@ public class AreaViewer extends ChildFrame
       }
     }
 
-    // Returns the pseudo layer item for the ARE's song structure
+    /** Returns the pseudo layer item for the ARE's song structure. */
     public AbstractLayerItem getSongItem()
     {
       return songItem;
     }
 
-    // Returns the pseudo layer item for the ARE's rest encounter structure
+    /** Returns the pseudo layer item for the ARE's rest encounter structure. */
     public AbstractLayerItem getRestItem()
     {
       return restItem;
     }
 
-    // Returns whether the current map supports day/twilight/night settings
+    /** Returns whether the current map supports day/twilight/night settings. */
     public boolean hasDayNight()
     {
       return hasDayNight;
     }
 
-    // Returns true if the current map has separate WEDs for day/night
+    /** Returns true if the current map has separate WEDs for day/night. */
     public boolean hasExtendedNight()
     {
       return hasExtendedNight;
@@ -2853,7 +2856,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Defines a panel providing controls for setting day times (either by hour or by general day time)
+  /** Defines a panel providing controls for setting day times (either by hour or by general day time). */
   private static final class DayTimePanel extends JPanel implements ActionListener, ChangeListener
   {
     private final List<ChangeListener> listeners = new ArrayList<ChangeListener>();
@@ -2862,7 +2865,7 @@ public class AreaViewer extends ChildFrame
 
     private JSlider sHours;
 
-    // Creates and returns a string describing the time for display on the parent button
+    /** Creates and returns a string describing the time for display on the parent button. */
     public static String getButtonText(int hour)
     {
       final String[] dayTime = new String[]{"Day", "Twilight", "Night"};
@@ -2973,7 +2976,7 @@ public class AreaViewer extends ChildFrame
 
     // --------------------- End Interface ChangeListener ---------------------
 
-    // Fires a stateChanged event for all registered listeners
+    /** Fires a stateChanged event for all registered listeners. */
     private void fireStateChanged()
     {
       ChangeEvent event = new ChangeEvent(this);
@@ -2982,7 +2985,7 @@ public class AreaViewer extends ChildFrame
       }
     }
 
-    // Updates the text of the parent button
+    /** Updates the text of the parent button. */
     private void updateButton()
     {
       if (bpwDayTime != null) {
@@ -3060,7 +3063,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Adds support for visual components in JTree instances
+  /** Adds support for visual components in JTree instances. */
   private static class ComponentTreeCellRenderer extends DefaultTreeCellRenderer
   {
     public ComponentTreeCellRenderer()
@@ -3090,7 +3093,7 @@ public class AreaViewer extends ChildFrame
   }
 
 
-  // Adds support for editable visual components in JTree instances
+  /** Adds support for editable visual components in JTree instances. */
   private static class ComponentTreeCellEditor extends DefaultTreeCellEditor
   {
     public ComponentTreeCellEditor(JTree tree, ComponentTreeCellRenderer renderer)

--- a/src/org/infinity/resource/are/viewer/AreaViewer.java
+++ b/src/org/infinity/resource/are/viewer/AreaViewer.java
@@ -1334,16 +1334,16 @@ public class AreaViewer extends ChildFrame
                   }
                   sb.append(": ");
                   int lenPrefix = sb.length();
-                  int lenMsg = items[k].getQuickInfo().length();
+                  int lenMsg = items[k].getToolTipText().length();
                   if (lenPrefix + lenMsg > MaxLen) {
-                    sb.append(items[k].getQuickInfo().substring(0, MaxLen - lenPrefix));
+                    sb.append(items[k].getToolTipText().substring(0, MaxLen - lenPrefix));
                     sb.append("...");
                   } else {
-                    sb.append(items[k].getQuickInfo());
+                    sb.append(items[k].getToolTipText());
                   }
                   DataMenuItem dmi = new DataMenuItem(sb.toString(), null, items[k]);
                   if (lenPrefix + lenMsg > MaxLen) {
-                    dmi.setToolTipText(items[k].getQuickInfo());
+                    dmi.setToolTipText(items[k].getToolTipText());
                   }
                   dmi.addActionListener(getListeners());
                   menuItems.add(dmi);

--- a/src/org/infinity/resource/are/viewer/BasicLayer.java
+++ b/src/org/infinity/resource/are/viewer/BasicLayer.java
@@ -113,7 +113,7 @@ public abstract class BasicLayer<E extends LayerObject, R extends AbstractStruct
 
   /**
    * Returns the list of layer objects for direct manipulation.
-   * @return List of layer objects.
+   * @return List of layer objects. Never {@code null}
    */
   public List<E> getLayerObjects()
   {
@@ -320,18 +320,18 @@ public abstract class BasicLayer<E extends LayerObject, R extends AbstractStruct
     return fields;
   }
 
-  /** Convenience method: sets required listeners. */
+  /**
+   * Subscribe viewer to events from all items in this object.
+   *
+   * @param obj Layer object, must not be {@code null}
+   */
   protected void setListeners(LayerObject obj)
   {
-    if (obj != null) {
-      for (final AbstractLayerItem item : obj.getLayerItems()) {
-        if (item != null) {
-          item.addActionListener(viewer.getListeners());
-          item.addLayerItemListener(viewer.getListeners());
-          item.addMouseListener(viewer.getListeners());
-          item.addMouseMotionListener(viewer.getListeners());
-        }
-      }
+    for (final AbstractLayerItem item : obj.getLayerItems()) {
+      item.addActionListener(viewer.getListeners());
+      item.addLayerItemListener(viewer.getListeners());
+      item.addMouseListener(viewer.getListeners());
+      item.addMouseMotionListener(viewer.getListeners());
     }
   }
 

--- a/src/org/infinity/resource/are/viewer/BasicLayer.java
+++ b/src/org/infinity/resource/are/viewer/BasicLayer.java
@@ -98,20 +98,6 @@ public abstract class BasicLayer<E extends LayerObject, R extends AbstractStruct
   }
 
   /**
-   * Returns the layer object at the specified index.
-   * @param index The index of the layer object.
-   * @return The layer object, of {@code null} if not available.
-   */
-  public E getLayerObject(int index)
-  {
-    if (index >= 0 && index < listObjects.size()) {
-      return listObjects.get(index);
-    } else {
-      return null;
-    }
-  }
-
-  /**
    * Returns the list of layer objects for direct manipulation.
    * @return List of layer objects. Never {@code null}
    */
@@ -142,24 +128,6 @@ public abstract class BasicLayer<E extends LayerObject, R extends AbstractStruct
       }
     }
     this.visible = visible;
-  }
-
-  /**
-   * Returns the layer object containing the specified layer item.
-   * @return The object, if it has been found, {@code null} otherwise.
-   */
-  public E getLayerObjectOf(AbstractLayerItem item)
-  {
-    if (item != null) {
-      for (final E obj : listObjects) {
-        for (final AbstractLayerItem layerItem : obj.getLayerItems()) {
-          if (layerItem == item) {
-            return obj;
-          }
-        }
-      }
-    }
-    return null;
   }
 
   /**
@@ -276,12 +244,10 @@ public abstract class BasicLayer<E extends LayerObject, R extends AbstractStruct
    */
   public boolean isScheduled(int index)
   {
-    E obj = getLayerObject(index);
-    if (obj != null) {
-      return !isScheduleEnabled() || obj.isScheduled(getSchedule());
-    } else {
-      return false;
+    if (index >= 0 && index < listObjects.size()) {
+      return !isScheduleEnabled() || listObjects.get(index).isScheduled(getSchedule());
     }
+    return false;
   }
 
   /**

--- a/src/org/infinity/resource/are/viewer/LayerAmbient.java
+++ b/src/org/infinity/resource/are/viewer/LayerAmbient.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -156,46 +156,6 @@ public class LayerAmbient extends BasicLayer<LayerObjectAmbient, AreResource>
       count += listGlobalSounds.size();
     }
     return count;
-  }
-
-  /**
-   * Returns the layer object at the specified index of the desired sound type.
-   * @param ambientType The ambient sound type (either ViewerConstants.AMBIENT_TYPE_GLOBAL,
-   *                    ViewerConstants.AMBIENT_TYPE_LOCAL or ViewerConstants.AMBIENT_TYPE_ALL).
-   * @param index The index of the layer object.
-   * @return The layer object, of {@code null} if not available.
-   */
-  public LayerObjectAmbient getLayerObject(int ambientType, int index)
-  {
-    index = Math.min(Math.max(index, 0), getLayerObjectCount(ambientType));
-    if ((ambientType & ViewerConstants.AMBIENT_TYPE_ALL) == ViewerConstants.AMBIENT_TYPE_LOCAL) {
-      return listLocalSounds.get(index);
-    } else if ((ambientType & ViewerConstants.AMBIENT_TYPE_ALL) == ViewerConstants.AMBIENT_TYPE_GLOBAL) {
-      return listGlobalSounds.get(index);
-    } else if ((ambientType & ViewerConstants.AMBIENT_TYPE_ALL) == ViewerConstants.AMBIENT_TYPE_ALL) {
-      return getLayerObject(index);
-    } else {
-      return null;
-    }
-  }
-
-  /**
-   * Returns the list of layer objects of the specified type for direct manipulation.
-   * @param ambientType The ambient sound type (either ViewerConstants.AMBIENT_TYPE_GLOBAL,
-   *                    ViewerConstants.AMBIENT_TYPE_LOCAL or ViewerConstants.AMBIENT_TYPE_ALL).
-   * @return List of layer objects.
-   */
-  public List<LayerObjectAmbient> getLayerObjects(int ambientType)
-  {
-    if ((ambientType & ViewerConstants.AMBIENT_TYPE_ALL) == ViewerConstants.AMBIENT_TYPE_LOCAL) {
-      return listLocalSounds;
-    } else if ((ambientType & ViewerConstants.AMBIENT_TYPE_ALL) == ViewerConstants.AMBIENT_TYPE_GLOBAL) {
-      return listGlobalSounds;
-    } else if ((ambientType & ViewerConstants.AMBIENT_TYPE_ALL) == ViewerConstants.AMBIENT_TYPE_ALL) {
-      return getLayerObjects();
-    } else {
-      return new ArrayList<LayerObjectAmbient>();
-    }
   }
 
   @Override

--- a/src/org/infinity/resource/are/viewer/LayerAmbient.java
+++ b/src/org/infinity/resource/are/viewer/LayerAmbient.java
@@ -62,6 +62,7 @@ public class LayerAmbient extends BasicLayer<LayerObjectAmbient, AreResource>
    * Sets the visibility state of all items in the layer. Takes enabled states of the different
    * item types into account.
    */
+  @Override
   public void setLayerVisible(boolean visible)
   {
     setVisibilityState(visible);

--- a/src/org/infinity/resource/are/viewer/LayerAnimation.java
+++ b/src/org/infinity/resource/are/viewer/LayerAnimation.java
@@ -75,6 +75,7 @@ public class LayerAnimation extends BasicLayer<LayerObjectAnimation, AreResource
    * Sets the visibility state of all items in the layer. Takes enabled states of the different
    * item types into account.
    */
+  @Override
   public void setLayerVisible(boolean visible)
   {
     setVisibilityState(visible);

--- a/src/org/infinity/resource/are/viewer/LayerManager.java
+++ b/src/org/infinity/resource/are/viewer/LayerManager.java
@@ -7,7 +7,6 @@ package org.infinity.resource.are.viewer;
 import java.util.EnumMap;
 import java.util.List;
 
-import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.resource.are.AreResource;
 import org.infinity.resource.are.viewer.ViewerConstants.LayerType;
 import org.infinity.resource.wed.WedResource;
@@ -359,21 +358,6 @@ public final class LayerManager
   }
 
   /**
-   * Returns a specific layer object.
-   * @param layer The layer of the object.
-   * @param index The index of the object.
-   * @return The layer object if found, {@code null} otherwise.
-   */
-  public LayerObject getLayerObject(LayerType layer, int index)
-  {
-    BasicLayer<?, ?> bl = layers.get(layer);
-    if (bl != null) {
-      return bl.getLayerObject(index);
-    }
-    return null;
-  }
-
-  /**
    * Returns a list of objects associated with the specified layer.
    * @param layer The layer of the objects
    * @return A list of objects or {@code null} if not found.
@@ -559,28 +543,6 @@ public final class LayerManager
         bl.setLayerVisible(visible);
       }
     }
-  }
-
-  /**
-   * Attempts to find the LayerObject instance the specified item belongs to.
-   * @param item The AbstractLayerItem object.
-   * @return A LayerObject instance if a match has been found, {@code null} otherwise.
-   */
-  public LayerObject getLayerObjectOf(AbstractLayerItem item)
-  {
-    if (item != null) {
-      for (final LayerType type: LayerType.values())
-      {
-        BasicLayer<?, ?> bl = layers.get(type);
-        if (bl != null) {
-          LayerObject obj = bl.getLayerObjectOf(item);
-          if (obj != null) {
-            return obj;
-          }
-        }
-      }
-    }
-    return null;
   }
 
   // Loads objects for each layer if the parent resource (are, wed) has changed.

--- a/src/org/infinity/resource/are/viewer/LayerObject.java
+++ b/src/org/infinity/resource/are/viewer/LayerObject.java
@@ -178,13 +178,12 @@ public abstract class LayerObject
    * @param type The specific vertex type to look for.
    * @return Array of Point objects containing vertex data.
    */
-  protected Point[] loadVertices(AbstractStruct superStruct, int baseOfs, int index, int count,
-                                 Class<? extends Vertex> type)
+  protected static Point[] loadVertices(AbstractStruct superStruct, int baseOfs, int index, int count,
+                                        Class<? extends Vertex> type)
   {
-    Point[] coords = null;
     if (superStruct != null && index >= 0 && count > 0 && type != null) {
       int idx = 0, cnt = 0;
-      coords = new Point[count];
+      final Point[] coords = new Point[count];
       for (final StructEntry e : superStruct.getFields()) {
         if (e.getOffset() >= baseOfs && type.isAssignableFrom(e.getClass())) {
           if (idx >= index) {
@@ -204,11 +203,9 @@ public abstract class LayerObject
       for (int i = cnt; i < coords.length; i++) {
         coords[i] = new Point();
       }
-    } else {
-      coords = new Point[0];
+      return coords;
     }
-
-    return coords;
+    return new Point[0];
   }
 
   /**
@@ -217,7 +214,7 @@ public abstract class LayerObject
    * @param zoomFactor Coordinates will be scaled by this value.
    * @return A {@code Polygon} object.
    */
-  protected Polygon createPolygon(Point[] coords, double zoomFactor)
+  protected static Polygon createPolygon(Point[] coords, double zoomFactor)
   {
     Polygon poly = new Polygon();
     if (coords != null) {
@@ -235,7 +232,7 @@ public abstract class LayerObject
    * @param poly The polygon to normalize (will be processed in place).
    * @return Bounding box of the polygon in global coordinates.
    */
-  protected Rectangle normalizePolygon(Polygon poly)
+  protected static Rectangle normalizePolygon(Polygon poly)
   {
     if (poly != null) {
       Rectangle r = poly.getBounds();
@@ -251,7 +248,7 @@ public abstract class LayerObject
    * @param flags The appearance schedule.
    * @param dayTime The desired day time.
    */
-  protected boolean isActiveAt(Flag flags, int dayTime)
+  protected static boolean isActiveAt(Flag flags, int dayTime)
   {
     if (flags != null && flags.getSize() > 2) {
       if (dayTime == ViewerConstants.LIGHTING_NIGHT) {

--- a/src/org/infinity/resource/are/viewer/LayerObject.java
+++ b/src/org/infinity/resource/are/viewer/LayerObject.java
@@ -26,17 +26,15 @@ import org.infinity.resource.vertex.Vertex;
  */
 public abstract class LayerObject
 {
-  private final int resourceType;
   private final String category;
   private final Class<? extends AbstractStruct> classType;
   private final AbstractStruct parent;    // base structure (e.g. AreResource or WedResource)
 
   private boolean visible;
 
-  protected LayerObject(int resourceType, String category, Class<? extends AbstractStruct> classType,
+  protected LayerObject(String category, Class<? extends AbstractStruct> classType,
                         AbstractStruct parent)
   {
-    this.resourceType = resourceType;
     this.category = (category != null && !category.isEmpty()) ? category : "Layer object";
     this.classType = (classType != null) ? classType : AbstractStruct.class;
     this.parent = parent;
@@ -84,14 +82,6 @@ public abstract class LayerObject
         }
       }
     }
-  }
-
-  /**
-   * Returns the type of the parent resource (either RESOURCE_ARE or RESOURCE_WED).
-   */
-  public int getResourceType()
-  {
-    return resourceType;
   }
 
   /**

--- a/src/org/infinity/resource/are/viewer/LayerObject.java
+++ b/src/org/infinity/resource/are/viewer/LayerObject.java
@@ -4,6 +4,7 @@
 
 package org.infinity.resource.are.viewer;
 
+import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
@@ -310,5 +311,20 @@ public abstract class LayerObject
     } else {
       return false;
     }
+  }
+
+  protected static Image[] getIcons(Image[] defIcons)
+  {
+    final Image[] icons;
+    final String keyIcon = SharedResourceCache.createKey(defIcons[0])
+                         + SharedResourceCache.createKey(defIcons[1]);
+    if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
+      icons = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
+      SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);
+    } else {
+      icons = defIcons;
+      SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icons));
+    }
+    return icons;
   }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObject.java
+++ b/src/org/infinity/resource/are/viewer/LayerObject.java
@@ -47,40 +47,36 @@ public abstract class LayerObject
    */
   public void close()
   {
-    AbstractLayerItem[] items = getLayerItems();
-    if (items != null) {
-      for (int i = 0; i < items.length; i++) {
-        // removing listeners from layer item
-        EventListener[][] listeners = new EventListener[4][];
-        listeners[0] = items[i].getActionListeners();
-        listeners[1] = items[i].getLayerItemListeners();
-        listeners[2] = items[i].getMouseListeners();
-        listeners[3] = items[i].getMouseMotionListeners();
-        for (int j = 0; j < listeners.length; j++) {
-          if (listeners[j] != null) {
-            for (int k = 0; k < listeners[j].length; k++) {
-              switch (j) {
-                case 0:
-                  items[i].removeActionListener((ActionListener)listeners[j][k]);
-                  break;
-                case 1:
-                  items[i].removeLayerItemListener((LayerItemListener)listeners[j][k]);
-                  break;
-                case 2:
-                  items[i].removeMouseListener((MouseListener)listeners[j][k]);
-                  break;
-                case 3:
-                  items[i].removeMouseMotionListener((MouseMotionListener)listeners[j][k]);
-                  break;
-              }
+    for (final AbstractLayerItem item : getLayerItems()) {
+      // removing listeners from layer item
+      EventListener[][] listeners = new EventListener[4][];
+      listeners[0] = item.getActionListeners();
+      listeners[1] = item.getLayerItemListeners();
+      listeners[2] = item.getMouseListeners();
+      listeners[3] = item.getMouseMotionListeners();
+      for (int j = 0; j < listeners.length; j++) {
+        if (listeners[j] != null) {
+          for (final EventListener l : listeners[j]) {
+            switch (j) {
+              case 0:
+                item.removeActionListener((ActionListener) l);
+                break;
+              case 1:
+                item.removeLayerItemListener((LayerItemListener) l);
+                break;
+              case 2:
+                item.removeMouseListener((MouseListener) l);
+                break;
+              case 3:
+                item.removeMouseMotionListener((MouseMotionListener) l);
+                break;
             }
           }
         }
-
-        // removing items from container
-        if (items[i].getParent() != null) {
-          items[i].getParent().remove(items[i]);
-        }
+      }
+      // removing items from container
+      if (item.getParent() != null) {
+        item.getParent().remove(item);
       }
     }
   }
@@ -126,11 +122,8 @@ public abstract class LayerObject
   {
     if (state != visible) {
       visible = state;
-      AbstractLayerItem[] items = getLayerItems();
-      if (items != null) {
-        for (int i = 0; i < items.length; i++) {
-          items[i].setVisible(visible);
-        }
+      for (final AbstractLayerItem item : getLayerItems()) {
+        item.setVisible(visible);
       }
     }
   }
@@ -154,7 +147,8 @@ public abstract class LayerObject
   /**
    * Returns all layer items associated with the layer object. This method is useful for layer objects
    * consisting of multiple layer items (e.g. door polygons or ambient sounds/sound ranges).
-   * @return A list of layer items associated with the layer object.
+   * @return A list of layer items associated with the layer object. Never {@code null}
+   *         and array do not contain {@code null}'s
    */
   public abstract AbstractLayerItem[] getLayerItems();
 

--- a/src/org/infinity/resource/are/viewer/LayerObject.java
+++ b/src/org/infinity/resource/are/viewer/LayerObject.java
@@ -144,20 +144,6 @@ public abstract class LayerObject
   public abstract Viewable getViewable();
 
   /**
-   * Returns all structures associated with the layer object. This method is useful for layer objects
-   * consisting of multiple structures.
-   * @return A list of structures associated with the layer object.
-   */
-  public abstract Viewable[] getViewables();
-
-  /**
-   * Returns the layer item associated with the layer object. If the layer object consists of
-   * multiple layer items, then the first one available will be returned.
-   * @return The layer item associated with the layer object.
-   */
-  public abstract AbstractLayerItem getLayerItem();
-
-  /**
    * Returns the specified layer item. {@code type} is layer type specific, usually defined
    * as an identifier in {@code ViewerConstants}.
    * @param type A layer-specific type to identify the item to return.
@@ -173,31 +159,10 @@ public abstract class LayerObject
   public abstract AbstractLayerItem[] getLayerItems();
 
   /**
-   * Reloads structure data and associated layer item(s). Note: {@link #update(double)} has
-   * to be called afterwards to account for canvas-specific settings.
-   */
-  public abstract void reload();
-
-  /**
    * Updates the layer item positions. Takes zoom factor into account.
    * Note: Always call this method after loading/reloading structure data.
    */
   public abstract void update(double zoomFactor);
-
-  /**
-   * Returns the original map position of the first available layer item (center or top-left,
-   * depending on object type). Note: This is the location specified in the resource structure.
-   * The resulting position on the canvas may be different.
-   */
-  public abstract Point getMapLocation();
-
-  /**
-   * Returns the original map positions of all available layer items (center or top-left,
-   * depending on object type). Note: This is the location specified in the resource structure.
-   * The resulting position on the canvas may be different.
-   * @return
-   */
-  public abstract Point[] getMapLocations();
 
   /**
    * Returns whether the layer object is active at a specific scheduled time.

--- a/src/org/infinity/resource/are/viewer/LayerObject.java
+++ b/src/org/infinity/resource/are/viewer/LayerObject.java
@@ -15,6 +15,8 @@ import java.util.EventListener;
 
 import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.Flag;
+import org.infinity.datatype.IsNumeric;
+import org.infinity.datatype.ResourceRef;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.LayerItemListener;
 import org.infinity.resource.AbstractStruct;
@@ -282,5 +284,27 @@ public abstract class LayerObject
       SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icons));
     }
     return icons;
+  }
+
+  protected static void addResResDesc(StringBuilder sb, AbstractStruct struct, String resRefAttr, String desc)
+  {
+    final ResourceRef res = (ResourceRef)struct.getAttribute(resRefAttr, false);
+    if (res != null && !res.isEmpty()) {
+      if (sb.length() > 1) sb.append(", ");
+      sb.append(desc).append(res);
+    }
+  }
+
+  protected static void addTrappedDesc(StringBuilder sb, AbstractStruct struct, String trappedAttr, String difficultyAttr, String scriptAttr)
+  {
+    final boolean isTrapped = ((IsNumeric)struct.getAttribute(trappedAttr, false)).getValue() != 0;
+    if (isTrapped) {
+      int v = ((IsNumeric)struct.getAttribute(difficultyAttr, false)).getValue();
+      if (v > 0) {
+        if (sb.length() > 1) sb.append(", ");
+        sb.append("Trapped (").append(v).append(')');
+      }
+    }
+    addResResDesc(sb, struct, scriptAttr, "Script: ");
   }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectActor.java
@@ -34,12 +34,6 @@ public abstract class LayerObjectActor extends LayerObject
   }
 
   @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return item;
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     return (type == 0) ? item : null;
@@ -58,18 +52,6 @@ public abstract class LayerObjectActor extends LayerObject
       item.setItemLocation((int)(location.x*zoomFactor + (zoomFactor / 2.0)),
                            (int)(location.y*zoomFactor + (zoomFactor / 2.0)));
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location};
   }
   //</editor-fold>
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectActor.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -22,9 +22,10 @@ public abstract class LayerObjectActor extends LayerObject
 
   protected LayerObjectActor(Class<? extends AbstractStruct> classType, AbstractStruct parent)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Actor", classType, parent);
+    super("Actor", classType, parent);
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public void close()
   {
@@ -70,4 +71,5 @@ public abstract class LayerObjectActor extends LayerObject
   {
     return new Point[]{location};
   }
+  //</editor-fold>
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
@@ -48,11 +48,12 @@ public class LayerObjectAmbient extends LayerObject
 
   public LayerObjectAmbient(AreResource parent, Ambient ambient)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Sound", Ambient.class, parent);
+    super("Sound", Ambient.class, parent);
     this.ambient = ambient;
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -139,6 +140,7 @@ public class LayerObjectAmbient extends LayerObject
   {
     return new Point[]{location, location};
   }
+  //</editor-fold>
 
   /**
    * Returns whether the ambient sound uses a local sound radius.

--- a/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
@@ -29,10 +29,10 @@ import org.infinity.resource.are.viewer.icon.ViewerIcons;
  */
 public class LayerObjectAmbient extends LayerObject
 {
-  private static final Image[] ICON_GLOBAL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AMBIENT_G_1),
-                                              Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AMBIENT_G_2)};
-  private static final Image[] ICON_LOCAL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AMBIENT_L_1),
-                                             Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AMBIENT_L_2)};
+  private static final Image[] ICONS_GLOBAL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AMBIENT_G_1),
+                                               Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AMBIENT_G_2)};
+  private static final Image[] ICONS_LOCAL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AMBIENT_L_1),
+                                              Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AMBIENT_L_2)};
   private static final Point CENTER = new Point(16, 16);
   private static final Color[] COLOR_RANGE = {new Color(0xA0000080, true), new Color(0xA0000080, true),
                                               new Color(0x00204080, true), new Color(0x004060C0, true)};
@@ -181,7 +181,7 @@ public class LayerObjectAmbient extends LayerObject
   {
     if (ambient != null) {
       String msg = "";
-      Image[] icon = ICON_GLOBAL;
+      Image[] icons = ICONS_GLOBAL;
       Shape circle = null;
       Color[] color = new Color[COLOR_RANGE.length];
       try {
@@ -190,16 +190,16 @@ public class LayerObjectAmbient extends LayerObject
         radiusLocal = ((DecNumber)ambient.getAttribute(Ambient.ARE_AMBIENT_RADIUS)).getValue();
         volume = ((DecNumber)ambient.getAttribute(Ambient.ARE_AMBIENT_VOLUME)).getValue();
         if (((Flag)ambient.getAttribute(Ambient.ARE_AMBIENT_FLAGS)).isFlagSet(2)) {
-          icon = ICON_GLOBAL;
+          icons = ICONS_GLOBAL;
           radiusLocal = 0;
         } else {
-          icon = ICON_LOCAL;
+          icons = ICONS_LOCAL;
         }
 
         scheduleFlags = ((Flag)ambient.getAttribute(Ambient.ARE_AMBIENT_ACTIVE_AT));
 
         msg = ((TextString)ambient.getAttribute(Ambient.ARE_AMBIENT_NAME)).toString();
-        if (icon == ICON_LOCAL) {
+        if (icons == ICONS_LOCAL) {
           circle = createShape(1.0);
           double minAlpha = 0.0, maxAlpha = 64.0;
           double alphaF = minAlpha + Math.sqrt((double)volume) / 10.0 * (maxAlpha - minAlpha);
@@ -214,25 +214,18 @@ public class LayerObjectAmbient extends LayerObject
       }
 
       // Using cached icons
-      String keyIcon = String.format("%s%s", SharedResourceCache.createKey(icon[0]),
-                                                 SharedResourceCache.createKey(icon[1]));
-      if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
-        icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);
-      } else {
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
-      }
+      icons = getIcons(icons);
 
       // creating sound item
-      itemIcon = new IconLayerItem(ambient, msg, msg, icon[0], CENTER);
+      itemIcon = new IconLayerItem(ambient, msg, msg, icons[0], CENTER);
       itemIcon.setLabelEnabled(Settings.ShowLabelSounds);
       itemIcon.setName(getCategory());
       itemIcon.setToolTipText(msg);
-      itemIcon.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
+      itemIcon.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
       itemIcon.setVisible(isVisible());
 
       // creating sound range item
-      if (icon == ICON_LOCAL) {
+      if (icons == ICONS_LOCAL) {
         itemShape = new ShapedLayerItem(ambient, msg, msg, circle, new Point(radiusLocal, radiusLocal));
         itemShape.setName(getCategory());
         itemShape.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, color[0]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
@@ -13,6 +13,7 @@ import java.awt.geom.Ellipse2D;
 
 import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.Flag;
+import org.infinity.datatype.IsNumeric;
 import org.infinity.datatype.TextString;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.IconLayerItem;
@@ -180,15 +181,15 @@ public class LayerObjectAmbient extends LayerObject
   private void init()
   {
     if (ambient != null) {
-      String msg = "";
+      String msg = null;
       Image[] icons = ICONS_GLOBAL;
       Shape circle = null;
       Color[] color = new Color[COLOR_RANGE.length];
       try {
-        location.x = ((DecNumber)ambient.getAttribute(Ambient.ARE_AMBIENT_ORIGIN_X)).getValue();
-        location.y = ((DecNumber)ambient.getAttribute(Ambient.ARE_AMBIENT_ORIGIN_Y)).getValue();
-        radiusLocal = ((DecNumber)ambient.getAttribute(Ambient.ARE_AMBIENT_RADIUS)).getValue();
-        volume = ((DecNumber)ambient.getAttribute(Ambient.ARE_AMBIENT_VOLUME)).getValue();
+        location.x = ((IsNumeric)ambient.getAttribute(Ambient.ARE_AMBIENT_ORIGIN_X)).getValue();
+        location.y = ((IsNumeric)ambient.getAttribute(Ambient.ARE_AMBIENT_ORIGIN_Y)).getValue();
+        radiusLocal = ((IsNumeric)ambient.getAttribute(Ambient.ARE_AMBIENT_RADIUS)).getValue();
+        volume = ((IsNumeric)ambient.getAttribute(Ambient.ARE_AMBIENT_VOLUME)).getValue();
         if (((Flag)ambient.getAttribute(Ambient.ARE_AMBIENT_FLAGS)).isFlagSet(2)) {
           icons = ICONS_GLOBAL;
           radiusLocal = 0;
@@ -198,11 +199,11 @@ public class LayerObjectAmbient extends LayerObject
 
         scheduleFlags = ((Flag)ambient.getAttribute(Ambient.ARE_AMBIENT_ACTIVE_AT));
 
-        msg = ((TextString)ambient.getAttribute(Ambient.ARE_AMBIENT_NAME)).toString();
+        msg = ambient.getAttribute(Ambient.ARE_AMBIENT_NAME).toString();
         if (icons == ICONS_LOCAL) {
           circle = createShape(1.0);
           double minAlpha = 0.0, maxAlpha = 64.0;
-          double alphaF = minAlpha + Math.sqrt((double)volume) / 10.0 * (maxAlpha - minAlpha);
+          final double alphaF = minAlpha + Math.sqrt(volume) / 10.0 * (maxAlpha - minAlpha);
           int alpha = (int)alphaF & 0xff;
           color[0] = COLOR_RANGE[0];
           color[1] = COLOR_RANGE[1];
@@ -217,16 +218,15 @@ public class LayerObjectAmbient extends LayerObject
       icons = getIcons(icons);
 
       // creating sound item
-      itemIcon = new IconLayerItem(ambient, msg, msg, icons[0], CENTER);
+      itemIcon = new IconLayerItem(ambient, msg, icons[0], CENTER);
       itemIcon.setLabelEnabled(Settings.ShowLabelSounds);
       itemIcon.setName(getCategory());
-      itemIcon.setToolTipText(msg);
       itemIcon.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
       itemIcon.setVisible(isVisible());
 
       // creating sound range item
       if (icons == ICONS_LOCAL) {
-        itemShape = new ShapedLayerItem(ambient, msg, msg, circle, new Point(radiusLocal, radiusLocal));
+        itemShape = new ShapedLayerItem(ambient, msg, circle);
         itemShape.setName(getCategory());
         itemShape.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, color[0]);
         itemShape.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, color[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -222,7 +222,7 @@ public class LayerObjectAmbient extends LayerObject
       }
 
       // creating sound item
-      itemIcon = new IconLayerItem(location, ambient, msg, msg, icon[0], CENTER);
+      itemIcon = new IconLayerItem(ambient, msg, msg, icon[0], CENTER);
       itemIcon.setLabelEnabled(Settings.ShowLabelSounds);
       itemIcon.setName(getCategory());
       itemIcon.setToolTipText(msg);
@@ -231,7 +231,7 @@ public class LayerObjectAmbient extends LayerObject
 
       // creating sound range item
       if (icon == ICON_LOCAL) {
-        itemShape = new ShapedLayerItem(location, ambient, msg, msg, circle, new Point(radiusLocal, radiusLocal));
+        itemShape = new ShapedLayerItem(ambient, msg, msg, circle, new Point(radiusLocal, radiusLocal));
         itemShape.setName(getCategory());
         itemShape.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, color[0]);
         itemShape.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, color[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAmbient.java
@@ -62,22 +62,6 @@ public class LayerObjectAmbient extends LayerObject
     return ambient;
   }
 
-  @Override
-  public Viewable[] getViewables()
-  {
-    if (isLocal()) {
-      return new Viewable[]{ambient, ambient};
-    } else {
-      return new Viewable[]{ambient};
-    }
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return itemIcon;
-  }
-
   /**
    * Returns the layer item of specified type.
    * @param type The type of the item to return (either {@code ViewerConstants.AMBIENT_ITEM_ICON} or
@@ -107,12 +91,6 @@ public class LayerObjectAmbient extends LayerObject
   }
 
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public void update(double zoomFactor)
   {
     int x = (int)(location.x*zoomFactor + (zoomFactor / 2.0));
@@ -129,18 +107,6 @@ public class LayerObjectAmbient extends LayerObject
       itemShape.setCenterPosition(new Point(rect.width / 2, rect.height / 2));
       itemShape.setShape(circle);
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location, location};
   }
 
   @Override

--- a/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
@@ -59,7 +59,7 @@ public class LayerObjectAnimation extends LayerObject
 
   public LayerObjectAnimation(AreResource parent, Animation anim)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Animation", Animation.class, parent);
+    super("Animation", Animation.class, parent);
     this.anim = anim;
     init();
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -64,6 +64,7 @@ public class LayerObjectAnimation extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public void close()
   {
@@ -163,6 +164,7 @@ public class LayerObjectAnimation extends LayerObject
       return false;
     }
   }
+  //</editor-fold>
 
   /**
    * Sets the lighting condition of the animation. Does nothing if the animation is flagged as
@@ -340,7 +342,7 @@ public class LayerObjectAnimation extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      IconLayerItem item1 = new IconLayerItem(location, anim, msg, msg, icon[0], CENTER);
+      IconLayerItem item1 = new IconLayerItem(anim, msg, msg, icon[0], CENTER);
       item1.setData(keyIcon);
       item1.setLabelEnabled(Settings.ShowLabelAnimations);
       item1.setName(getCategory());
@@ -349,7 +351,7 @@ public class LayerObjectAnimation extends LayerObject
       item1.setVisible(isVisible());
       items[0] = item1;
 
-      AnimatedLayerItem item2 = new AnimatedLayerItem(location, anim, msg, msg, animation);
+      AnimatedLayerItem item2 = new AnimatedLayerItem(anim, msg, msg, animation);
       item2.setData(keyAnim);
       item2.setName(getCategory());
       item2.setToolTipText(msg);
@@ -366,7 +368,7 @@ public class LayerObjectAnimation extends LayerObject
     }
   }
 
-  // Loads a palette from the specified BMP resource (only 8-bit standard BMPs supported)
+  /** Loads a palette from the specified BMP resource (only 8-bit standard BMPs supported). */
   private int[] getExternalPalette(String bmpFile)
   {
     int[] retVal = null;

--- a/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
@@ -293,31 +293,28 @@ public class LayerObjectAnimation extends LayerObject
   /** Loads a palette from the specified BMP resource (only 8-bit standard BMPs supported). */
   private static int[] getExternalPalette(String bmpFile)
   {
-    int[] retVal = null;
-    if (bmpFile != null && !bmpFile.isEmpty()) {
-      ResourceEntry entry = ResourceFactory.getResourceEntry(bmpFile);
-      if (entry == null) {
-        entry = new FileResourceEntry(FileManager.resolve(bmpFile));
-      }
-      try {
-        final ByteBuffer buffer = entry.getResourceBuffer();
-        if (buffer != null && buffer.limit() > 1078) {
-          final boolean isBMP = (buffer.getShort(0) == 0x4D42);   // 'BM'
-          final int palOfs = buffer.getInt(0x0e);
-          final int bpp = buffer.getShort(0x1c);
-          if (isBMP && palOfs >= 0x28 && bpp == 8) {
-            final int ofs = 0x0e + palOfs;
-            retVal = new int[256];
-            for (int i = 0; i < 256; i++) {
-              retVal[i] = buffer.getInt(ofs + i*4);
-            }
-          }
+    ResourceEntry entry = ResourceFactory.getResourceEntry(bmpFile);
+    if (entry == null) {
+      entry = new FileResourceEntry(FileManager.resolve(bmpFile));
+    }
+    try {
+      final ByteBuffer buffer = entry.getResourceBuffer();
+      if (buffer != null && buffer.limit() > 256*4 + 54) {
+        final boolean isBMP = (buffer.getShort(0) == 0x4D42);   // 'BM'
+        final int palOfs = buffer.getInt(0x0e);
+        final int bpp = buffer.getShort(0x1c);
+        if (isBMP && palOfs >= 0x28 && bpp == 8) {
+          final int ofs = 0x0e + palOfs;
+          final int[] palette = new int[256];
+          buffer.position(ofs).asIntBuffer().get(palette);
+          return palette;
         }
-      } catch (Exception e) {
       }
+    } catch (Exception e) {
+      e.printStackTrace();
     }
 
-    return retVal == null ? new int[0] : retVal;
+    return new int[0];
   }
 
   private static BamDecoder getDecoder(Image icon)

--- a/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
@@ -71,17 +71,15 @@ public class LayerObjectAnimation extends LayerObject
     super.close();
     // removing cached references
     for (int i = 0; i < items.length; i++) {
-      if (items[i] != null) {
-        Object key = items[i].getData();
-        if (key != null) {
-          switch (i) {
-            case ViewerConstants.ANIM_ITEM_ICON:
-              SharedResourceCache.remove(SharedResourceCache.Type.ICON, key);
-              break;
-            case ViewerConstants.ANIM_ITEM_REAL:
-              SharedResourceCache.remove(SharedResourceCache.Type.ANIMATION, key);
-              break;
-          }
+      Object key = items[i].getData();
+      if (key != null) {
+        switch (i) {
+          case ViewerConstants.ANIM_ITEM_ICON:
+            SharedResourceCache.remove(SharedResourceCache.Type.ICON, key);
+            break;
+          case ViewerConstants.ANIM_ITEM_REAL:
+            SharedResourceCache.remove(SharedResourceCache.Type.ANIMATION, key);
+            break;
         }
       }
     }
@@ -115,12 +113,10 @@ public class LayerObjectAnimation extends LayerObject
   public void update(double zoomFactor)
   {
     for (int i = 0; i < items.length; i++) {
-      if (items[i] != null) {
-        items[i].setItemLocation((int)(location.x*zoomFactor + (zoomFactor / 2.0)),
-                                 (int)(location.y*zoomFactor + (zoomFactor / 2.0)));
-        if (i == ViewerConstants.ANIM_ITEM_REAL) {
-          ((AnimatedLayerItem)items[i]).setZoomFactor(zoomFactor);
-        }
+      items[i].setItemLocation((int)(location.x*zoomFactor + (zoomFactor / 2.0)),
+                               (int)(location.y*zoomFactor + (zoomFactor / 2.0)));
+      if (i == ViewerConstants.ANIM_ITEM_REAL) {
+        ((AnimatedLayerItem)items[i]).setZoomFactor(zoomFactor);
       }
     }
   }
@@ -144,16 +140,14 @@ public class LayerObjectAnimation extends LayerObject
    */
   public void setLighting(int dayTime)
   {
-    if (items[ViewerConstants.ANIM_ITEM_REAL] != null) {
-      AnimatedLayerItem item = (AnimatedLayerItem)items[ViewerConstants.ANIM_ITEM_REAL];
-      if (item != null) {
-        BasicAnimationProvider provider = item.getAnimation();
-        if (provider instanceof BackgroundAnimationProvider) {
-          BackgroundAnimationProvider anim = (BackgroundAnimationProvider)provider;
-          anim.setLighting(dayTime);
-        }
-        item.repaint();
+    AnimatedLayerItem item = (AnimatedLayerItem)items[ViewerConstants.ANIM_ITEM_REAL];
+    if (item != null) {
+      BasicAnimationProvider provider = item.getAnimation();
+      if (provider instanceof BackgroundAnimationProvider) {
+        BackgroundAnimationProvider anim = (BackgroundAnimationProvider)provider;
+        anim.setLighting(dayTime);
       }
+      item.repaint();
     }
   }
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
@@ -331,16 +331,9 @@ public class LayerObjectAnimation extends LayerObject
       }
 
       // Using cached icons
-      Image[] icon;
-      String keyIcon = String.format("%s%s", SharedResourceCache.createKey(ICON[iconIdx][0]),
-                                                 SharedResourceCache.createKey(ICON[iconIdx][1]));
-      if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
-        icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);
-      } else {
-        icon = ICON[iconIdx];
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
-      }
+      final Image[] icon = getIcons(ICON[iconIdx]);
+      final String keyIcon = SharedResourceCache.createKey(ICON[iconIdx])
+                           + SharedResourceCache.createKey(ICON[iconIdx]);
 
       IconLayerItem item1 = new IconLayerItem(anim, msg, msg, icon[0], CENTER);
       item1.setData(keyIcon);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAnimation.java
@@ -93,18 +93,6 @@ public class LayerObjectAnimation extends LayerObject
     return anim;
   }
 
-  @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{anim};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return items[0];
-  }
-
   /**
    * Returns the layer item of the specific state. (either ANIM_ITEM_ICON or ANIM_ITEM_REAL).
    * @param type The state of the item to be returned.
@@ -124,12 +112,6 @@ public class LayerObjectAnimation extends LayerObject
   }
 
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public void update(double zoomFactor)
   {
     for (int i = 0; i < items.length; i++) {
@@ -141,18 +123,6 @@ public class LayerObjectAnimation extends LayerObject
         }
       }
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location, location};
   }
 
   @Override

--- a/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
@@ -134,7 +134,6 @@ public class LayerObjectAreActor extends LayerObjectActor
       item = new IconLayerItem(location, actor, msg, info, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelActorsAre);
       item.setName(getCategory());
-      item.setToolTipText(info);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
       item.setVisible(isVisible());
     }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
@@ -30,12 +30,12 @@ import org.infinity.resource.cre.CreResource;
  */
 public class LayerObjectAreActor extends LayerObjectActor
 {
-  private static final Image[] ICON_GOOD = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_G_1),
-                                            Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_G_2)};
-  private static final Image[] ICON_NEUTRAL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_B_1),
-                                               Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_B_2)};
-  private static final Image[] ICON_EVIL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_R_1),
-                                            Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_R_2)};
+  private static final Image[] ICONS_GOOD = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_G_1),
+                                             Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_G_2)};
+  private static final Image[] ICONS_NEUTRAL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_B_1),
+                                                Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_B_2)};
+  private static final Image[] ICONS_EVIL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_R_1),
+                                             Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ARE_ACTOR_R_2)};
   private static final Point CENTER = new Point(12, 40);
 
   private final Actor actor;
@@ -83,7 +83,7 @@ public class LayerObjectAreActor extends LayerObjectActor
     if (actor != null) {
       String actorName = "";
       String actorCreName = "";
-      Image[] icon = ICON_NEUTRAL;
+      Image[] icons = ICONS_NEUTRAL;
       int ea = 128;   // default: neutral
       try {
         actorName = ((IsTextual)actor.getAttribute(Actor.ARE_ACTOR_NAME)).getText();
@@ -108,35 +108,28 @@ public class LayerObjectAreActor extends LayerObjectActor
           ea = (int)((IdsBitmap)cre.getAttribute(CreResource.CRE_ALLEGIANCE)).getValue();
         }
         if (ea >= 2 && ea <= 30) {
-          icon = ICON_GOOD;
+          icons = ICONS_GOOD;
         } else if (ea >= 200) {
-          icon = ICON_EVIL;
+          icons = ICONS_EVIL;
         } else {
-          icon = ICON_NEUTRAL;
+          icons = ICONS_NEUTRAL;
         }
       } catch (Exception e) {
         e.printStackTrace();
       }
 
       // Using cached icons
-      String keyIcon = String.format("%s%s", SharedResourceCache.createKey(icon[0]),
-                                                 SharedResourceCache.createKey(icon[1]));
-      if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
-        icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);
-      } else {
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
-      }
+      icons = getIcons(icons);
 
       String info = actorName.isEmpty() ? actorCreName : actorName;
       String msg = actorName;
       if (!actorCreName.equals(actorName)) {
         msg += " (" + actorCreName + ")";
       }
-      item = new IconLayerItem(actor, msg, info, icon[0], CENTER);
+      item = new IconLayerItem(actor, msg, info, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelActorsAre);
       item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
+      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
       item.setVisible(isVisible());
     }
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
@@ -48,21 +48,9 @@ public class LayerObjectAreActor extends LayerObjectActor
 
   //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public Viewable getViewable()
   {
     return actor;
-  }
-
-  @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{actor};
   }
 
   @Override

--- a/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -48,6 +48,7 @@ public class LayerObjectAreActor extends LayerObjectActor
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public void reload()
   {
@@ -75,6 +76,7 @@ public class LayerObjectAreActor extends LayerObjectActor
       return false;
     }
   }
+  //</editor-fold>
 
   private void init()
   {
@@ -131,7 +133,7 @@ public class LayerObjectAreActor extends LayerObjectActor
       if (!actorCreName.equals(actorName)) {
         msg += " (" + actorCreName + ")";
       }
-      item = new IconLayerItem(location, actor, msg, info, icon[0], CENTER);
+      item = new IconLayerItem(actor, msg, info, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelActorsAre);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
@@ -43,7 +43,54 @@ public class LayerObjectAreActor extends LayerObjectActor
   {
     super(Actor.class, parent);
     this.actor = actor;
-    init();
+    String actorName = null;
+    String actorCreName = null;
+    Image[] icons = ICONS_NEUTRAL;
+    int ea = 128;   // default: neutral
+    try {
+      actorName  = ((IsTextual)actor.getAttribute(Actor.ARE_ACTOR_NAME)).getText();
+      location.x = ((IsNumeric)actor.getAttribute(Actor.ARE_ACTOR_POS_X)).getValue();
+      location.y = ((IsNumeric)actor.getAttribute(Actor.ARE_ACTOR_POS_Y)).getValue();
+
+      scheduleFlags = ((Flag)actor.getAttribute(Actor.ARE_ACTOR_PRESENT_AT));
+
+      StructEntry obj = actor.getAttribute(Actor.ARE_ACTOR_CHARACTER);
+      CreResource cre = null;
+      if (obj instanceof TextString) {
+        // ARE in saved game
+        cre = (CreResource)actor.getAttribute(Actor.ARE_ACTOR_CRE_FILE);
+      } else if (obj instanceof ResourceRef) {
+        String creName = ((ResourceRef)obj).getResourceName();
+        if (creName.lastIndexOf('.') > 0) {
+          cre = new CreResource(ResourceFactory.getResourceEntry(creName));
+        }
+      }
+      if (cre != null) {
+        actorCreName = cre.getAttribute(CreResource.CRE_NAME).toString();
+        ea = ((IsNumeric)cre.getAttribute(CreResource.CRE_ALLEGIANCE)).getValue();
+      }
+      if (ea >= 2 && ea <= 30) {
+        icons = ICONS_GOOD;
+      } else if (ea >= 200) {
+        icons = ICONS_EVIL;
+      } else {
+        icons = ICONS_NEUTRAL;
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    // Using cached icons
+    icons = getIcons(icons);
+
+    final String msg = actorCreName == null
+        ? actorName
+        : actorCreName + " (" + actorName + ')';
+    item = new IconLayerItem(actor, msg, icons[0], CENTER);
+    item.setLabelEnabled(Settings.ShowLabelActorsAre);
+    item.setName(getCategory());
+    item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
+    item.setVisible(isVisible());
   }
 
   //<editor-fold defaultstate="collapsed" desc="LayerObject">
@@ -63,58 +110,4 @@ public class LayerObjectAreActor extends LayerObjectActor
     }
   }
   //</editor-fold>
-
-  private void init()
-  {
-    if (actor != null) {
-      String actorName = null;
-      String actorCreName = null;
-      Image[] icons = ICONS_NEUTRAL;
-      int ea = 128;   // default: neutral
-      try {
-        actorName  = ((IsTextual)actor.getAttribute(Actor.ARE_ACTOR_NAME)).getText();
-        location.x = ((IsNumeric)actor.getAttribute(Actor.ARE_ACTOR_POS_X)).getValue();
-        location.y = ((IsNumeric)actor.getAttribute(Actor.ARE_ACTOR_POS_Y)).getValue();
-
-        scheduleFlags = ((Flag)actor.getAttribute(Actor.ARE_ACTOR_PRESENT_AT));
-
-        StructEntry obj = actor.getAttribute(Actor.ARE_ACTOR_CHARACTER);
-        CreResource cre = null;
-        if (obj instanceof TextString) {
-          // ARE in saved game
-          cre = (CreResource)actor.getAttribute(Actor.ARE_ACTOR_CRE_FILE);
-        } else if (obj instanceof ResourceRef) {
-          String creName = ((ResourceRef)obj).getResourceName();
-          if (creName.lastIndexOf('.') > 0) {
-            cre = new CreResource(ResourceFactory.getResourceEntry(creName));
-          }
-        }
-        if (cre != null) {
-          actorCreName = cre.getAttribute(CreResource.CRE_NAME).toString();
-          ea = ((IsNumeric)cre.getAttribute(CreResource.CRE_ALLEGIANCE)).getValue();
-        }
-        if (ea >= 2 && ea <= 30) {
-          icons = ICONS_GOOD;
-        } else if (ea >= 200) {
-          icons = ICONS_EVIL;
-        } else {
-          icons = ICONS_NEUTRAL;
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-
-      // Using cached icons
-      icons = getIcons(icons);
-
-      final String msg = actorCreName == null
-          ? actorName
-          : actorCreName + " (" + actorName + ')';
-      item = new IconLayerItem(actor, msg, icons[0], CENTER);
-      item.setLabelEnabled(Settings.ShowLabelActorsAre);
-      item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
-      item.setVisible(isVisible());
-    }
-  }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
@@ -7,12 +7,10 @@ package org.infinity.resource.are.viewer;
 import java.awt.Image;
 import java.awt.Point;
 
-import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.Flag;
-import org.infinity.datatype.IdsBitmap;
+import org.infinity.datatype.IsNumeric;
 import org.infinity.datatype.IsTextual;
 import org.infinity.datatype.ResourceRef;
-import org.infinity.datatype.StringRef;
 import org.infinity.datatype.TextString;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.IconLayerItem;
@@ -81,14 +79,14 @@ public class LayerObjectAreActor extends LayerObjectActor
   private void init()
   {
     if (actor != null) {
-      String actorName = "";
-      String actorCreName = "";
+      String actorName = null;
+      String actorCreName = null;
       Image[] icons = ICONS_NEUTRAL;
       int ea = 128;   // default: neutral
       try {
-        actorName = ((IsTextual)actor.getAttribute(Actor.ARE_ACTOR_NAME)).getText();
-        location.x = ((DecNumber)actor.getAttribute(Actor.ARE_ACTOR_POS_X)).getValue();
-        location.y = ((DecNumber)actor.getAttribute(Actor.ARE_ACTOR_POS_Y)).getValue();
+        actorName  = ((IsTextual)actor.getAttribute(Actor.ARE_ACTOR_NAME)).getText();
+        location.x = ((IsNumeric)actor.getAttribute(Actor.ARE_ACTOR_POS_X)).getValue();
+        location.y = ((IsNumeric)actor.getAttribute(Actor.ARE_ACTOR_POS_Y)).getValue();
 
         scheduleFlags = ((Flag)actor.getAttribute(Actor.ARE_ACTOR_PRESENT_AT));
 
@@ -104,8 +102,8 @@ public class LayerObjectAreActor extends LayerObjectActor
           }
         }
         if (cre != null) {
-          actorCreName = ((StringRef)cre.getAttribute(Actor.ARE_ACTOR_NAME)).toString();
-          ea = (int)((IdsBitmap)cre.getAttribute(CreResource.CRE_ALLEGIANCE)).getValue();
+          actorCreName = cre.getAttribute(CreResource.CRE_NAME).toString();
+          ea = ((IsNumeric)cre.getAttribute(CreResource.CRE_ALLEGIANCE)).getValue();
         }
         if (ea >= 2 && ea <= 30) {
           icons = ICONS_GOOD;
@@ -121,12 +119,10 @@ public class LayerObjectAreActor extends LayerObjectActor
       // Using cached icons
       icons = getIcons(icons);
 
-      String info = actorName.isEmpty() ? actorCreName : actorName;
-      String msg = actorName;
-      if (!actorCreName.equals(actorName)) {
-        msg += " (" + actorCreName + ")";
-      }
-      item = new IconLayerItem(actor, msg, info, icons[0], CENTER);
+      final String msg = actorCreName == null
+          ? actorName
+          : actorCreName + " (" + actorName + ')';
+      item = new IconLayerItem(actor, msg, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelActorsAre);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAreActor.java
@@ -59,10 +59,11 @@ public class LayerObjectAreActor extends LayerObjectActor
       if (obj instanceof TextString) {
         // ARE in saved game
         cre = (CreResource)actor.getAttribute(Actor.ARE_ACTOR_CRE_FILE);
-      } else if (obj instanceof ResourceRef) {
-        String creName = ((ResourceRef)obj).getResourceName();
-        if (creName.lastIndexOf('.') > 0) {
-          cre = new CreResource(ResourceFactory.getResourceEntry(creName));
+      } else
+      if (obj instanceof ResourceRef) {
+        final ResourceRef creRef = (ResourceRef)obj;
+        if (!creRef.isEmpty()) {
+          cre = new CreResource(ResourceFactory.getResourceEntry(creRef.getResourceName()));
         }
       }
       if (cre != null) {

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
@@ -59,18 +59,6 @@ public class LayerObjectAutomap extends LayerObject
   }
 
   @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{note};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return item;
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     return (type == 0) ? item : null;
@@ -83,30 +71,12 @@ public class LayerObjectAutomap extends LayerObject
   }
 
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public void update(double zoomFactor)
   {
     if (item != null) {
       item.setItemLocation((int)(location.x*zoomFactor + (zoomFactor / 2.0)),
                            (int)(location.y*zoomFactor + (zoomFactor / 2.0)));
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location};
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -55,6 +55,7 @@ public class LayerObjectAutomap extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -111,6 +112,7 @@ public class LayerObjectAutomap extends LayerObject
   {
     return new Point[]{location};
   }
+  //</editor-fold>
 
   private void init()
   {
@@ -206,7 +208,7 @@ public class LayerObjectAutomap extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, note, msg, msg, icon[0], CENTER);
+      item = new IconLayerItem(note, msg, msg, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelMapNotes);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
@@ -50,7 +50,7 @@ public class LayerObjectAutomap extends LayerObject
 
   public LayerObjectAutomap(AreResource parent, AutomapNote note)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Automap", AutomapNote.class, parent);
+    super("Automap", AutomapNote.class, parent);
     this.note = note;
     init();
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
@@ -38,8 +38,8 @@ import org.infinity.util.io.FileManager;
  */
 public class LayerObjectAutomap extends LayerObject
 {
-  private static final Image[] ICON = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AUTOMAP_1),
-                                       Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AUTOMAP_2)};
+  private static final Image[] ICONS = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AUTOMAP_1),
+                                        Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AUTOMAP_2)};
   private static final Point CENTER = new Point(26, 26);
 
   private final AutomapNote note;
@@ -197,21 +197,12 @@ public class LayerObjectAutomap extends LayerObject
       }
 
       // Using cached icons
-      Image[] icon;
-      String keyIcon = String.format("%s%s", SharedResourceCache.createKey(ICON[0]),
-                                                 SharedResourceCache.createKey(ICON[1]));
-      if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
-        icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);
-      } else {
-        icon = ICON;
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
-      }
+      final Image[] icons = getIcons(ICONS);
 
-      item = new IconLayerItem(note, msg, msg, icon[0], CENTER);
+      item = new IconLayerItem(note, msg, msg, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelMapNotes);
       item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
+      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
       item.setVisible(isVisible());
     }
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
@@ -209,7 +209,6 @@ public class LayerObjectAutomap extends LayerObject
       item = new IconLayerItem(location, note, msg, msg, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelMapNotes);
       item.setName(getCategory());
-      item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
       item.setVisible(isVisible());
     }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomap.java
@@ -9,13 +9,9 @@ import java.awt.Point;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.infinity.datatype.Bitmap;
-import org.infinity.datatype.DecNumber;
-import org.infinity.datatype.HexNumber;
+import org.infinity.datatype.IsNumeric;
 import org.infinity.datatype.SectionCount;
 import org.infinity.datatype.SectionOffset;
-import org.infinity.datatype.StringRef;
-import org.infinity.datatype.TextEdit;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.IconLayerItem;
 import org.infinity.icon.Icons;
@@ -117,18 +113,18 @@ public class LayerObjectAutomap extends LayerObject
   private void init()
   {
     if (note != null) {
-      String msg = "";
+      String msg = null;
       try {
-        location.x = ((DecNumber)note.getAttribute(AutomapNote.ARE_AUTOMAP_LOCATION_X)).getValue();
-        location.y = ((DecNumber)note.getAttribute(AutomapNote.ARE_AUTOMAP_LOCATION_Y)).getValue();
-        if (((Bitmap)note.getAttribute(AutomapNote.ARE_AUTOMAP_TEXT_LOCATION)).getValue() == 1) {
+        location.x = ((IsNumeric)note.getAttribute(AutomapNote.ARE_AUTOMAP_LOCATION_X)).getValue();
+        location.y = ((IsNumeric)note.getAttribute(AutomapNote.ARE_AUTOMAP_LOCATION_Y)).getValue();
+        if (((IsNumeric)note.getAttribute(AutomapNote.ARE_AUTOMAP_TEXT_LOCATION)).getValue() == 1) {// 1 - Dialog.tlk
           // fetching string from dialog.tlk
-          msg = ((StringRef)note.getAttribute(AutomapNote.ARE_AUTOMAP_TEXT)).toString();
+          msg = note.getAttribute(AutomapNote.ARE_AUTOMAP_TEXT).toString();
         } else {
           // fetching string from talk override
           msg = "[user-defined]";
           try {
-            int srcStrref = ((StringRef)note.getAttribute(AutomapNote.ARE_AUTOMAP_TEXT)).getValue();
+            int srcStrref = ((IsNumeric)note.getAttribute(AutomapNote.ARE_AUTOMAP_TEXT)).getValue();
             if (srcStrref > 0) {
               String path = getParentStructure().getResourceEntry().getActualPath().toString();
               path = path.replace(getParentStructure().getResourceEntry().getResourceName(), "");
@@ -144,12 +140,12 @@ public class LayerObjectAutomap extends LayerObject
                     for (int i = 0, count = sc.getValue(), curOfs = so.getValue(); i < count; i++) {
                       StrRefEntry2 strref = (StrRefEntry2)toh.getAttribute(curOfs, false);
                       if (strref != null) {
-                        int v = ((StringRef)strref.getAttribute(StrRefEntry2.TOH_STRREF_OVERRIDDEN)).getValue();
+                        int v = ((IsNumeric)strref.getAttribute(StrRefEntry2.TOH_STRREF_OVERRIDDEN)).getValue();
                         if (v == srcStrref) {
-                          int sofs = ((HexNumber)strref.getAttribute(StrRefEntry2.TOH_STRREF_OFFSET_STRING)).getValue();
+                          int sofs = ((IsNumeric)strref.getAttribute(StrRefEntry2.TOH_STRREF_OFFSET_STRING)).getValue();
                           StringEntry2 se = (StringEntry2)toh.getAttribute(so.getValue() + sofs, false);
                           if (se != null) {
-                            msg = ((TextEdit)se.getAttribute(StringEntry2.TOH_STRING_TEXT)).toString();
+                            msg = se.getAttribute(StringEntry2.TOH_STRING_TEXT).toString();
                           }
                           break;
                         }
@@ -172,12 +168,12 @@ public class LayerObjectAutomap extends LayerObject
                     for (int i = 0, count = sc.getValue(), curOfs = 0x14; i < count; i++) {
                       StrRefEntry strref = (StrRefEntry)toh.getAttribute(curOfs, false);
                       if (strref != null) {
-                        int v = ((StringRef)strref.getAttribute(StrRefEntry.TOH_STRREF_OVERRIDDEN)).getValue();
+                        int v = ((IsNumeric)strref.getAttribute(StrRefEntry.TOH_STRREF_OVERRIDDEN)).getValue();
                         if (v == srcStrref) {
-                          int sofs = ((HexNumber)strref.getAttribute(StrRefEntry.TOH_STRREF_OFFSET_TOT_STRING)).getValue();
+                          int sofs = ((IsNumeric)strref.getAttribute(StrRefEntry.TOH_STRREF_OFFSET_TOT_STRING)).getValue();
                           StringEntry se = (StringEntry)tot.getAttribute(sofs, false);
                           if (se != null) {
-                            msg = ((TextEdit)se.getAttribute(StringEntry.TOT_STRING_TEXT)).toString();
+                            msg = se.getAttribute(StringEntry.TOT_STRING_TEXT).toString();
                           }
                           break;
                         }
@@ -199,7 +195,7 @@ public class LayerObjectAutomap extends LayerObject
       // Using cached icons
       final Image[] icons = getIcons(ICONS);
 
-      item = new IconLayerItem(note, msg, msg, icons[0], CENTER);
+      item = new IconLayerItem(note, msg, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelMapNotes);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
@@ -22,8 +22,8 @@ import org.infinity.resource.are.viewer.icon.ViewerIcons;
  */
 public class LayerObjectAutomapPST extends LayerObject
 {
-  private static final Image[] ICON = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AUTOMAP_1),
-                                       Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AUTOMAP_2)};
+  private static final Image[] ICONS = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AUTOMAP_1),
+                                        Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AUTOMAP_2)};
   private static final Point CENTER = new Point(26, 26);
   private static final double MapScale = 32.0 / 3.0;    // scaling factor for MOS to TIS coordinates
 
@@ -114,21 +114,12 @@ public class LayerObjectAutomapPST extends LayerObject
       }
 
       // Using cached icons
-      Image[] icon;
-      String keyIcon = String.format("%s%s", SharedResourceCache.createKey(ICON[0]),
-                                                 SharedResourceCache.createKey(ICON[1]));
-      if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
-        icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);
-      } else {
-        icon = ICON;
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
-      }
+      final Image[] icons = getIcons(ICONS);
 
-      item = new IconLayerItem(note, msg, msg, icon[0], CENTER);
+      item = new IconLayerItem(note, msg, msg, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelMapNotes);
       item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
+      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
       item.setVisible(isVisible());
     }
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
@@ -35,7 +35,7 @@ public class LayerObjectAutomapPST extends LayerObject
 
   public LayerObjectAutomapPST(AreResource parent, AutomapNotePST note)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Automap", AutomapNotePST.class, parent);
+    super("Automap", AutomapNotePST.class, parent);
     this.note = note;
     init();
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
@@ -7,8 +7,7 @@ package org.infinity.resource.are.viewer;
 import java.awt.Image;
 import java.awt.Point;
 
-import org.infinity.datatype.DecNumber;
-import org.infinity.datatype.TextString;
+import org.infinity.datatype.IsNumeric;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.IconLayerItem;
 import org.infinity.icon.Icons;
@@ -25,7 +24,7 @@ public class LayerObjectAutomapPST extends LayerObject
   private static final Image[] ICONS = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AUTOMAP_1),
                                         Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_AUTOMAP_2)};
   private static final Point CENTER = new Point(26, 26);
-  private static final double MapScale = 32.0 / 3.0;    // scaling factor for MOS to TIS coordinates
+  private static final double MAP_SCALE = 32.0 / 3.0;    // scaling factor for MOS to TIS coordinates
 
   private final AutomapNotePST note;
   private final Point location = new Point();
@@ -102,13 +101,13 @@ public class LayerObjectAutomapPST extends LayerObject
   private void init()
   {
     if (note != null) {
-      String msg = "";
+      String msg = null;
       try {
-        int v = ((DecNumber)note.getAttribute(AutomapNotePST.ARE_AUTOMAP_LOCATION_X)).getValue();
-        location.x = (int)(v * MapScale);
-        v = ((DecNumber)note.getAttribute(AutomapNotePST.ARE_AUTOMAP_LOCATION_Y)).getValue();
-        location.y = (int)(v * MapScale);
-        msg = ((TextString)note.getAttribute(AutomapNotePST.ARE_AUTOMAP_TEXT)).toString();
+        final IsNumeric x = (IsNumeric)note.getAttribute(AutomapNotePST.ARE_AUTOMAP_LOCATION_X);
+        final IsNumeric y = (IsNumeric)note.getAttribute(AutomapNotePST.ARE_AUTOMAP_LOCATION_Y);
+        location.x = (int)(x.getValue() * MAP_SCALE);
+        location.y = (int)(y.getValue() * MAP_SCALE);
+        msg = note.getAttribute(AutomapNotePST.ARE_AUTOMAP_TEXT).toString();
       } catch (Exception e) {
         e.printStackTrace();
       }
@@ -116,7 +115,7 @@ public class LayerObjectAutomapPST extends LayerObject
       // Using cached icons
       final Image[] icons = getIcons(ICONS);
 
-      item = new IconLayerItem(note, msg, msg, icons[0], CENTER);
+      item = new IconLayerItem(note, msg, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelMapNotes);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
@@ -47,18 +47,6 @@ public class LayerObjectAutomapPST extends LayerObject
   }
 
   @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{note};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return item;
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     return (type == 0) ? item : null;
@@ -71,30 +59,12 @@ public class LayerObjectAutomapPST extends LayerObject
   }
 
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public void update(double zoomFactor)
   {
     if (note != null) {
       item.setItemLocation((int)(location.x*zoomFactor + (zoomFactor / 2.0)),
                            (int)(location.y*zoomFactor + (zoomFactor / 2.0)));
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location};
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -40,6 +40,7 @@ public class LayerObjectAutomapPST extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -96,6 +97,7 @@ public class LayerObjectAutomapPST extends LayerObject
   {
     return new Point[]{location};
   }
+  //</editor-fold>
 
   private void init()
   {
@@ -123,7 +125,7 @@ public class LayerObjectAutomapPST extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, note, msg, msg, icon[0], CENTER);
+      item = new IconLayerItem(note, msg, msg, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelMapNotes);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
@@ -126,7 +126,6 @@ public class LayerObjectAutomapPST extends LayerObject
       item = new IconLayerItem(location, note, msg, msg, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelMapNotes);
       item.setName(getCategory());
-      item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
       item.setVisible(isVisible());
     }

--- a/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectAutomapPST.java
@@ -29,14 +29,32 @@ public class LayerObjectAutomapPST extends LayerObject
   private final AutomapNotePST note;
   private final Point location = new Point();
 
-  private IconLayerItem item;
+  private final IconLayerItem item;
 
 
   public LayerObjectAutomapPST(AreResource parent, AutomapNotePST note)
   {
     super("Automap", AutomapNotePST.class, parent);
     this.note = note;
-    init();
+    String msg = null;
+    try {
+      final IsNumeric x = (IsNumeric)note.getAttribute(AutomapNotePST.ARE_AUTOMAP_LOCATION_X);
+      final IsNumeric y = (IsNumeric)note.getAttribute(AutomapNotePST.ARE_AUTOMAP_LOCATION_Y);
+      location.x = (int)(x.getValue() * MAP_SCALE);
+      location.y = (int)(y.getValue() * MAP_SCALE);
+      msg = note.getAttribute(AutomapNotePST.ARE_AUTOMAP_TEXT).toString();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    // Using cached icons
+    final Image[] icons = getIcons(ICONS);
+
+    item = new IconLayerItem(note, msg, icons[0], CENTER);
+    item.setLabelEnabled(Settings.ShowLabelMapNotes);
+    item.setName(getCategory());
+    item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
+    item.setVisible(isVisible());
   }
 
   //<editor-fold defaultstate="collapsed" desc="LayerObject">
@@ -67,29 +85,4 @@ public class LayerObjectAutomapPST extends LayerObject
     }
   }
   //</editor-fold>
-
-  private void init()
-  {
-    if (note != null) {
-      String msg = null;
-      try {
-        final IsNumeric x = (IsNumeric)note.getAttribute(AutomapNotePST.ARE_AUTOMAP_LOCATION_X);
-        final IsNumeric y = (IsNumeric)note.getAttribute(AutomapNotePST.ARE_AUTOMAP_LOCATION_Y);
-        location.x = (int)(x.getValue() * MAP_SCALE);
-        location.y = (int)(y.getValue() * MAP_SCALE);
-        msg = note.getAttribute(AutomapNotePST.ARE_AUTOMAP_TEXT).toString();
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-
-      // Using cached icons
-      final Image[] icons = getIcons(ICONS);
-
-      item = new IconLayerItem(note, msg, icons[0], CENTER);
-      item.setLabelEnabled(Settings.ShowLabelMapNotes);
-      item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
-      item.setVisible(isVisible());
-    }
-  }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
@@ -100,40 +100,38 @@ public class LayerObjectContainer extends LayerObject
 
   private String getAttributes()
   {
-    StringBuilder sb = new StringBuilder();
-    if (container != null) {
-      sb.append('[');
+    final StringBuilder sb = new StringBuilder();
+    sb.append('[');
 
-      boolean isLocked = ((Flag)container.getAttribute(Container.ARE_CONTAINER_FLAGS)).isFlagSet(0);
-      if (isLocked) {
-        int v = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_LOCK_DIFFICULTY)).getValue();
-        if (v > 0) {
-          sb.append("Locked (").append(v).append(')');
-          final ResourceRef key = (ResourceRef)container.getAttribute(Container.ARE_CONTAINER_KEY);
-          if (!key.isEmpty()) {
-            sb.append(", Key: ").append(key);
-          }
+    final boolean isLocked = ((Flag)container.getAttribute(Container.ARE_CONTAINER_FLAGS)).isFlagSet(0);
+    if (isLocked) {
+      int v = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_LOCK_DIFFICULTY)).getValue();
+      if (v > 0) {
+        sb.append("Locked (").append(v).append(')');
+        final ResourceRef key = (ResourceRef)container.getAttribute(Container.ARE_CONTAINER_KEY);
+        if (key != null && !key.isEmpty()) {
+          sb.append(", Key: ").append(key);
         }
       }
-
-      boolean isTrapped = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_TRAPPED)).getValue() != 0;
-      if (isTrapped) {
-        int v = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_TRAP_REMOVAL_DIFFICULTY)).getValue();
-        if (v > 0) {
-          if (sb.length() > 1) sb.append(", ");
-          sb.append("Trapped (").append(v).append(')');
-        }
-      }
-
-      final ResourceRef script = (ResourceRef)container.getAttribute(Container.ARE_CONTAINER_SCRIPT_TRAP);
-      if (!script.isEmpty()) {
-        if (sb.length() > 1) sb.append(", ");
-        sb.append("Script: ").append(script);
-      }
-
-      if (sb.length() == 1) sb.append("No Flags");
-      sb.append(']');
     }
+
+    final boolean isTrapped = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_TRAPPED)).getValue() != 0;
+    if (isTrapped) {
+      int v = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_TRAP_REMOVAL_DIFFICULTY)).getValue();
+      if (v > 0) {
+        if (sb.length() > 1) sb.append(", ");
+        sb.append("Trapped (").append(v).append(')');
+      }
+    }
+
+    final ResourceRef script = (ResourceRef)container.getAttribute(Container.ARE_CONTAINER_SCRIPT_TRAP);
+    if (script != null && !script.isEmpty()) {
+      if (sb.length() > 1) sb.append(", ");
+      sb.append("Script: ").append(script);
+    }
+
+    if (sb.length() == 1) sb.append("No Flags");
+    sb.append(']');
     return sb.toString();
   }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
@@ -150,7 +150,7 @@ public class LayerObjectContainer extends LayerObject
       }
 
       location.x = bounds.x; location.y = bounds.y;
-      item = new ShapedLayerItem(location, container, msg, msg, poly);
+      item = new ShapedLayerItem(container, msg, msg, poly);
       item.setName(getCategory());
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
@@ -11,7 +11,6 @@ import java.awt.Rectangle;
 
 import org.infinity.datatype.Flag;
 import org.infinity.datatype.IsNumeric;
-import org.infinity.datatype.ResourceRef;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.ShapedLayerItem;
 import org.infinity.resource.Viewable;
@@ -108,27 +107,14 @@ public class LayerObjectContainer extends LayerObject
       int v = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_LOCK_DIFFICULTY)).getValue();
       if (v > 0) {
         sb.append("Locked (").append(v).append(')');
-        final ResourceRef key = (ResourceRef)container.getAttribute(Container.ARE_CONTAINER_KEY);
-        if (key != null && !key.isEmpty()) {
-          sb.append(", Key: ").append(key);
-        }
+        addResResDesc(sb, container, Container.ARE_CONTAINER_KEY, "Key: ");
       }
     }
 
-    final boolean isTrapped = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_TRAPPED)).getValue() != 0;
-    if (isTrapped) {
-      int v = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_TRAP_REMOVAL_DIFFICULTY)).getValue();
-      if (v > 0) {
-        if (sb.length() > 1) sb.append(", ");
-        sb.append("Trapped (").append(v).append(')');
-      }
-    }
-
-    final ResourceRef script = (ResourceRef)container.getAttribute(Container.ARE_CONTAINER_SCRIPT_TRAP);
-    if (script != null && !script.isEmpty()) {
-      if (sb.length() > 1) sb.append(", ");
-      sb.append("Script: ").append(script);
-    }
+    addTrappedDesc(sb, container,
+                   Container.ARE_CONTAINER_TRAPPED,
+                   Container.ARE_CONTAINER_TRAP_REMOVAL_DIFFICULTY,
+                   Container.ARE_CONTAINER_SCRIPT_TRAP);
 
     if (sb.length() == 1) sb.append("No Flags");
     sb.append(']');

--- a/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
@@ -9,13 +9,9 @@ import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 
-import org.infinity.datatype.Bitmap;
-import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.Flag;
-import org.infinity.datatype.HexNumber;
 import org.infinity.datatype.IsNumeric;
-import org.infinity.datatype.IsTextual;
-import org.infinity.datatype.TextString;
+import org.infinity.datatype.ResourceRef;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.ShapedLayerItem;
 import org.infinity.resource.Viewable;
@@ -28,9 +24,6 @@ import org.infinity.resource.vertex.Vertex;
  */
 public class LayerObjectContainer extends LayerObject
 {
-  private static final String[] TYPE = {"Unknown", "Bag", "Chest", "Drawer", "Pile",
-                                        "Table", "Shelf", "Altar", "Invisible",
-                                        "Spellbook", "Body", "Barrel", "Crate"};
   private static final Color[] COLOR = {new Color(0xFF004040, true), new Color(0xFF004040, true),
                                         new Color(0xC0008080, true), new Color(0xC000C0C0, true)};
 
@@ -122,17 +115,17 @@ public class LayerObjectContainer extends LayerObject
   {
     if (container != null) {
       shapeCoords = null;
-      String msg = "";
+      String msg = null;
       Polygon poly = null;
       Rectangle bounds = null;
       try {
-        int type = ((Bitmap)container.getAttribute(Container.ARE_CONTAINER_TYPE)).getValue();
-        if (type < 0) type = 0; else if (type >= TYPE.length) type = TYPE.length - 1;
+        int type = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_TYPE)).getValue();
+        if (type < 0) type = 0; else if (type >= Container.s_type.length) type = Container.s_type.length - 1;
         msg = String.format("%s (%s) %s",
-                            ((TextString)container.getAttribute(Container.ARE_CONTAINER_NAME)).toString(),
-                            TYPE[type], getAttributes());
-        int vNum = ((DecNumber)container.getAttribute(Container.ARE_CONTAINER_NUM_VERTICES)).getValue();
-        int vOfs = ((HexNumber)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
+                            container.getAttribute(Container.ARE_CONTAINER_NAME).toString(),
+                            Container.s_type[type], getAttributes());
+        int vNum = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_NUM_VERTICES)).getValue();
+        int vOfs = ((IsNumeric)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
         shapeCoords = loadVertices(container, vOfs, 0, vNum, Vertex.class);
         poly = createPolygon(shapeCoords, 1.0);
         bounds = normalizePolygon(poly);
@@ -150,7 +143,7 @@ public class LayerObjectContainer extends LayerObject
       }
 
       location.x = bounds.x; location.y = bounds.y;
-      item = new ShapedLayerItem(container, msg, msg, poly);
+      item = new ShapedLayerItem(container, msg, poly);
       item.setName(getCategory());
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);
@@ -173,9 +166,9 @@ public class LayerObjectContainer extends LayerObject
         int v = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_LOCK_DIFFICULTY)).getValue();
         if (v > 0) {
           sb.append("Locked (").append(v).append(')');
-          String key = ((IsTextual)container.getAttribute(Container.ARE_CONTAINER_KEY)).getText();
-          if (!key.isEmpty() && !key.equalsIgnoreCase("NONE")) {
-            sb.append(", Key: ").append(key).append(".ITM");
+          final ResourceRef key = (ResourceRef)container.getAttribute(Container.ARE_CONTAINER_KEY);
+          if (!key.isEmpty()) {
+            sb.append(", Key: ").append(key);
           }
         }
       }
@@ -189,10 +182,10 @@ public class LayerObjectContainer extends LayerObject
         }
       }
 
-      String script = ((IsTextual)container.getAttribute(Container.ARE_CONTAINER_SCRIPT_TRAP)).getText();
-      if (!script.isEmpty() && !script.equalsIgnoreCase("NONE")) {
+      final ResourceRef script = (ResourceRef)container.getAttribute(Container.ARE_CONTAINER_SCRIPT_TRAP);
+      if (!script.isEmpty()) {
         if (sb.length() > 1) sb.append(", ");
-        sb.append("Script: ").append(script).append(".BCS");
+        sb.append("Script: ").append(script);
       }
 
       if (sb.length() == 1) sb.append("No Flags");

--- a/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -47,6 +47,7 @@ public class LayerObjectContainer extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -107,6 +108,7 @@ public class LayerObjectContainer extends LayerObject
   {
     return new Point[]{location};
   }
+  //</editor-fold>
 
   /**
    * Returns vertices of the polygon used to define the container shape.
@@ -150,7 +152,6 @@ public class LayerObjectContainer extends LayerObject
       location.x = bounds.x; location.y = bounds.y;
       item = new ShapedLayerItem(location, container, msg, msg, poly);
       item.setName(getCategory());
-      item.setToolTipText(msg);
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);
       item.setFillColor(AbstractLayerItem.ItemState.NORMAL, COLOR[2]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
@@ -48,18 +48,6 @@ public class LayerObjectContainer extends LayerObject
   }
 
   @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{container};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return item;
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     return (type == 0) ? item : null;
@@ -69,12 +57,6 @@ public class LayerObjectContainer extends LayerObject
   public AbstractLayerItem[] getLayerItems()
   {
     return new AbstractLayerItem[]{item};
-  }
-
-  @Override
-  public void reload()
-  {
-    init();
   }
 
   @Override
@@ -88,18 +70,6 @@ public class LayerObjectContainer extends LayerObject
       normalizePolygon(poly);
       item.setShape(poly);
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location};
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
@@ -42,7 +42,7 @@ public class LayerObjectContainer extends LayerObject
 
   public LayerObjectContainer(AreResource parent, Container container)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Container", Container.class, parent);
+    super("Container", Container.class, parent);
     this.container = container;
     init();
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectContainer.java
@@ -73,21 +73,10 @@ public class LayerObjectContainer extends LayerObject
   }
   //</editor-fold>
 
-  /**
-   * Returns vertices of the polygon used to define the container shape.
-   */
-  public Point[] getShapeCoords()
-  {
-    return shapeCoords;
-  }
-
   private void init()
   {
     if (container != null) {
-      shapeCoords = null;
       String msg = null;
-      Polygon poly = null;
-      Rectangle bounds = null;
       try {
         int type = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_TYPE)).getValue();
         if (type < 0) type = 0; else if (type >= Container.s_type.length) type = Container.s_type.length - 1;
@@ -97,20 +86,11 @@ public class LayerObjectContainer extends LayerObject
         int vNum = ((IsNumeric)container.getAttribute(Container.ARE_CONTAINER_NUM_VERTICES)).getValue();
         int vOfs = ((IsNumeric)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
         shapeCoords = loadVertices(container, vOfs, 0, vNum, Vertex.class);
-        poly = createPolygon(shapeCoords, 1.0);
-        bounds = normalizePolygon(poly);
       } catch (Exception e) {
         e.printStackTrace();
-        if (shapeCoords == null) {
-          shapeCoords = new Point[0];
-        }
-        if (poly == null) {
-          poly = new Polygon();
-        }
-        if (bounds == null) {
-          bounds = new Rectangle();
-        }
       }
+      final Polygon poly = createPolygon(shapeCoords, 1.0);
+      final Rectangle bounds = normalizePolygon(poly);
 
       location.x = bounds.x; location.y = bounds.y;
       item = new ShapedLayerItem(container, msg, poly);

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -11,8 +11,6 @@ import java.awt.Rectangle;
 
 import org.infinity.datatype.Flag;
 import org.infinity.datatype.IsNumeric;
-import org.infinity.datatype.IsTextual;
-import org.infinity.datatype.ResourceRef;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.ShapedLayerItem;
 import org.infinity.resource.Profile;
@@ -131,28 +129,15 @@ public class LayerObjectDoor extends LayerObject
         int bit = (Profile.getEngine() == Profile.Engine.IWD2) ? 14 : 10;
         boolean usesKey = ((Flag)door.getAttribute(Door.ARE_DOOR_FLAGS)).isFlagSet(bit);
         if (usesKey) {
-          final ResourceRef key = (ResourceRef)door.getAttribute(Door.ARE_DOOR_KEY);
-          if (key != null && !key.isEmpty()) {
-            sb.append(", Key: ").append(key);
-          }
+          addResResDesc(sb, door, Door.ARE_DOOR_KEY, "Key: ");
         }
       }
     }
 
-    final boolean isTrapped = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_TRAPPED)).getValue() != 0;
-    if (isTrapped) {
-      int v = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_TRAP_REMOVAL_DIFFICULTY)).getValue();
-      if (v > 0) {
-        if (sb.length() > 1) sb.append(", ");
-        sb.append("Trapped (").append(v).append(')');
-      }
-    }
-
-    final ResourceRef script = (ResourceRef)door.getAttribute(Door.ARE_DOOR_SCRIPT);
-    if (script != null && !script.isEmpty()) {
-      if (sb.length() > 1) sb.append(", ");
-      sb.append("Script: ").append(script);
-    }
+    addTrappedDesc(sb, door,
+                   Door.ARE_DOOR_TRAPPED,
+                   Door.ARE_DOOR_TRAP_REMOVAL_DIFFICULTY,
+                   Door.ARE_DOOR_SCRIPT);
 
     final boolean isSecret = ((Flag)door.getAttribute(Door.ARE_DOOR_FLAGS)).isFlagSet(7);
     if (isSecret) {

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -62,11 +62,7 @@ public class LayerObjectDoor extends LayerObject
     } else {
       type = (type == ViewerConstants.DOOR_OPEN) ? ViewerConstants.DOOR_OPEN : ViewerConstants.DOOR_CLOSED;
     }
-    if (items != null && items.length > type) {
-      return items[type];
-    } else {
-      return null;
-    }
+    return items[type];
   }
 
   @Override
@@ -79,13 +75,11 @@ public class LayerObjectDoor extends LayerObject
   public void update(double zoomFactor)
   {
     for (int i = 0; i < items.length; i++) {
-      if (items[i] != null) {
-        items[i].setItemLocation((int)(location[i].x*zoomFactor + (zoomFactor / 2.0)),
-                                 (int)(location[i].y*zoomFactor + (zoomFactor / 2.0)));
-        Polygon poly = createPolygon(shapeCoords[i], zoomFactor);
-        normalizePolygon(poly);
-        items[i].setShape(poly);
-      }
+      items[i].setItemLocation((int)(location[i].x*zoomFactor + (zoomFactor / 2.0)),
+                               (int)(location[i].y*zoomFactor + (zoomFactor / 2.0)));
+      Polygon poly = createPolygon(shapeCoords[i], zoomFactor);
+      normalizePolygon(poly);
+      items[i].setShape(poly);
     }
   }
   //</editor-fold>

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -38,7 +38,40 @@ public class LayerObjectDoor extends LayerObject
   {
     super("Door", Door.class, parent);
     this.door = door;
-    init();
+    final String[] msg = new String[2];
+    try {
+      String attr = getAttributes();
+      final String name = door.getAttribute(Door.ARE_DOOR_NAME).toString();
+      final int vOfs = ((IsNumeric)parent.getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
+
+      // processing opened state door
+      msg[ViewerConstants.DOOR_OPEN] = String.format("%s (Open) %s", name, attr);
+      int vNum = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_NUM_VERTICES_OPEN)).getValue();
+      shapeCoords[ViewerConstants.DOOR_OPEN] = loadVertices(door, vOfs, 0, vNum, OpenVertex.class);
+
+      // processing closed state door
+      msg[ViewerConstants.DOOR_CLOSED] = String.format("%s (Closed) %s", name, attr);
+      vNum = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_NUM_VERTICES_CLOSED)).getValue();
+      shapeCoords[ViewerConstants.DOOR_CLOSED] = loadVertices(door, vOfs, 0, vNum, ClosedVertex.class);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    for (int i = 0; i < 2; i++) {
+      final Polygon poly = createPolygon(shapeCoords[i], 1.0);
+      final Rectangle bounds = normalizePolygon(poly);
+
+      location[i].x = bounds.x; location[i].y = bounds.y;
+      items[i] = new ShapedLayerItem(door, msg[i], poly);
+      items[i].setName(getCategory());
+      items[i].setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
+      items[i].setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);
+      items[i].setFillColor(AbstractLayerItem.ItemState.NORMAL, COLOR[2]);
+      items[i].setFillColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[3]);
+      items[i].setStroked(true);
+      items[i].setFilled(true);
+      items[i].setVisible(isVisible());
+    }
   }
 
   //<editor-fold defaultstate="collapsed" desc="LayerObject">
@@ -83,46 +116,6 @@ public class LayerObjectDoor extends LayerObject
     }
   }
   //</editor-fold>
-
-  private void init()
-  {
-    if (door != null) {
-      final String[] msg = new String[2];
-      try {
-        String attr = getAttributes();
-        final String name = door.getAttribute(Door.ARE_DOOR_NAME).toString();
-        final int vOfs = ((IsNumeric)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
-
-        // processing opened state door
-        msg[ViewerConstants.DOOR_OPEN] = String.format("%s (Open) %s", name, attr);
-        int vNum = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_NUM_VERTICES_OPEN)).getValue();
-        shapeCoords[ViewerConstants.DOOR_OPEN] = loadVertices(door, vOfs, 0, vNum, OpenVertex.class);
-
-        // processing closed state door
-        msg[ViewerConstants.DOOR_CLOSED] = String.format("%s (Closed) %s", name, attr);
-        vNum = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_NUM_VERTICES_CLOSED)).getValue();
-        shapeCoords[ViewerConstants.DOOR_CLOSED] = loadVertices(door, vOfs, 0, vNum, ClosedVertex.class);
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-
-      for (int i = 0; i < 2; i++) {
-        final Polygon poly = createPolygon(shapeCoords[i], 1.0);
-        final Rectangle bounds = normalizePolygon(poly);
-
-        location[i].x = bounds.x; location[i].y = bounds.y;
-        items[i] = new ShapedLayerItem(door, msg[i], poly);
-        items[i].setName(getCategory());
-        items[i].setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
-        items[i].setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);
-        items[i].setFillColor(AbstractLayerItem.ItemState.NORMAL, COLOR[2]);
-        items[i].setFillColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[3]);
-        items[i].setStroked(true);
-        items[i].setFilled(true);
-        items[i].setVisible(isVisible());
-      }
-    }
-  }
 
   private String getAttributes()
   {

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -44,6 +44,7 @@ public class LayerObjectDoor extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -120,7 +121,7 @@ public class LayerObjectDoor extends LayerObject
   {
     return location;
   }
-
+  //</editor-fold>
 
   private void init()
   {
@@ -167,7 +168,6 @@ public class LayerObjectDoor extends LayerObject
         location[i].x = bounds[i].x; location[i].y = bounds[i].y;
         items[i] = new ShapedLayerItem(location[i], door, msg[i], msg[i], poly[i]);
         items[i].setName(getCategory());
-        items[i].setToolTipText(msg[i]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);
         items[i].setFillColor(AbstractLayerItem.ItemState.NORMAL, COLOR[2]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -39,7 +39,7 @@ public class LayerObjectDoor extends LayerObject
 
   public LayerObjectDoor(AreResource parent, Door door)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Door", Door.class, parent);
+    super("Door", Door.class, parent);
     this.door = door;
     init();
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -9,12 +9,9 @@ import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 
-import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.Flag;
-import org.infinity.datatype.HexNumber;
 import org.infinity.datatype.IsNumeric;
 import org.infinity.datatype.IsTextual;
-import org.infinity.datatype.TextString;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.ShapedLayerItem;
 import org.infinity.resource.Profile;
@@ -128,24 +125,24 @@ public class LayerObjectDoor extends LayerObject
     if (door != null) {
       shapeCoords[ViewerConstants.DOOR_OPEN] = null;
       shapeCoords[ViewerConstants.DOOR_CLOSED] = null;
-      String[] msg = new String[]{"", ""};
-      Polygon[] poly = new Polygon[]{null, null};
-      Rectangle[] bounds = new Rectangle[]{null, null};
+      final String[] msg = new String[2];
+      final Polygon[] poly = new Polygon[2];
+      final Rectangle[] bounds = new Rectangle[2];
       try {
         String attr = getAttributes();
+        final String name = door.getAttribute(Door.ARE_DOOR_NAME).toString();
+        final int vOfs = ((IsNumeric)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
 
         // processing opened state door
-        msg[0] = String.format("%s (Open) %s", ((TextString)door.getAttribute(Door.ARE_DOOR_NAME)).toString(), attr);
-        int vNum = ((DecNumber)door.getAttribute(Door.ARE_DOOR_NUM_VERTICES_OPEN)).getValue();
-        int vOfs = ((HexNumber)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
+        msg[ViewerConstants.DOOR_OPEN] = String.format("%s (Open) %s", name, attr);
+        int vNum = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_NUM_VERTICES_OPEN)).getValue();
         shapeCoords[ViewerConstants.DOOR_OPEN] = loadVertices(door, vOfs, 0, vNum, OpenVertex.class);
         poly[ViewerConstants.DOOR_OPEN] = createPolygon(shapeCoords[ViewerConstants.DOOR_OPEN], 1.0);
         bounds[ViewerConstants.DOOR_OPEN] = normalizePolygon(poly[ViewerConstants.DOOR_OPEN]);
 
         // processing closed state door
-        msg[1] = String.format("%s (Closed) %s", ((TextString)door.getAttribute(Door.ARE_DOOR_NAME)).toString(), attr);
-        vNum = ((DecNumber)door.getAttribute(Door.ARE_DOOR_NUM_VERTICES_CLOSED)).getValue();
-        vOfs = ((HexNumber)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
+        msg[ViewerConstants.DOOR_CLOSED] = String.format("%s (Closed) %s", name, attr);
+        vNum = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_NUM_VERTICES_CLOSED)).getValue();
         shapeCoords[ViewerConstants.DOOR_CLOSED] = loadVertices(door, vOfs, 0, vNum, ClosedVertex.class);
         poly[ViewerConstants.DOOR_CLOSED] = createPolygon(shapeCoords[ViewerConstants.DOOR_CLOSED], 1.0);
         bounds[ViewerConstants.DOOR_CLOSED] = normalizePolygon(poly[ViewerConstants.DOOR_CLOSED]);
@@ -166,7 +163,7 @@ public class LayerObjectDoor extends LayerObject
 
       for (int i = 0; i < 2; i++) {
         location[i].x = bounds[i].x; location[i].y = bounds[i].y;
-        items[i] = new ShapedLayerItem(door, msg[i], msg[i], poly[i]);
+        items[i] = new ShapedLayerItem(door, msg[i], poly[i]);
         items[i].setName(getCategory());
         items[i].setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -166,7 +166,7 @@ public class LayerObjectDoor extends LayerObject
 
       for (int i = 0; i < 2; i++) {
         location[i].x = bounds[i].x; location[i].y = bounds[i].y;
-        items[i] = new ShapedLayerItem(location[i], door, msg[i], msg[i], poly[i]);
+        items[i] = new ShapedLayerItem(door, msg[i], msg[i], poly[i]);
         items[i].setName(getCategory());
         items[i].setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -12,6 +12,7 @@ import java.awt.Rectangle;
 import org.infinity.datatype.Flag;
 import org.infinity.datatype.IsNumeric;
 import org.infinity.datatype.IsTextual;
+import org.infinity.datatype.ResourceRef;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.ShapedLayerItem;
 import org.infinity.resource.Profile;
@@ -119,50 +120,48 @@ public class LayerObjectDoor extends LayerObject
 
   private String getAttributes()
   {
-    StringBuilder sb = new StringBuilder();
-    if (door != null) {
-      sb.append('[');
+    final StringBuilder sb = new StringBuilder();
+    sb.append('[');
 
-      boolean isLocked = ((Flag)door.getAttribute(Door.ARE_DOOR_FLAGS)).isFlagSet(1);
-      if (isLocked) {
-        int v = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_LOCK_DIFFICULTY)).getValue();
-        if (v > 0) {
-          sb.append("Locked (").append(v).append(')');
-          int bit = (Profile.getEngine() == Profile.Engine.IWD2) ? 14 : 10;
-          boolean usesKey = ((Flag)door.getAttribute(Door.ARE_DOOR_FLAGS)).isFlagSet(bit);
-          if (usesKey) {
-            String key = ((IsTextual)door.getAttribute(Door.ARE_DOOR_KEY)).getText();
-            if (!key.isEmpty() && !key.equalsIgnoreCase("NONE")) {
-              sb.append(", Key: ").append(key).append(".ITM");
-            }
+    final boolean isLocked = ((Flag)door.getAttribute(Door.ARE_DOOR_FLAGS)).isFlagSet(1);
+    if (isLocked) {
+      int v = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_LOCK_DIFFICULTY)).getValue();
+      if (v > 0) {
+        sb.append("Locked (").append(v).append(')');
+        int bit = (Profile.getEngine() == Profile.Engine.IWD2) ? 14 : 10;
+        boolean usesKey = ((Flag)door.getAttribute(Door.ARE_DOOR_FLAGS)).isFlagSet(bit);
+        if (usesKey) {
+          final ResourceRef key = (ResourceRef)door.getAttribute(Door.ARE_DOOR_KEY);
+          if (key != null && !key.isEmpty()) {
+            sb.append(", Key: ").append(key);
           }
         }
       }
-
-      boolean isTrapped = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_TRAPPED)).getValue() != 0;
-      if (isTrapped) {
-        int v = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_TRAP_REMOVAL_DIFFICULTY)).getValue();
-        if (v > 0) {
-          if (sb.length() > 1) sb.append(", ");
-          sb.append("Trapped (").append(v).append(')');
-        }
-      }
-
-      String script = ((IsTextual)door.getAttribute(Door.ARE_DOOR_SCRIPT)).getText();
-      if (!script.isEmpty() && !script.equalsIgnoreCase("NONE")) {
-        if (sb.length() > 1) sb.append(", ");
-        sb.append("Script: ").append(script).append(".BCS");
-      }
-
-      boolean isSecret = ((Flag)door.getAttribute(Door.ARE_DOOR_FLAGS)).isFlagSet(7);
-      if (isSecret) {
-        if (sb.length() > 1) sb.append(", ");
-        sb.append("Secret door");
-      }
-
-      if (sb.length() == 1) sb.append("No flags");
-      sb.append(']');
     }
+
+    final boolean isTrapped = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_TRAPPED)).getValue() != 0;
+    if (isTrapped) {
+      int v = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_TRAP_REMOVAL_DIFFICULTY)).getValue();
+      if (v > 0) {
+        if (sb.length() > 1) sb.append(", ");
+        sb.append("Trapped (").append(v).append(')');
+      }
+    }
+
+    final ResourceRef script = (ResourceRef)door.getAttribute(Door.ARE_DOOR_SCRIPT);
+    if (script != null && !script.isEmpty()) {
+      if (sb.length() > 1) sb.append(", ");
+      sb.append("Script: ").append(script);
+    }
+
+    final boolean isSecret = ((Flag)door.getAttribute(Door.ARE_DOOR_FLAGS)).isFlagSet(7);
+    if (isSecret) {
+      if (sb.length() > 1) sb.append(", ");
+      sb.append("Secret door");
+    }
+
+    if (sb.length() == 1) sb.append("No flags");
+    sb.append(']');
     return sb.toString();
   }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -93,11 +93,7 @@ public class LayerObjectDoor extends LayerObject
   private void init()
   {
     if (door != null) {
-      shapeCoords[ViewerConstants.DOOR_OPEN] = null;
-      shapeCoords[ViewerConstants.DOOR_CLOSED] = null;
       final String[] msg = new String[2];
-      final Polygon[] poly = new Polygon[2];
-      final Rectangle[] bounds = new Rectangle[2];
       try {
         String attr = getAttributes();
         final String name = door.getAttribute(Door.ARE_DOOR_NAME).toString();
@@ -107,33 +103,21 @@ public class LayerObjectDoor extends LayerObject
         msg[ViewerConstants.DOOR_OPEN] = String.format("%s (Open) %s", name, attr);
         int vNum = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_NUM_VERTICES_OPEN)).getValue();
         shapeCoords[ViewerConstants.DOOR_OPEN] = loadVertices(door, vOfs, 0, vNum, OpenVertex.class);
-        poly[ViewerConstants.DOOR_OPEN] = createPolygon(shapeCoords[ViewerConstants.DOOR_OPEN], 1.0);
-        bounds[ViewerConstants.DOOR_OPEN] = normalizePolygon(poly[ViewerConstants.DOOR_OPEN]);
 
         // processing closed state door
         msg[ViewerConstants.DOOR_CLOSED] = String.format("%s (Closed) %s", name, attr);
         vNum = ((IsNumeric)door.getAttribute(Door.ARE_DOOR_NUM_VERTICES_CLOSED)).getValue();
         shapeCoords[ViewerConstants.DOOR_CLOSED] = loadVertices(door, vOfs, 0, vNum, ClosedVertex.class);
-        poly[ViewerConstants.DOOR_CLOSED] = createPolygon(shapeCoords[ViewerConstants.DOOR_CLOSED], 1.0);
-        bounds[ViewerConstants.DOOR_CLOSED] = normalizePolygon(poly[ViewerConstants.DOOR_CLOSED]);
       } catch (Exception e) {
         e.printStackTrace();
-        for (int i = 0; i < 2; i++) {
-          if (shapeCoords[i] == null) {
-            shapeCoords[i] = new Point[0];
-          }
-          if (poly[i] == null) {
-            poly[i] = new Polygon();
-          }
-          if (bounds[i] == null) {
-            bounds[i] = new Rectangle();
-          }
-        }
       }
 
       for (int i = 0; i < 2; i++) {
-        location[i].x = bounds[i].x; location[i].y = bounds[i].y;
-        items[i] = new ShapedLayerItem(door, msg[i], poly[i]);
+        final Polygon poly = createPolygon(shapeCoords[i], 1.0);
+        final Rectangle bounds = normalizePolygon(poly);
+
+        location[i].x = bounds.x; location[i].y = bounds.y;
+        items[i] = new ShapedLayerItem(door, msg[i], poly);
         items[i].setName(getCategory());
         items[i].setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoor.java
@@ -48,18 +48,6 @@ public class LayerObjectDoor extends LayerObject
     return door;
   }
 
-  @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{door};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return items[ViewerConstants.DOOR_OPEN];
-  }
-
   /**
    * Returns the layer item of specified state.
    * @param type The open/closed state of the item.
@@ -88,12 +76,6 @@ public class LayerObjectDoor extends LayerObject
   }
 
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public void update(double zoomFactor)
   {
     for (int i = 0; i < items.length; i++) {
@@ -105,18 +87,6 @@ public class LayerObjectDoor extends LayerObject
         items[i].setShape(poly);
       }
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location[0];
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return location;
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
@@ -25,7 +25,11 @@ import org.infinity.resource.wed.Door;
 import org.infinity.resource.wed.WedResource;
 
 /**
- * Handles specific layer type: WED/Door Polygon
+ * Handles specific layer type: WED/Door Polygon.
+ * <p>
+ * Polygon represents clickable area for interaction with door. As a rule, closed
+ * state geometry of door polygon matches opened state geometry of the
+ * {@link LayerObjectDoor door itself} and vice versa.
  */
 public class LayerObjectDoorPoly extends LayerObject
 {
@@ -41,7 +45,7 @@ public class LayerObjectDoorPoly extends LayerObject
 
   public LayerObjectDoorPoly(WedResource parent, Door doorPoly)
   {
-    super(ViewerConstants.RESOURCE_WED, "Door Poly", Door.class, parent);
+    super("Door Poly", Door.class, parent);
     this.door = doorPoly;
     init();
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
@@ -55,22 +55,6 @@ public class LayerObjectDoorPoly extends LayerObject
   }
 
   @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{door};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    if (items.length > 0) {
-      return items[0];
-    } else {
-      return null;
-    }
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     if (Profile.getEngine() == Profile.Engine.PST) {
@@ -93,12 +77,6 @@ public class LayerObjectDoorPoly extends LayerObject
   }
 
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public void update(double zoomFactor)
   {
     for (int i = 0; i < items.length; i++) {
@@ -109,22 +87,6 @@ public class LayerObjectDoorPoly extends LayerObject
       normalizePolygon(poly);
       items[i].setShape(poly);
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    if (location.length > 0) {
-      return location[0];
-    } else {
-      return null;
-    }
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return location;
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
@@ -46,6 +46,7 @@ public class LayerObjectDoorPoly extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -124,6 +125,7 @@ public class LayerObjectDoorPoly extends LayerObject
   {
     return location;
   }
+  //</editor-fold>
 
   /**
    * Returns the number of layer items for a specific open/closed state.
@@ -265,7 +267,6 @@ public class LayerObjectDoorPoly extends LayerObject
         location[i] = new Point(bounds[i].x, bounds[i].y);
         items[i] = new ShapedLayerItem(location[i], door, msg[i], info[i], poly[i]);
         items[i].setName(getCategory());
-        items[i].setToolTipText(info[i]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);
         items[i].setFillColor(AbstractLayerItem.ItemState.NORMAL, COLOR[2]);
@@ -295,7 +296,7 @@ public class LayerObjectDoorPoly extends LayerObject
     return null;
   }
 
-  // Returns a flags string
+  /** Returns a flags string. */
   private String createFlags(Flag flags, String[] desc)
   {
     if (flags != null) {

--- a/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectDoorPoly.java
@@ -265,7 +265,7 @@ public class LayerObjectDoorPoly extends LayerObject
       items = new ShapedLayerItem[count];
       for (int i = 0; i < count; i++) {
         location[i] = new Point(bounds[i].x, bounds[i].y);
-        items[i] = new ShapedLayerItem(location[i], door, msg[i], info[i], poly[i]);
+        items[i] = new ShapedLayerItem(door, msg[i], info[i], poly[i]);
         items[i].setName(getCategory());
         items[i].setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
         items[i].setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -40,6 +40,7 @@ public class LayerObjectEntrance extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -96,6 +97,7 @@ public class LayerObjectEntrance extends LayerObject
   {
     return new Point[]{location};
   }
+  //</editor-fold>
 
   private void init()
   {
@@ -126,7 +128,7 @@ public class LayerObjectEntrance extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, entrance, msg, info, icon[0], CENTER);
+      item = new IconLayerItem(entrance, msg, info, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelEntrances);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
@@ -7,9 +7,7 @@ package org.infinity.resource.are.viewer;
 import java.awt.Image;
 import java.awt.Point;
 
-import org.infinity.datatype.Bitmap;
-import org.infinity.datatype.DecNumber;
-import org.infinity.datatype.TextString;
+import org.infinity.datatype.IsNumeric;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.IconLayerItem;
 import org.infinity.icon.Icons;
@@ -102,16 +100,14 @@ public class LayerObjectEntrance extends LayerObject
   private void init()
   {
     if (entrance != null) {
-      String info = "";
-      String msg = "";
+      String msg = null;
       try {
-        location.x = ((DecNumber)entrance.getAttribute(Entrance.ARE_ENTRANCE_LOCATION_X)).getValue();
-        location.y = ((DecNumber)entrance.getAttribute(Entrance.ARE_ENTRANCE_LOCATION_Y)).getValue();
-        int o = ((Bitmap)entrance.getAttribute(Entrance.ARE_ENTRANCE_ORIENTATION)).getValue();
+        location.x = ((IsNumeric)entrance.getAttribute(Entrance.ARE_ENTRANCE_LOCATION_X)).getValue();
+        location.y = ((IsNumeric)entrance.getAttribute(Entrance.ARE_ENTRANCE_LOCATION_Y)).getValue();
+        int o = ((IsNumeric)entrance.getAttribute(Entrance.ARE_ENTRANCE_ORIENTATION)).getValue();
         if (o < 0) o = 0; else if (o >= Actor.s_orientation.length) o = Actor.s_orientation.length - 1;
-        info = ((TextString)entrance.getAttribute(Entrance.ARE_ENTRANCE_NAME)).toString();
-        msg = String.format("%s (%s)", ((TextString)entrance.getAttribute(Entrance.ARE_ENTRANCE_NAME)).toString(),
-                            Actor.s_orientation[o]);
+        final String name = entrance.getAttribute(Entrance.ARE_ENTRANCE_NAME).toString();
+        msg = String.format("%s (%s)", name, Actor.s_orientation[o]);
       } catch (Exception e) {
         e.printStackTrace();
       }
@@ -119,7 +115,7 @@ public class LayerObjectEntrance extends LayerObject
       // Using cached icons
       final Image[] icons = getIcons(ICONS);
 
-      item = new IconLayerItem(entrance, msg, info, icons[0], CENTER);
+      item = new IconLayerItem(entrance, msg, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelEntrances);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
@@ -29,13 +29,32 @@ public class LayerObjectEntrance extends LayerObject
   private final Entrance entrance;
   private final Point location = new Point();
 
-  private IconLayerItem item;
+  private final IconLayerItem item;
 
   public LayerObjectEntrance(AreResource parent, Entrance entrance)
   {
     super("Entrance", Entrance.class, parent);
     this.entrance = entrance;
-    init();
+    String msg = null;
+    try {
+      location.x = ((IsNumeric)entrance.getAttribute(Entrance.ARE_ENTRANCE_LOCATION_X)).getValue();
+      location.y = ((IsNumeric)entrance.getAttribute(Entrance.ARE_ENTRANCE_LOCATION_Y)).getValue();
+      int o = ((IsNumeric)entrance.getAttribute(Entrance.ARE_ENTRANCE_ORIENTATION)).getValue();
+      if (o < 0) o = 0; else if (o >= Actor.s_orientation.length) o = Actor.s_orientation.length - 1;
+      final String name = entrance.getAttribute(Entrance.ARE_ENTRANCE_NAME).toString();
+      msg = String.format("%s (%s)", name, Actor.s_orientation[o]);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    // Using cached icons
+    final Image[] icons = getIcons(ICONS);
+
+    item = new IconLayerItem(entrance, msg, icons[0], CENTER);
+    item.setLabelEnabled(Settings.ShowLabelEntrances);
+    item.setName(getCategory());
+    item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
+    item.setVisible(isVisible());
   }
 
   //<editor-fold defaultstate="collapsed" desc="LayerObject">
@@ -66,30 +85,4 @@ public class LayerObjectEntrance extends LayerObject
     }
   }
   //</editor-fold>
-
-  private void init()
-  {
-    if (entrance != null) {
-      String msg = null;
-      try {
-        location.x = ((IsNumeric)entrance.getAttribute(Entrance.ARE_ENTRANCE_LOCATION_X)).getValue();
-        location.y = ((IsNumeric)entrance.getAttribute(Entrance.ARE_ENTRANCE_LOCATION_Y)).getValue();
-        int o = ((IsNumeric)entrance.getAttribute(Entrance.ARE_ENTRANCE_ORIENTATION)).getValue();
-        if (o < 0) o = 0; else if (o >= Actor.s_orientation.length) o = Actor.s_orientation.length - 1;
-        final String name = entrance.getAttribute(Entrance.ARE_ENTRANCE_NAME).toString();
-        msg = String.format("%s (%s)", name, Actor.s_orientation[o]);
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-
-      // Using cached icons
-      final Image[] icons = getIcons(ICONS);
-
-      item = new IconLayerItem(entrance, msg, icons[0], CENTER);
-      item.setLabelEnabled(Settings.ShowLabelEntrances);
-      item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
-      item.setVisible(isVisible());
-    }
-  }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
@@ -35,7 +35,7 @@ public class LayerObjectEntrance extends LayerObject
 
   public LayerObjectEntrance(AreResource parent, Entrance entrance)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Entrance", Entrance.class, parent);
+    super("Entrance", Entrance.class, parent);
     this.entrance = entrance;
     init();
   }
@@ -119,7 +119,7 @@ public class LayerObjectEntrance extends LayerObject
       // Using cached icons
       Image[] icon;
       String keyIcon = String.format("%s%s", SharedResourceCache.createKey(ICON[0]),
-                                                 SharedResourceCache.createKey(ICON[1]));
+                                             SharedResourceCache.createKey(ICON[1]));
       if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
         icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);

--- a/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
@@ -46,18 +46,6 @@ public class LayerObjectEntrance extends LayerObject
   }
 
   @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{entrance};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return item;
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     return (type == 0) ? item : null;
@@ -70,30 +58,12 @@ public class LayerObjectEntrance extends LayerObject
   }
 
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public void update(double zoomFactor)
   {
     if (item != null) {
       item.setItemLocation((int)(location.x*zoomFactor + (zoomFactor / 2.0)),
                            (int)(location.y*zoomFactor + (zoomFactor / 2.0)));
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location};
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
@@ -24,8 +24,8 @@ import org.infinity.resource.are.viewer.icon.ViewerIcons;
  */
 public class LayerObjectEntrance extends LayerObject
 {
-  private static final Image[] ICON = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ENTRANCE_1),
-                                       Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ENTRANCE_2)};
+  private static final Image[] ICONS = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ENTRANCE_1),
+                                        Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_ENTRANCE_2)};
   private static final Point CENTER = new Point(11, 18);
 
   private final Entrance entrance;
@@ -117,21 +117,12 @@ public class LayerObjectEntrance extends LayerObject
       }
 
       // Using cached icons
-      Image[] icon;
-      String keyIcon = String.format("%s%s", SharedResourceCache.createKey(ICON[0]),
-                                             SharedResourceCache.createKey(ICON[1]));
-      if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
-        icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);
-      } else {
-        icon = ICON;
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
-      }
+      final Image[] icons = getIcons(ICONS);
 
-      item = new IconLayerItem(entrance, msg, info, icon[0], CENTER);
+      item = new IconLayerItem(entrance, msg, info, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelEntrances);
       item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
+      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
       item.setVisible(isVisible());
     }
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectEntrance.java
@@ -129,7 +129,6 @@ public class LayerObjectEntrance extends LayerObject
       item = new IconLayerItem(location, entrance, msg, info, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelEntrances);
       item.setName(getCategory());
-      item.setToolTipText(info);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
       item.setVisible(isVisible());
     }

--- a/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
@@ -153,7 +153,6 @@ public class LayerObjectIniActor extends LayerObjectActor
       item = new IconLayerItem(location, ini, msg, info, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelActorsIni);
       item.setName(getCategory());
-      item.setToolTipText(info);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
       item.setVisible(isVisible());
     }

--- a/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -52,6 +52,7 @@ public class LayerObjectIniActor extends LayerObjectActor
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public void reload()
   {
@@ -79,7 +80,7 @@ public class LayerObjectIniActor extends LayerObjectActor
   {
     return true;  // always active
   }
-
+  //</editor-fold>
 
   private void init() throws Exception
   {
@@ -150,7 +151,7 @@ public class LayerObjectIniActor extends LayerObjectActor
       }
 
       ini.setHighlightedLine(creData.getLine() + 1);
-      item = new IconLayerItem(location, ini, msg, info, icon[0], CENTER);
+      item = new IconLayerItem(ini, msg, info, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelActorsIni);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
@@ -48,25 +48,9 @@ public class LayerObjectIniActor extends LayerObjectActor
 
   //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
-  public void reload()
-  {
-    try {
-      init();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-  }
-
-  @Override
   public Viewable getViewable()
   {
     return ini;
-  }
-
-  @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{ini};
   }
 
   @Override

--- a/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
@@ -26,12 +26,12 @@ import org.infinity.util.IniMapSection;
  */
 public class LayerObjectIniActor extends LayerObjectActor
 {
-  private static final Image[] ICON_GOOD = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_G_1),
-                                            Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_G_2)};
-  private static final Image[] ICON_NEUTRAL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_B_1),
-                                               Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_B_2)};
-  private static final Image[] ICON_EVIL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_R_1),
-                                            Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_R_2)};
+  private static final Image[] ICONS_GOOD = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_G_1),
+                                             Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_G_2)};
+  private static final Image[] ICONS_NEUTRAL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_B_1),
+                                                Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_B_2)};
+  private static final Image[] ICONS_EVIL = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_R_1),
+                                             Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_INI_ACTOR_R_2)};
   private static final Point CENTER = new Point(12, 40);
 
   private final PlainTextResource ini;
@@ -120,7 +120,6 @@ public class LayerObjectIniActor extends LayerObjectActor
       }
 
       // initializations
-      Image[] icon;
       String info = sectionName;
       String msg = ((StringRef)cre.getAttribute(CreResource.CRE_NAME)).toString() + " [" + sectionName + "]";
       int ea = (int)((IdsBitmap)cre.getAttribute(CreResource.CRE_ALLEGIANCE)).getValue();
@@ -132,29 +131,23 @@ public class LayerObjectIniActor extends LayerObjectActor
         ea = object[0];
       }
 
+      Image[] icons;
       if (ea >= 2 && ea <= 30) {
-        icon = ICON_GOOD;
+        icons = ICONS_GOOD;
       } else if (ea >= 200) {
-        icon = ICON_EVIL;
+        icons = ICONS_EVIL;
       } else {
-        icon = ICON_NEUTRAL;
+        icons = ICONS_NEUTRAL;
       }
 
       // Using cached icons
-      String keyIcon = String.format("%s%s", SharedResourceCache.createKey(icon[0]),
-                                                 SharedResourceCache.createKey(icon[1]));
-      if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
-        icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);
-      } else {
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
-      }
+      icons = getIcons(icons);
 
       ini.setHighlightedLine(creData.getLine() + 1);
-      item = new IconLayerItem(ini, msg, info, icon[0], CENTER);
+      item = new IconLayerItem(ini, msg, info, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelActorsIni);
       item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
+      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
       item.setVisible(isVisible());
     }
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectIniActor.java
@@ -7,8 +7,7 @@ package org.infinity.resource.are.viewer;
 import java.awt.Image;
 import java.awt.Point;
 
-import org.infinity.datatype.IdsBitmap;
-import org.infinity.datatype.StringRef;
+import org.infinity.datatype.IsNumeric;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.IconLayerItem;
 import org.infinity.icon.Icons;
@@ -37,11 +36,6 @@ public class LayerObjectIniActor extends LayerObjectActor
   private final PlainTextResource ini;
   private final IniMapSection creData;
   private final int creIndex;
-
-  public LayerObjectIniActor(PlainTextResource ini, IniMapSection creData) throws Exception
-  {
-    this(ini, creData, 0);
-  }
 
   public LayerObjectIniActor(PlainTextResource ini, IniMapSection creData, int creIndex) throws Exception
   {
@@ -91,7 +85,7 @@ public class LayerObjectIniActor extends LayerObjectActor
 
       IniMapEntry entryPoint = creData.getEntry("spawn_point");
       if (entryPoint == null) {
-        throw new Exception(creData.getName() + ": Invalid spawn point");
+        throw new Exception(creData.getName() + ": Invalid spawn point - entry \"spawn_point\" not found in .INI");
       }
       String[] position = IniMapEntry.splitValues(entryPoint.getValue(), IniMapEntry.REGEX_POSITION);
       if (position == null || creIndex >= position.length) {
@@ -99,7 +93,7 @@ public class LayerObjectIniActor extends LayerObjectActor
       }
       int[] pos = IniMapEntry.splitPositionValue(position[creIndex]);
       if (pos == null || pos.length < 2) {
-        throw new Exception(creData.getName() + ": Invalid spawn point value");
+        throw new Exception(creData.getName() + ": Invalid spawn point value #" + creIndex);
       }
 
       String sectionName = creData.getName();
@@ -114,15 +108,12 @@ public class LayerObjectIniActor extends LayerObjectActor
         cre = new CreResource(creEntry);
       } catch (Exception e) {
         e.printStackTrace();
-      }
-      if (cre == null) {
-        throw new Exception(creData.getName() + ": Invalid CRE resource");
+        throw new Exception(creData.getName() + ": Invalid CRE resource", e);
       }
 
       // initializations
-      String info = sectionName;
-      String msg = ((StringRef)cre.getAttribute(CreResource.CRE_NAME)).toString() + " [" + sectionName + "]";
-      int ea = (int)((IdsBitmap)cre.getAttribute(CreResource.CRE_ALLEGIANCE)).getValue();
+      final String msg = cre.getAttribute(CreResource.CRE_NAME).toString() + " [" + sectionName + "]";
+      int ea = ((IsNumeric)cre.getAttribute(CreResource.CRE_ALLEGIANCE)).getValue();
       location.x = pos[0];
       location.y = pos[1];
 
@@ -144,7 +135,7 @@ public class LayerObjectIniActor extends LayerObjectActor
       icons = getIcons(icons);
 
       ini.setHighlightedLine(creData.getLine() + 1);
-      item = new IconLayerItem(ini, msg, info, icons[0], CENTER);
+      item = new IconLayerItem(ini, msg, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelActorsIni);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
@@ -28,13 +28,35 @@ public class LayerObjectProTrap extends LayerObject
   private final ProTrap trap;
   private final Point location = new Point();
 
-  private IconLayerItem item;
+  private final IconLayerItem item;
 
   public LayerObjectProTrap(AreResource parent, ProTrap trap)
   {
     super("Trap", ProTrap.class, parent);
     this.trap = trap;
-    init();
+    String msg = null;
+    try {
+      msg = trap.getAttribute(ProTrap.ARE_PROTRAP_TRAP).toString();
+      location.x = ((IsNumeric)trap.getAttribute(ProTrap.ARE_PROTRAP_LOCATION_X)).getValue();
+      location.y = ((IsNumeric)trap.getAttribute(ProTrap.ARE_PROTRAP_LOCATION_Y)).getValue();
+      int target = ((IsNumeric)trap.getAttribute(ProTrap.ARE_PROTRAP_TARGET)).getValue();
+      if (target < 0) target = 0; else if (target > 255) target = 255;
+      if (target >= 2 && target <= 30) {
+        msg += " (hostile)";
+      } else if (target >= 200) {
+        msg += " (friendly)";
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    // Using cached icons
+    final Image[] icons = getIcons(ICONS);
+
+    item = new IconLayerItem(trap, msg, icons[0], CENTER);
+    item.setName(getCategory());
+    item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, ICONS[1]);
+    item.setVisible(isVisible());
   }
 
   //<editor-fold defaultstate="collapsed" desc="LayerObject">
@@ -65,33 +87,4 @@ public class LayerObjectProTrap extends LayerObject
     }
   }
   //</editor-fold>
-
-  private void init()
-  {
-    if (trap != null) {
-      String msg = null;
-      try {
-        location.x = ((IsNumeric)trap.getAttribute(ProTrap.ARE_PROTRAP_LOCATION_X)).getValue();
-        location.y = ((IsNumeric)trap.getAttribute(ProTrap.ARE_PROTRAP_LOCATION_Y)).getValue();
-        msg = trap.getAttribute(ProTrap.ARE_PROTRAP_TRAP).toString();
-        int target = ((IsNumeric)trap.getAttribute(ProTrap.ARE_PROTRAP_TARGET)).getValue();
-        if (target < 0) target = 0; else if (target > 255) target = 255;
-        if (target >= 2 && target <= 30) {
-          msg += " (hostile)";
-        } else if (target >= 200) {
-          msg += " (friendly)";
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-
-      // Using cached icons
-      final Image[] icons = getIcons(ICONS);
-
-      item = new IconLayerItem(trap, msg, icons[0], CENTER);
-      item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, ICONS[1]);
-      item.setVisible(isVisible());
-    }
-  }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -39,6 +39,7 @@ public class LayerObjectProTrap extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -95,6 +96,7 @@ public class LayerObjectProTrap extends LayerObject
   {
     return new Point[]{location};
   }
+  //</editor-fold>
 
   private void init()
   {
@@ -127,7 +129,7 @@ public class LayerObjectProTrap extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, trap, msg, msg, icon[0], CENTER);
+      item = new IconLayerItem(trap, msg, msg, icon[0], CENTER);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, ICON[1]);
       item.setVisible(isVisible());

--- a/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
@@ -23,8 +23,8 @@ import org.infinity.resource.are.viewer.icon.ViewerIcons;
  */
 public class LayerObjectProTrap extends LayerObject
 {
-  private static final Image[] ICON = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_PRO_TRAP_1),
-                                       Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_PRO_TRAP_2)};
+  private static final Image[] ICONS = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_PRO_TRAP_1),
+                                        Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_PRO_TRAP_2)};
   private static final Point CENTER = new Point(14, 14);
 
   private final ProTrap trap;
@@ -118,20 +118,11 @@ public class LayerObjectProTrap extends LayerObject
       }
 
       // Using cached icons
-      Image[] icon;
-      String keyIcon = String.format("%s%s", SharedResourceCache.createKey(ICON[0]),
-                                             SharedResourceCache.createKey(ICON[1]));
-      if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
-        icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);
-      } else {
-        icon = ICON;
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
-      }
+      final Image[] icons = getIcons(ICONS);
 
-      item = new IconLayerItem(trap, msg, msg, icon[0], CENTER);
+      item = new IconLayerItem(trap, msg, msg, icons[0], CENTER);
       item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, ICON[1]);
+      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, ICONS[1]);
       item.setVisible(isVisible());
     }
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
@@ -129,7 +129,6 @@ public class LayerObjectProTrap extends LayerObject
 
       item = new IconLayerItem(location, trap, msg, msg, icon[0], CENTER);
       item.setName(getCategory());
-      item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, ICON[1]);
       item.setVisible(isVisible());
     }

--- a/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
@@ -45,18 +45,6 @@ public class LayerObjectProTrap extends LayerObject
   }
 
   @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{trap};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return item;
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     return (type == 0) ? item : null;
@@ -69,30 +57,12 @@ public class LayerObjectProTrap extends LayerObject
   }
 
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public void update(double zoomFactor)
   {
     if (item != null) {
       item.setItemLocation((int)(location.x*zoomFactor + (zoomFactor / 2.0)),
                            (int)(location.y*zoomFactor + (zoomFactor / 2.0)));
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location};
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
@@ -7,9 +7,7 @@ package org.infinity.resource.are.viewer;
 import java.awt.Image;
 import java.awt.Point;
 
-import org.infinity.datatype.DecNumber;
-import org.infinity.datatype.IdsBitmap;
-import org.infinity.datatype.ResourceRef;
+import org.infinity.datatype.IsNumeric;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.IconLayerItem;
 import org.infinity.icon.Icons;
@@ -101,12 +99,12 @@ public class LayerObjectProTrap extends LayerObject
   private void init()
   {
     if (trap != null) {
-      String msg = "";
+      String msg = null;
       try {
-        location.x = ((DecNumber)trap.getAttribute(ProTrap.ARE_PROTRAP_LOCATION_X)).getValue();
-        location.y = ((DecNumber)trap.getAttribute(ProTrap.ARE_PROTRAP_LOCATION_Y)).getValue();
-        msg = ((ResourceRef)trap.getAttribute(ProTrap.ARE_PROTRAP_TRAP)).toString();
-        int target = (int)((IdsBitmap)trap.getAttribute(ProTrap.ARE_PROTRAP_TARGET)).getValue();
+        location.x = ((IsNumeric)trap.getAttribute(ProTrap.ARE_PROTRAP_LOCATION_X)).getValue();
+        location.y = ((IsNumeric)trap.getAttribute(ProTrap.ARE_PROTRAP_LOCATION_Y)).getValue();
+        msg = trap.getAttribute(ProTrap.ARE_PROTRAP_TRAP).toString();
+        int target = ((IsNumeric)trap.getAttribute(ProTrap.ARE_PROTRAP_TARGET)).getValue();
         if (target < 0) target = 0; else if (target > 255) target = 255;
         if (target >= 2 && target <= 30) {
           msg += " (hostile)";
@@ -120,7 +118,7 @@ public class LayerObjectProTrap extends LayerObject
       // Using cached icons
       final Image[] icons = getIcons(ICONS);
 
-      item = new IconLayerItem(trap, msg, msg, icons[0], CENTER);
+      item = new IconLayerItem(trap, msg, icons[0], CENTER);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, ICONS[1]);
       item.setVisible(isVisible());

--- a/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectProTrap.java
@@ -34,7 +34,7 @@ public class LayerObjectProTrap extends LayerObject
 
   public LayerObjectProTrap(AreResource parent, ProTrap trap)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Trap", ProTrap.class, parent);
+    super("Trap", ProTrap.class, parent);
     this.trap = trap;
     init();
   }
@@ -120,7 +120,7 @@ public class LayerObjectProTrap extends LayerObject
       // Using cached icons
       Image[] icon;
       String keyIcon = String.format("%s%s", SharedResourceCache.createKey(ICON[0]),
-                                                 SharedResourceCache.createKey(ICON[1]));
+                                             SharedResourceCache.createKey(ICON[1]));
       if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
         icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);

--- a/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
@@ -11,6 +11,7 @@ import java.awt.Rectangle;
 
 import org.infinity.datatype.IsNumeric;
 import org.infinity.datatype.IsTextual;
+import org.infinity.datatype.ResourceRef;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.ShapedLayerItem;
 import org.infinity.resource.Viewable;
@@ -115,9 +116,13 @@ public class LayerObjectRegion extends LayerObject
       try {
         type = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_TYPE)).getValue();
         if (type < 0) type = 0; else if (type >= ITEPoint.s_type.length) type = ITEPoint.s_type.length - 1;
-        msg = String.format("%s (%s) %s",
+
+        final IsTextual info = (IsTextual)region.getAttribute(ITEPoint.ARE_TRIGGER_INFO_POINT_TEXT);
+        msg = String.format("%s (%s) %s\n%s",
                             region.getAttribute(ITEPoint.ARE_TRIGGER_NAME).toString(),
-                            ITEPoint.s_type[type], getAttributes());
+                            ITEPoint.s_type[type], getAttributes(),
+                            // For "1 - Info point" show description
+                            type == 1 && info != null ? info.getText() : "");
         final int vNum = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_NUM_VERTICES)).getValue();
         final int vOfs = ((IsNumeric)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
         shapeCoords = loadVertices(region, vOfs, 0, vNum, Vertex.class);
@@ -162,16 +167,19 @@ public class LayerObjectRegion extends LayerObject
         if (v > 0) sb.append("Trapped (").append(v).append(')');
       }
 
-      String script = ((IsTextual)region.getAttribute(ITEPoint.ARE_TRIGGER_SCRIPT)).getText();
-      if (!script.isEmpty() && !script.equalsIgnoreCase("NONE")) {
+      final ResourceRef script = (ResourceRef)region.getAttribute(ITEPoint.ARE_TRIGGER_SCRIPT);
+      if (!script.isEmpty()) {
         if (sb.length() > 1) sb.append(", ");
-        sb.append("Script: ").append(script).append(".BCS");
+        sb.append("Script: ").append(script);
       }
 
-      String area = ((IsTextual)region.getAttribute(ITEPoint.ARE_TRIGGER_DESTINATION_AREA)).getText();
-      if (!area.isEmpty() && !area.equalsIgnoreCase("NONE")) {
+      final ResourceRef dest = (ResourceRef)region.getAttribute(ITEPoint.ARE_TRIGGER_DESTINATION_AREA);
+      if (!dest.isEmpty()) {
         if (sb.length() > 1) sb.append(", ");
-        sb.append("Destination: ").append(area).append(".ARE");
+
+        final AreResource self = (AreResource)getParentStructure();
+        final boolean isSelf = dest.getResourceName().equalsIgnoreCase(self.getName());
+        sb.append("Destination: ").append(isSelf ? "(this area)" : dest);
         String entrance = ((IsTextual)region.getAttribute(ITEPoint.ARE_TRIGGER_ENTRANCE_NAME)).getText();
         if (!entrance.isEmpty() && !entrance.equalsIgnoreCase("NONE")) {
           sb.append('>').append(entrance);

--- a/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
@@ -42,7 +42,7 @@ public class LayerObjectRegion extends LayerObject
 
   public LayerObjectRegion(AreResource parent, ITEPoint region)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Region", ITEPoint.class, parent);
+    super("Region", ITEPoint.class, parent);
     this.region = region;
     init();
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
@@ -78,10 +78,7 @@ public class LayerObjectRegion extends LayerObject
   private void init()
   {
     if (region != null) {
-      shapeCoords = null;
       String msg = null;
-      Polygon poly = null;
-      Rectangle bounds = null;
       int type = 0;
       try {
         type = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_TYPE)).getValue();
@@ -96,20 +93,11 @@ public class LayerObjectRegion extends LayerObject
         final int vNum = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_NUM_VERTICES)).getValue();
         final int vOfs = ((IsNumeric)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
         shapeCoords = loadVertices(region, vOfs, 0, vNum, Vertex.class);
-        poly = createPolygon(shapeCoords, 1.0);
-        bounds = normalizePolygon(poly);
       } catch (Exception e) {
         e.printStackTrace();
-        if (shapeCoords == null) {
-          shapeCoords = new Point[0];
-        }
-        if (poly == null) {
-          poly = new Polygon();
-        }
-        if (bounds == null) {
-          bounds = new Rectangle();
-        }
       }
+      final Polygon poly = createPolygon(shapeCoords, 1.0);
+      final Rectangle bounds = normalizePolygon(poly);
 
       int colorType = Settings.UseColorShades ? type : 0;
       location.x = bounds.x; location.y = bounds.y;

--- a/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
@@ -111,17 +111,10 @@ public class LayerObjectRegion extends LayerObject
     final StringBuilder sb = new StringBuilder();
     sb.append('[');
 
-    final boolean isTrapped = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_TRAPPED)).getValue() != 0;
-    if (isTrapped) {
-      int v = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_TRAP_REMOVAL_DIFFICULTY)).getValue();
-      if (v > 0) sb.append("Trapped (").append(v).append(')');
-    }
-
-    final ResourceRef script = (ResourceRef)region.getAttribute(ITEPoint.ARE_TRIGGER_SCRIPT);
-    if (script != null && !script.isEmpty()) {
-      if (sb.length() > 1) sb.append(", ");
-      sb.append("Script: ").append(script);
-    }
+    addTrappedDesc(sb, region,
+                   ITEPoint.ARE_TRIGGER_TRAPPED,
+                   ITEPoint.ARE_TRIGGER_TRAP_REMOVAL_DIFFICULTY,
+                   ITEPoint.ARE_TRIGGER_SCRIPT);
 
     final ResourceRef dest = (ResourceRef)region.getAttribute(ITEPoint.ARE_TRIGGER_DESTINATION_AREA);
     if (dest != null && !dest.isEmpty()) {

--- a/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
@@ -143,7 +143,7 @@ public class LayerObjectRegion extends LayerObject
 
       int colorType = Settings.UseColorShades ? type : 0;
       location.x = bounds.x; location.y = bounds.y;
-      item = new ShapedLayerItem(location, region, msg, msg, poly);
+      item = new ShapedLayerItem(region, msg, msg, poly);
       item.setName(getCategory());
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[colorType][0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[colorType][1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -47,6 +47,7 @@ public class LayerObjectRegion extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -106,6 +107,7 @@ public class LayerObjectRegion extends LayerObject
   {
     return new Point[]{location};
   }
+  //</editor-fold>
 
   private void init()
   {
@@ -143,7 +145,6 @@ public class LayerObjectRegion extends LayerObject
       location.x = bounds.x; location.y = bounds.y;
       item = new ShapedLayerItem(location, region, msg, msg, poly);
       item.setName(getCategory());
-      item.setToolTipText(msg);
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[colorType][0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[colorType][1]);
       item.setFillColor(AbstractLayerItem.ItemState.NORMAL, COLOR[colorType][2]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
@@ -108,38 +108,36 @@ public class LayerObjectRegion extends LayerObject
 
   private String getAttributes()
   {
-    StringBuilder sb = new StringBuilder();
-    if (region != null) {
-      sb.append('[');
+    final StringBuilder sb = new StringBuilder();
+    sb.append('[');
 
-      boolean isTrapped = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_TRAPPED)).getValue() != 0;
-      if (isTrapped) {
-        int v = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_TRAP_REMOVAL_DIFFICULTY)).getValue();
-        if (v > 0) sb.append("Trapped (").append(v).append(')');
-      }
-
-      final ResourceRef script = (ResourceRef)region.getAttribute(ITEPoint.ARE_TRIGGER_SCRIPT);
-      if (!script.isEmpty()) {
-        if (sb.length() > 1) sb.append(", ");
-        sb.append("Script: ").append(script);
-      }
-
-      final ResourceRef dest = (ResourceRef)region.getAttribute(ITEPoint.ARE_TRIGGER_DESTINATION_AREA);
-      if (!dest.isEmpty()) {
-        if (sb.length() > 1) sb.append(", ");
-
-        final AreResource self = (AreResource)getParentStructure();
-        final boolean isSelf = dest.getResourceName().equalsIgnoreCase(self.getName());
-        sb.append("Destination: ").append(isSelf ? "(this area)" : dest);
-        String entrance = ((IsTextual)region.getAttribute(ITEPoint.ARE_TRIGGER_ENTRANCE_NAME)).getText();
-        if (!entrance.isEmpty() && !entrance.equalsIgnoreCase("NONE")) {
-          sb.append('>').append(entrance);
-        }
-      }
-
-      if (sb.length() == 1) sb.append("No flags");
-      sb.append(']');
+    final boolean isTrapped = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_TRAPPED)).getValue() != 0;
+    if (isTrapped) {
+      int v = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_TRAP_REMOVAL_DIFFICULTY)).getValue();
+      if (v > 0) sb.append("Trapped (").append(v).append(')');
     }
+
+    final ResourceRef script = (ResourceRef)region.getAttribute(ITEPoint.ARE_TRIGGER_SCRIPT);
+    if (script != null && !script.isEmpty()) {
+      if (sb.length() > 1) sb.append(", ");
+      sb.append("Script: ").append(script);
+    }
+
+    final ResourceRef dest = (ResourceRef)region.getAttribute(ITEPoint.ARE_TRIGGER_DESTINATION_AREA);
+    if (dest != null && !dest.isEmpty()) {
+      if (sb.length() > 1) sb.append(", ");
+
+      final AreResource self = (AreResource)getParentStructure();
+      final boolean isSelf = dest.getResourceName().equalsIgnoreCase(self.getName());
+      sb.append("Destination: ").append(isSelf ? "(this area)" : dest);
+      String entrance = ((IsTextual)region.getAttribute(ITEPoint.ARE_TRIGGER_ENTRANCE_NAME)).getText();
+      if (!entrance.isEmpty() && !entrance.equalsIgnoreCase("NONE")) {
+        sb.append('>').append(entrance);
+      }
+    }
+
+    if (sb.length() == 1) sb.append("No flags");
+    sb.append(']');
     return sb.toString();
   }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
@@ -9,12 +9,8 @@ import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 
-import org.infinity.datatype.Bitmap;
-import org.infinity.datatype.DecNumber;
-import org.infinity.datatype.HexNumber;
 import org.infinity.datatype.IsNumeric;
 import org.infinity.datatype.IsTextual;
-import org.infinity.datatype.TextString;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.ShapedLayerItem;
 import org.infinity.resource.Viewable;
@@ -27,8 +23,7 @@ import org.infinity.resource.vertex.Vertex;
  */
 public class LayerObjectRegion extends LayerObject
 {
-  private static final String[] TYPE = {"Proximity trigger", "Info point", "Travel region"};
-  private static final Color[][] COLOR = new Color[][]{
+  private static final Color[][] COLOR = {
     {new Color(0xFF400000, true), new Color(0xFF400000, true), new Color(0xC0800000, true), new Color(0xC0C00000, true)},
     {new Color(0xFF400000, true), new Color(0xFF400000, true), new Color(0xC0804040, true), new Color(0xC0C06060, true)},
     {new Color(0xFF400000, true), new Color(0xFF400000, true), new Color(0xC0800040, true), new Color(0xC0C00060, true)},
@@ -113,18 +108,18 @@ public class LayerObjectRegion extends LayerObject
   {
     if (region != null) {
       shapeCoords = null;
-      String msg = "";
+      String msg = null;
       Polygon poly = null;
       Rectangle bounds = null;
       int type = 0;
       try {
-        type = ((Bitmap)region.getAttribute(ITEPoint.ARE_TRIGGER_TYPE)).getValue();
-        if (type < 0) type = 0; else if (type >= TYPE.length) type = TYPE.length - 1;
+        type = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_TYPE)).getValue();
+        if (type < 0) type = 0; else if (type >= ITEPoint.s_type.length) type = ITEPoint.s_type.length - 1;
         msg = String.format("%s (%s) %s",
-                            ((TextString)region.getAttribute(ITEPoint.ARE_TRIGGER_NAME)).toString(),
-                            TYPE[type], getAttributes());
-        int vNum = ((DecNumber)region.getAttribute(ITEPoint.ARE_TRIGGER_NUM_VERTICES)).getValue();
-        int vOfs = ((HexNumber)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
+                            region.getAttribute(ITEPoint.ARE_TRIGGER_NAME).toString(),
+                            ITEPoint.s_type[type], getAttributes());
+        final int vNum = ((IsNumeric)region.getAttribute(ITEPoint.ARE_TRIGGER_NUM_VERTICES)).getValue();
+        final int vOfs = ((IsNumeric)getParentStructure().getAttribute(AreResource.ARE_OFFSET_VERTICES)).getValue();
         shapeCoords = loadVertices(region, vOfs, 0, vNum, Vertex.class);
         poly = createPolygon(shapeCoords, 1.0);
         bounds = normalizePolygon(poly);
@@ -143,7 +138,7 @@ public class LayerObjectRegion extends LayerObject
 
       int colorType = Settings.UseColorShades ? type : 0;
       location.x = bounds.x; location.y = bounds.y;
-      item = new ShapedLayerItem(region, msg, msg, poly);
+      item = new ShapedLayerItem(region, msg, poly);
       item.setName(getCategory());
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[colorType][0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[colorType][1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectRegion.java
@@ -51,18 +51,6 @@ public class LayerObjectRegion extends LayerObject
   }
 
   @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{region};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return item;
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     return (type == 0) ? item : null;
@@ -75,12 +63,6 @@ public class LayerObjectRegion extends LayerObject
   }
 
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public void update(double zoomFactor)
   {
     if (item != null) {
@@ -90,18 +72,6 @@ public class LayerObjectRegion extends LayerObject
       normalizePolygon(poly);
       item.setShape(poly);
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location};
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
@@ -7,9 +7,8 @@ package org.infinity.resource.are.viewer;
 import java.awt.Image;
 import java.awt.Point;
 
-import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.Flag;
-import org.infinity.datatype.TextString;
+import org.infinity.datatype.IsNumeric;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.IconLayerItem;
 import org.infinity.icon.Icons;
@@ -114,14 +113,14 @@ public class LayerObjectSpawnPoint extends LayerObject
   private void init()
   {
     if (sp != null) {
-      String msg = "";
+      String msg = null;
       try {
-        location.x = ((DecNumber)sp.getAttribute(SpawnPoint.ARE_SPAWN_LOCATION_X)).getValue();
-        location.y = ((DecNumber)sp.getAttribute(SpawnPoint.ARE_SPAWN_LOCATION_Y)).getValue();
+        location.x = ((IsNumeric)sp.getAttribute(SpawnPoint.ARE_SPAWN_LOCATION_X)).getValue();
+        location.y = ((IsNumeric)sp.getAttribute(SpawnPoint.ARE_SPAWN_LOCATION_Y)).getValue();
 
         scheduleFlags = ((Flag)sp.getAttribute(SpawnPoint.ARE_SPAWN_ACTIVE_AT));
 
-        msg = ((TextString)sp.getAttribute(SpawnPoint.ARE_SPAWN_NAME)).toString();
+        msg = sp.getAttribute(SpawnPoint.ARE_SPAWN_NAME).toString();
       } catch (Exception e) {
         e.printStackTrace();
       }
@@ -129,7 +128,7 @@ public class LayerObjectSpawnPoint extends LayerObject
       // Using cached icons
       final Image[] icons = getIcons(ICONS);
 
-      item = new IconLayerItem(sp, msg, msg, icons[0], CENTER);
+      item = new IconLayerItem(sp, msg, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelSpawnPoints);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
@@ -29,7 +29,7 @@ public class LayerObjectSpawnPoint extends LayerObject
   private final SpawnPoint sp;
   private final Point location = new Point();
 
-  private IconLayerItem item;
+  private final IconLayerItem item;
   private Flag scheduleFlags;
 
 
@@ -37,7 +37,26 @@ public class LayerObjectSpawnPoint extends LayerObject
   {
     super("Spawn Point", SpawnPoint.class, parent);
     this.sp = sp;
-    init();
+    String msg = null;
+    try {
+      msg = sp.getAttribute(SpawnPoint.ARE_SPAWN_NAME).toString();
+      location.x = ((IsNumeric)sp.getAttribute(SpawnPoint.ARE_SPAWN_LOCATION_X)).getValue();
+      location.y = ((IsNumeric)sp.getAttribute(SpawnPoint.ARE_SPAWN_LOCATION_Y)).getValue();
+
+      scheduleFlags = ((Flag)sp.getAttribute(SpawnPoint.ARE_SPAWN_ACTIVE_AT));
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    // Using cached icons
+    final Image[] icons = getIcons(ICONS);
+
+    item = new IconLayerItem(sp, msg, icons[0], CENTER);
+    item.setLabelEnabled(Settings.ShowLabelSpawnPoints);
+    item.setName(getCategory());
+    item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
+    item.setVisible(isVisible());
   }
 
   //<editor-fold defaultstate="collapsed" desc="LayerObject">
@@ -78,31 +97,4 @@ public class LayerObjectSpawnPoint extends LayerObject
     }
   }
   //</editor-fold>
-
-
-  private void init()
-  {
-    if (sp != null) {
-      String msg = null;
-      try {
-        location.x = ((IsNumeric)sp.getAttribute(SpawnPoint.ARE_SPAWN_LOCATION_X)).getValue();
-        location.y = ((IsNumeric)sp.getAttribute(SpawnPoint.ARE_SPAWN_LOCATION_Y)).getValue();
-
-        scheduleFlags = ((Flag)sp.getAttribute(SpawnPoint.ARE_SPAWN_ACTIVE_AT));
-
-        msg = sp.getAttribute(SpawnPoint.ARE_SPAWN_NAME).toString();
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-
-      // Using cached icons
-      final Image[] icons = getIcons(ICONS);
-
-      item = new IconLayerItem(sp, msg, icons[0], CENTER);
-      item.setLabelEnabled(Settings.ShowLabelSpawnPoints);
-      item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
-      item.setVisible(isVisible());
-    }
-  }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -41,6 +41,7 @@ public class LayerObjectSpawnPoint extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -107,6 +108,7 @@ public class LayerObjectSpawnPoint extends LayerObject
       return false;
     }
   }
+  //</editor-fold>
 
 
   private void init()
@@ -136,7 +138,7 @@ public class LayerObjectSpawnPoint extends LayerObject
         SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
       }
 
-      item = new IconLayerItem(location, sp, msg, msg, icon[0], CENTER);
+      item = new IconLayerItem(sp, msg, msg, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelSpawnPoints);
       item.setName(getCategory());
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
@@ -23,8 +23,8 @@ import org.infinity.resource.are.viewer.icon.ViewerIcons;
  */
 public class LayerObjectSpawnPoint extends LayerObject
 {
-  private static final Image[] ICON = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_SPAWN_POINT_1),
-                                       Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_SPAWN_POINT_2)};
+  private static final Image[] ICONS = {Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_SPAWN_POINT_1),
+                                        Icons.getImage(ViewerIcons.class, ViewerIcons.ICON_ITM_SPAWN_POINT_2)};
   private static final Point CENTER = new Point(22, 22);
 
   private final SpawnPoint sp;
@@ -127,21 +127,12 @@ public class LayerObjectSpawnPoint extends LayerObject
       }
 
       // Using cached icons
-      Image[] icon;
-      String keyIcon = String.format("%s%s", SharedResourceCache.createKey(ICON[0]),
-                                                 SharedResourceCache.createKey(ICON[1]));
-      if (SharedResourceCache.contains(SharedResourceCache.Type.ICON, keyIcon)) {
-        icon = ((ResourceIcon)SharedResourceCache.get(SharedResourceCache.Type.ICON, keyIcon)).getData();
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon);
-      } else {
-        icon = ICON;
-        SharedResourceCache.add(SharedResourceCache.Type.ICON, keyIcon, new ResourceIcon(keyIcon, icon));
-      }
+      final Image[] icons = getIcons(ICONS);
 
-      item = new IconLayerItem(sp, msg, msg, icon[0], CENTER);
+      item = new IconLayerItem(sp, msg, msg, icons[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelSpawnPoints);
       item.setName(getCategory());
-      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
+      item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icons[1]);
       item.setVisible(isVisible());
     }
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
@@ -139,7 +139,6 @@ public class LayerObjectSpawnPoint extends LayerObject
       item = new IconLayerItem(location, sp, msg, msg, icon[0], CENTER);
       item.setLabelEnabled(Settings.ShowLabelSpawnPoints);
       item.setName(getCategory());
-      item.setToolTipText(msg);
       item.setImage(AbstractLayerItem.ItemState.HIGHLIGHTED, icon[1]);
       item.setVisible(isVisible());
     }

--- a/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
@@ -48,18 +48,6 @@ public class LayerObjectSpawnPoint extends LayerObject
   }
 
   @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{sp};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return item;
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     return (type == 0) ? item : null;
@@ -72,30 +60,12 @@ public class LayerObjectSpawnPoint extends LayerObject
   }
 
   @Override
-  public void reload()
-  {
-    init();
-  }
-
-  @Override
   public void update(double zoomFactor)
   {
     if (item != null) {
       item.setItemLocation((int)(location.x*zoomFactor + (zoomFactor / 2.0)),
                            (int)(location.y*zoomFactor + (zoomFactor / 2.0)));
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location};
   }
 
   @Override

--- a/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectSpawnPoint.java
@@ -36,7 +36,7 @@ public class LayerObjectSpawnPoint extends LayerObject
 
   public LayerObjectSpawnPoint(AreResource parent, SpawnPoint sp)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Spawn Point", SpawnPoint.class, parent);
+    super("Spawn Point", SpawnPoint.class, parent);
     this.sp = sp;
     init();
   }

--- a/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
@@ -36,7 +36,7 @@ public class LayerObjectTransition extends LayerObject
   private final int edge;
   private final TilesetRenderer renderer;
 
-  private ShapedLayerItem item;
+  private final ShapedLayerItem item;
 
   public LayerObjectTransition(AreResource parent, AreResource destination, int edge, TilesetRenderer renderer)
   {
@@ -44,7 +44,26 @@ public class LayerObjectTransition extends LayerObject
     this.destination = destination;
     this.edge = Math.min(ViewerConstants.EDGE_WEST, Math.max(ViewerConstants.EDGE_NORTH, edge));
     this.renderer = renderer;
-    init();
+    String msg = null;
+    try {
+      final ResourceRef ref = (ResourceRef)parent.getAttribute(FIELD_NAME[this.edge]);
+      if (ref != null && !ref.isEmpty()) {
+        msg = String.format("Transition to %s", ref.getResourceName());
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    item = new ShapedLayerItem(destination, msg, null);
+    item.setName(getCategory());
+    update(1.0);
+    item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
+    item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);
+    item.setFillColor(AbstractLayerItem.ItemState.NORMAL, COLOR[2]);
+    item.setFillColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[3]);
+    item.setStroked(true);
+    item.setFilled(true);
+    item.setVisible(isVisible());
   }
 
   //<editor-fold defaultstate="collapsed" desc="LayerObject">
@@ -69,7 +88,7 @@ public class LayerObjectTransition extends LayerObject
   @Override
   public void update(double zoomFactor)
   {
-    if (item != null && renderer != null) {
+    if (renderer != null) {
       int mapW = renderer.getMapWidth(true);
       int mapH = renderer.getMapHeight(true);
       switch (edge) {
@@ -107,31 +126,4 @@ public class LayerObjectTransition extends LayerObject
     }
   }
   //</editor-fold>
-
-  private void init()
-  {
-    if (destination != null && renderer != null) {
-      AreResource parent = (AreResource)getParentStructure();
-      String msg = null;
-      try {
-        ResourceRef ref = (ResourceRef)parent.getAttribute(FIELD_NAME[edge]);
-        if (ref != null && !ref.isEmpty()) {
-          msg = String.format("Transition to %s", ref.getResourceName());
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-
-      item = new ShapedLayerItem(destination, msg, null);
-      item.setName(getCategory());
-      update(1.0);
-      item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
-      item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);
-      item.setFillColor(AbstractLayerItem.ItemState.NORMAL, COLOR[2]);
-      item.setFillColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[3]);
-      item.setStroked(true);
-      item.setFilled(true);
-      item.setVisible(isVisible());
-    }
-  }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
@@ -48,7 +48,7 @@ public class LayerObjectTransition extends LayerObject
     try {
       final ResourceRef ref = (ResourceRef)parent.getAttribute(FIELD_NAME[this.edge]);
       if (ref != null && !ref.isEmpty()) {
-        msg = String.format("Transition to %s", ref.getResourceName());
+        msg = String.format("Transition to %s", ref);
       }
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
@@ -108,14 +108,6 @@ public class LayerObjectTransition extends LayerObject
   }
   //</editor-fold>
 
-  /**
-   * Returns the edge of the map this transition is location.
-   */
-  public int getEdge()
-  {
-    return edge;
-  }
-
   private void init()
   {
     if (destination != null && renderer != null) {
@@ -123,8 +115,7 @@ public class LayerObjectTransition extends LayerObject
       String msg = null;
       try {
         ResourceRef ref = (ResourceRef)parent.getAttribute(FIELD_NAME[edge]);
-        if (ref != null && !ref.getResourceName().isEmpty() &&
-            !"None".equalsIgnoreCase(ref.getResourceName())) {
+        if (ref != null && !ref.isEmpty()) {
           msg = String.format("Transition to %s", ref.getResourceName());
         }
       } catch (Exception e) {

--- a/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
@@ -20,7 +20,12 @@ import org.infinity.resource.are.AreResource;
  */
 public class LayerObjectTransition extends LayerObject
 {
-  public static final String[] FIELD_NAME = {"Area north", "Area east", "Area south", "Area west"};
+  public static final String[] FIELD_NAME = {
+    AreResource.ARE_AREA_NORTH,
+    AreResource.ARE_AREA_EAST,
+    AreResource.ARE_AREA_SOUTH,
+    AreResource.ARE_AREA_WEST,
+  };
 
   private static final Color[] COLOR = {new Color(0xFF404000, true), new Color(0xFF404000, true),
                                         new Color(0xC0808000, true), new Color(0xC0C0C000, true)};
@@ -147,7 +152,7 @@ public class LayerObjectTransition extends LayerObject
   {
     if (destination != null && renderer != null) {
       AreResource parent = (AreResource)getParentStructure();
-      String msg = "";
+      String msg = null;
       try {
         ResourceRef ref = (ResourceRef)parent.getAttribute(FIELD_NAME[edge]);
         if (ref != null && !ref.getResourceName().isEmpty() &&
@@ -158,7 +163,7 @@ public class LayerObjectTransition extends LayerObject
         e.printStackTrace();
       }
 
-      item = new ShapedLayerItem(destination, msg, msg, null);
+      item = new ShapedLayerItem(destination, msg, null);
       item.setName(getCategory());
       update(1.0);
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
@@ -158,7 +158,7 @@ public class LayerObjectTransition extends LayerObject
         e.printStackTrace();
       }
 
-      item = new ShapedLayerItem(location, are, msg, msg, null);
+      item = new ShapedLayerItem(are, msg, msg, null);
       item.setName(getCategory());
       update(1.0);
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
@@ -27,7 +27,7 @@ public class LayerObjectTransition extends LayerObject
   private static final int WIDTH = 16;    // "width" of the transition polygon
 
   /** Destination area. */
-  private final AreResource are;
+  private final AreResource destination;
   private final Point location = new Point();
   private final Point[] shapeCoords = {new Point(), new Point(), new Point(), new Point()};
   private final int edge;
@@ -35,10 +35,10 @@ public class LayerObjectTransition extends LayerObject
 
   private ShapedLayerItem item;
 
-  public LayerObjectTransition(AreResource parent, AreResource are, int edge, TilesetRenderer renderer)
+  public LayerObjectTransition(AreResource parent, AreResource destination, int edge, TilesetRenderer renderer)
   {
-    super(ViewerConstants.RESOURCE_ARE, "Transition", AreResource.class, parent);
-    this.are = are;
+    super("Transition", AreResource.class, parent);
+    this.destination = destination;
     this.edge = Math.min(ViewerConstants.EDGE_WEST, Math.max(ViewerConstants.EDGE_NORTH, edge));
     this.renderer = renderer;
     init();
@@ -48,13 +48,13 @@ public class LayerObjectTransition extends LayerObject
   @Override
   public Viewable getViewable()
   {
-    return are;
+    return destination;
   }
 
   @Override
   public Viewable[] getViewables()
   {
-    return new AbstractStruct[]{are};
+    return new AbstractStruct[]{destination};
   }
 
   @Override
@@ -145,7 +145,7 @@ public class LayerObjectTransition extends LayerObject
 
   private void init()
   {
-    if (getParentStructure() instanceof AreResource && are != null && renderer != null) {
+    if (destination != null && renderer != null) {
       AreResource parent = (AreResource)getParentStructure();
       String msg = "";
       try {
@@ -158,7 +158,7 @@ public class LayerObjectTransition extends LayerObject
         e.printStackTrace();
       }
 
-      item = new ShapedLayerItem(are, msg, msg, null);
+      item = new ShapedLayerItem(destination, msg, msg, null);
       item.setName(getCategory());
       update(1.0);
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -155,9 +155,8 @@ public class LayerObjectTransition extends LayerObject
         e.printStackTrace();
       }
 
-      item = new ShapedLayerItem(location, are, msg);
+      item = new ShapedLayerItem(location, are, msg, msg, null);
       item.setName(getCategory());
-      item.setToolTipText(msg);
       update(1.0);
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
@@ -26,6 +26,7 @@ public class LayerObjectTransition extends LayerObject
                                         new Color(0xC0808000, true), new Color(0xC0C0C000, true)};
   private static final int WIDTH = 16;    // "width" of the transition polygon
 
+  /** Destination area. */
   private final AreResource are;
   private final Point location = new Point();
   private final Point[] shapeCoords = {new Point(), new Point(), new Point(), new Point()};
@@ -43,6 +44,7 @@ public class LayerObjectTransition extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -131,6 +133,7 @@ public class LayerObjectTransition extends LayerObject
   {
     return new Point[]{location};
   }
+  //</editor-fold>
 
   /**
    * Returns the edge of the map this transition is location.

--- a/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectTransition.java
@@ -11,7 +11,6 @@ import java.awt.Polygon;
 import org.infinity.datatype.ResourceRef;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.ShapedLayerItem;
-import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.Viewable;
 import org.infinity.resource.are.AreResource;
 
@@ -33,7 +32,6 @@ public class LayerObjectTransition extends LayerObject
 
   /** Destination area. */
   private final AreResource destination;
-  private final Point location = new Point();
   private final Point[] shapeCoords = {new Point(), new Point(), new Point(), new Point()};
   private final int edge;
   private final TilesetRenderer renderer;
@@ -57,18 +55,6 @@ public class LayerObjectTransition extends LayerObject
   }
 
   @Override
-  public Viewable[] getViewables()
-  {
-    return new AbstractStruct[]{destination};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return item;
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     return (type == 0) ? item : null;
@@ -78,12 +64,6 @@ public class LayerObjectTransition extends LayerObject
   public AbstractLayerItem[] getLayerItems()
   {
     return new AbstractLayerItem[]{item};
-  }
-
-  @Override
-  public void reload()
-  {
-    init();
   }
 
   @Override
@@ -125,18 +105,6 @@ public class LayerObjectTransition extends LayerObject
       normalizePolygon(poly);
       item.setShape(poly);
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location};
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
@@ -9,10 +9,8 @@ import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 
-import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.Flag;
-import org.infinity.datatype.HexNumber;
-import org.infinity.datatype.SectionOffset;
+import org.infinity.datatype.IsNumeric;
 import org.infinity.gui.layeritem.AbstractLayerItem;
 import org.infinity.gui.layeritem.ShapedLayerItem;
 import org.infinity.resource.Viewable;
@@ -108,20 +106,15 @@ public class LayerObjectWallPoly extends LayerObject
   {
     if (wall != null) {
       shapeCoords = null;
-      String msg = "", info = "";
+      String msg = null;
       Polygon poly = null;
       Rectangle bounds = null;
-      int count = 0;
       try {
-        int baseOfs = ((SectionOffset)getParentStructure().getAttribute(WedResource.WED_OFFSET_WALL_POLYGONS)).getValue();
-        int ofs = wall.getOffset();
-        count = (ofs - baseOfs) / wall.getSize();
-        Flag flags = (Flag)wall.getAttribute(WallPolygon.WED_POLY_FLAGS);
-        info = "Wall polygon #" + count;
-        msg = String.format("Wall polygon #%d %s", count,
-                            createFlags(flags, org.infinity.resource.wed.Polygon.s_flags));
-        int vNum = ((DecNumber)wall.getAttribute(WallPolygon.WED_POLY_NUM_VERTICES)).getValue();
-        int vOfs = ((HexNumber)getParentStructure().getAttribute(WedResource.WED_OFFSET_VERTICES)).getValue();
+        final Flag flags = (Flag)wall.getAttribute(WallPolygon.WED_POLY_FLAGS, false);
+        msg = flags.toString();
+
+        final int vNum = ((IsNumeric)wall.getAttribute(WallPolygon.WED_POLY_NUM_VERTICES)).getValue();
+        final int vOfs = ((IsNumeric)getParentStructure().getAttribute(WedResource.WED_OFFSET_VERTICES)).getValue();
         int startIdx = flags.isFlagSet(2) ? 2 : 0;  // skipping first two vertices for "hovering walls"
         shapeCoords = loadVertices(wall, vOfs, startIdx, vNum - startIdx, Vertex.class);
         poly = createPolygon(shapeCoords, 1.0);
@@ -140,7 +133,7 @@ public class LayerObjectWallPoly extends LayerObject
       }
 
       location.x = bounds.x; location.y = bounds.y;
-      item = new ShapedLayerItem(wall, msg, info, poly);
+      item = new ShapedLayerItem(wall, msg, poly);
       item.setName(getCategory());
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);
@@ -150,39 +143,5 @@ public class LayerObjectWallPoly extends LayerObject
       item.setFilled(true);
       item.setVisible(isVisible());
     }
-  }
-
-  /** Returns a flags string. */
-  private String createFlags(Flag flags, String[] desc)
-  {
-    if (flags != null) {
-      int numFlags = 0;
-      for (int i = 0, size = flags.getSize() << 3; i < size; i++) {
-        if (flags.isFlagSet(i)) {
-          numFlags++;
-        }
-      }
-
-      if (numFlags > 0) {
-        StringBuilder sb = new StringBuilder("[");
-
-        for (int i = 0, size = flags.getSize() << 3; i < size; i++) {
-          if (flags.isFlagSet(i)) {
-            numFlags--;
-            if (desc != null && i+1 < desc.length) {
-              sb.append(desc[i+1]);
-            } else {
-              sb.append("Bit " + i);
-            }
-            if (numFlags > 0) {
-              sb.append(", ");
-            }
-          }
-        }
-        sb.append("]");
-        return sb.toString();
-      }
-    }
-    return "[No flags]";
   }
 }

--- a/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
@@ -75,10 +75,7 @@ public class LayerObjectWallPoly extends LayerObject
   private void init()
   {
     if (wall != null) {
-      shapeCoords = null;
       String msg = null;
-      Polygon poly = null;
-      Rectangle bounds = null;
       try {
         final Flag flags = (Flag)wall.getAttribute(WallPolygon.WED_POLY_FLAGS, false);
         msg = flags.toString();
@@ -87,20 +84,11 @@ public class LayerObjectWallPoly extends LayerObject
         final int vOfs = ((IsNumeric)getParentStructure().getAttribute(WedResource.WED_OFFSET_VERTICES)).getValue();
         int startIdx = flags.isFlagSet(2) ? 2 : 0;  // skipping first two vertices for "hovering walls"
         shapeCoords = loadVertices(wall, vOfs, startIdx, vNum - startIdx, Vertex.class);
-        poly = createPolygon(shapeCoords, 1.0);
-        bounds = normalizePolygon(poly);
       } catch (Exception e) {
         e.printStackTrace();
-        if (shapeCoords == null) {
-          shapeCoords = new Point[0];
-        }
-        if (poly == null) {
-          poly = new Polygon();
-        }
-        if (bounds == null) {
-          bounds = new Rectangle();
-        }
       }
+      final Polygon poly = createPolygon(shapeCoords, 1.0);
+      final Rectangle bounds = normalizePolygon(poly);
 
       location.x = bounds.x; location.y = bounds.y;
       item = new ShapedLayerItem(wall, msg, poly);

--- a/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
@@ -47,18 +47,6 @@ public class LayerObjectWallPoly extends LayerObject
   }
 
   @Override
-  public Viewable[] getViewables()
-  {
-    return new Viewable[]{wall};
-  }
-
-  @Override
-  public AbstractLayerItem getLayerItem()
-  {
-    return item;
-  }
-
-  @Override
   public AbstractLayerItem getLayerItem(int type)
   {
     return (type == 0) ? item : null;
@@ -68,12 +56,6 @@ public class LayerObjectWallPoly extends LayerObject
   public AbstractLayerItem[] getLayerItems()
   {
     return new AbstractLayerItem[]{item};
-  }
-
-  @Override
-  public void reload()
-  {
-    init();
   }
 
   @Override
@@ -87,18 +69,6 @@ public class LayerObjectWallPoly extends LayerObject
       normalizePolygon(poly);
       item.setShape(poly);
     }
-  }
-
-  @Override
-  public Point getMapLocation()
-  {
-    return location;
-  }
-
-  @Override
-  public Point[] getMapLocations()
-  {
-    return new Point[]{location};
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
@@ -140,7 +140,7 @@ public class LayerObjectWallPoly extends LayerObject
       }
 
       location.x = bounds.x; location.y = bounds.y;
-      item = new ShapedLayerItem(location, wall, msg, info, poly);
+      item = new ShapedLayerItem(wall, msg, info, poly);
       item.setName(getCategory());
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);

--- a/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are.viewer;
@@ -41,6 +41,7 @@ public class LayerObjectWallPoly extends LayerObject
     init();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="LayerObject">
   @Override
   public Viewable getViewable()
   {
@@ -101,6 +102,7 @@ public class LayerObjectWallPoly extends LayerObject
   {
     return new Point[]{location};
   }
+  //</editor-fold>
 
   private void init()
   {
@@ -140,7 +142,6 @@ public class LayerObjectWallPoly extends LayerObject
       location.x = bounds.x; location.y = bounds.y;
       item = new ShapedLayerItem(location, wall, msg, info, poly);
       item.setName(getCategory());
-      item.setToolTipText(info);
       item.setStrokeColor(AbstractLayerItem.ItemState.NORMAL, COLOR[0]);
       item.setStrokeColor(AbstractLayerItem.ItemState.HIGHLIGHTED, COLOR[1]);
       item.setFillColor(AbstractLayerItem.ItemState.NORMAL, COLOR[2]);
@@ -151,7 +152,7 @@ public class LayerObjectWallPoly extends LayerObject
     }
   }
 
-  // Returns a flags string
+  /** Returns a flags string. */
   private String createFlags(Flag flags, String[] desc)
   {
     if (flags != null) {

--- a/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
+++ b/src/org/infinity/resource/are/viewer/LayerObjectWallPoly.java
@@ -36,7 +36,7 @@ public class LayerObjectWallPoly extends LayerObject
 
   public LayerObjectWallPoly(WedResource parent, WallPolygon wallPoly)
   {
-    super(ViewerConstants.RESOURCE_WED, "Wall Poly", WallPolygon.class, parent);
+    super("Wall Poly", WallPolygon.class, parent);
     this.wall = wallPoly;
     init();
   }

--- a/src/org/infinity/resource/are/viewer/LayerTransition.java
+++ b/src/org/infinity/resource/are/viewer/LayerTransition.java
@@ -29,18 +29,14 @@ public class LayerTransition extends BasicLayer<LayerObjectTransition, AreResour
     final List<LayerObjectTransition> list = getLayerObjects();
     for (int i = 0; i < LayerObjectTransition.FIELD_NAME.length; i++) {
       ResourceRef ref = (ResourceRef)parent.getAttribute(LayerObjectTransition.FIELD_NAME[i]);
-      //TODO: replace "None" to null
-      if (ref != null && !ref.getResourceName().isEmpty() && !"None".equalsIgnoreCase(ref.getResourceName())) {
-        AreResource destAre = null;
+      if (ref != null && !ref.isEmpty()) {
         try {
-          destAre = new AreResource(ResourceFactory.getResourceEntry(ref.getResourceName()));
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-        if (destAre != null) {
+          final AreResource destAre = new AreResource(ResourceFactory.getResourceEntry(ref.getResourceName()));
           LayerObjectTransition obj = new LayerObjectTransition(parent, destAre, i, getViewer().getRenderer());
           setListeners(obj);
           list.add(obj);
+        } catch (Exception e) {
+          e.printStackTrace();
         }
       }
     }

--- a/src/org/infinity/resource/are/viewer/ViewerConstants.java
+++ b/src/org/infinity/resource/are/viewer/ViewerConstants.java
@@ -47,10 +47,6 @@ public final class ViewerConstants
   public static final int FRAME_AUTO    = 1;  // show frame on mouse-over
   public static final int FRAME_ALWAYS  = 2;  // always show frame
 
-  // Parent resource for layer objects
-  public static final int RESOURCE_ARE = 0;
-  public static final int RESOURCE_WED = 1;
-
   // Lighting conditions to simulate different day times (AnimatedLayerItem, TilesetRenderer)
   public static final int LIGHTING_DAY      = 0;
   public static final int LIGHTING_TWILIGHT = 1;


### PR DESCRIPTION
Improvements:
- Now for ARE actors localized in-game actor name are also shown. For info-point triggers text of info-point is shown in the tooltip and infobox:
![Improvements1](https://user-images.githubusercontent.com/450131/69012469-f26a8400-0997-11ea-95e7-9a8932889fd3.png)
- For transition triggers to the same area destination now shown as `(this area)` instead of area name. So it is easier to understand that the transition will be within the area:
![Improvements2](https://user-images.githubusercontent.com/450131/69012470-f26a8400-0997-11ea-94a1-efb6199c01b8.png)
- Now Map transitions/Trigger destinations also show localized name of destination area:
![Improvements3](https://user-images.githubusercontent.com/450131/69012471-f26a8400-0997-11ea-9053-350cbdff9007.png)

Also remove a lot of unused code (which is unlikely to ever be used)