### PR TITLE
Give a better name to the HasAddRemovable: HasChildStructs, getAddRemovables->getPrototypes

### DIFF
--- a/src/org/infinity/gui/StructViewer.java
+++ b/src/org/infinity/gui/StructViewer.java
@@ -178,8 +178,6 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
   private final StructTable table = new StructTable();
   private final HashMap<Integer, StructEntry> entryMap = new HashMap<>();
   private final HashMap<Viewable, ViewFrame> viewMap = new HashMap<>();
-  /** Array of prototype objects, that can be children of {@link #struct}. */
-  private AddRemovable prototypes[];
   private JMenuItem miFindAttribute, miFindReferences, miFindStateReferences, miFindRefToItem;
   private Editable editable;
   private JTabbedPane tabbedPane;
@@ -358,21 +356,24 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
     if (struct instanceof HasChildStructs && !struct.getFields().isEmpty()) {
       try {
-        prototypes = ((HasChildStructs)struct).getPrototypes();
+        final AddRemovable[] prototypes = ((HasChildStructs)struct).getPrototypes();
+        if (prototypes.length > 0) {
+          final JMenuItem menuItems[] = new JMenuItem[prototypes.length];
+          for (int i = 0; i < prototypes.length; i++) {
+            final AddRemovable proto = prototypes[i];
+            final JMenuItem menu = new JMenuItem(proto.getName());
+            menu.putClientProperty("prototype", proto);
+            menuItems[i] = menu;
+          }
+          ButtonPopupMenu bpmAdd = (ButtonPopupMenu)buttonPanel.addControl(ButtonPanel.Control.ADD);
+          bpmAdd.setMenuItems(menuItems);
+          bpmAdd.addItemListener(this);
+          JButton bRemove = (JButton)buttonPanel.addControl(ButtonPanel.Control.REMOVE);
+          bRemove.setEnabled(false);
+          bRemove.addActionListener(this);
+        }
       } catch (Exception e) {
         e.printStackTrace();
-      }
-      JMenuItem menuItems[] = new JMenuItem[prototypes.length];
-      for (int i = 0; i < menuItems.length; i++) {
-        menuItems[i] = new JMenuItem(prototypes[i].getName());
-      }
-      if (prototypes.length > 0) {
-        ButtonPopupMenu bpmAdd = (ButtonPopupMenu)buttonPanel.addControl(ButtonPanel.Control.ADD);
-        bpmAdd.setMenuItems(menuItems);
-        bpmAdd.addItemListener(this);
-        JButton bRemove = (JButton)buttonPanel.addControl(ButtonPanel.Control.REMOVE);
-        bRemove.setEnabled(false);
-        bRemove.addActionListener(this);
       }
     }
 
@@ -648,48 +649,35 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
   @Override
   public void itemStateChanged(ItemEvent event)
   {
-    if (event.getSource() instanceof ButtonPopupMenu &&
-        buttonPanel.getControlPosition((JComponent)event.getSource()) >= 0) {
-      if (buttonPanel.getControlByType(ButtonPanel.Control.ADD) == event.getSource()) {
-        if (!(struct instanceof HasChildStructs)) {
-          return;
-        }
-        ButtonPopupMenu bpmAdd = (ButtonPopupMenu)event.getSource();
-        JMenuItem item = bpmAdd.getSelectedItem();
-        AddRemovable toadd = null;
-        for (final AddRemovable proto : prototypes) {
-          if (proto.getName().equals(item.getText())) {
-            toadd = proto;
-            break;
-          }
-        }
-        try {
-          toadd = ((HasChildStructs)struct).confirmAddEntry(toadd);
-          if (toadd != null) {
-            toadd = (AddRemovable)toadd.clone();
-          }
-        } catch (Exception e) {
-          e.printStackTrace();
-          return;
+    final Object src = event.getSource();
+    if (src == buttonPanel.getControlByType(ButtonPanel.Control.ADD) && struct instanceof HasChildStructs) {
+      final JMenuItem item = ((ButtonPopupMenu)src).getSelectedItem();
+      AddRemovable toadd = (AddRemovable)item.getClientProperty("prototype");
+      try {
+        toadd = ((HasChildStructs)struct).confirmAddEntry(toadd);
+        if (toadd != null) {
+          toadd = (AddRemovable)toadd.clone();
         }
         int index = struct.addDatatype(toadd);
         table.getSelectionModel().setSelectionInterval(index, index);
         table.scrollRectToVisible(table.getCellRect(index, 1, true));
-      } else if (buttonPanel.getControlByType(ButtonPanel.Control.FIND_MENU) == event.getSource()) {
-        ButtonPopupMenu bpmFind = (ButtonPopupMenu)event.getSource();
-        JMenuItem item = bpmFind.getSelectedItem();
-        if (item == miFindAttribute) {
-          new AttributeSearcher(struct, (StructEntry)table.getValueAt(table.getSelectedRow(), 1),
-                                getTopLevelAncestor());
-        } else if (item == miFindReferences) {
-          struct.searchReferences(getTopLevelAncestor());
-        } else if (item == miFindStateReferences) {
-          State state = (State)table.getValueAt(table.getSelectedRow(), 1);
-          new DialogStateReferenceSearcher(struct.getResourceEntry(), state, getTopLevelAncestor());
-        } else if (item == miFindRefToItem) {
-          new DialogItemRefSearcher((DlgResource) struct, table.getValueAt(table.getSelectedRow(), 1),
-                                    getTopLevelAncestor());
-        }
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    } else
+    if (src == buttonPanel.getControlByType(ButtonPanel.Control.FIND_MENU)) {
+      final JMenuItem item = ((ButtonPopupMenu)src).getSelectedItem();
+      if (item == miFindAttribute) {
+        new AttributeSearcher(struct, (StructEntry)table.getValueAt(table.getSelectedRow(), 1),
+                              getTopLevelAncestor());
+      } else if (item == miFindReferences) {
+        struct.searchReferences(getTopLevelAncestor());
+      } else if (item == miFindStateReferences) {
+        State state = (State)table.getValueAt(table.getSelectedRow(), 1);
+        new DialogStateReferenceSearcher(struct.getResourceEntry(), state, getTopLevelAncestor());
+      } else if (item == miFindRefToItem) {
+        new DialogItemRefSearcher((DlgResource) struct, table.getValueAt(table.getSelectedRow(), 1),
+                                  getTopLevelAncestor());
       }
     }
   }

--- a/src/org/infinity/gui/StructViewer.java
+++ b/src/org/infinity/gui/StructViewer.java
@@ -83,7 +83,7 @@ import org.infinity.icon.Icons;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.resource.Closeable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
@@ -356,9 +356,9 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
     lowerpanel.addComponentListener(this);
     cards.show(lowerpanel, CARD_EMPTY);
 
-    if (struct instanceof HasAddRemovable && !struct.getFields().isEmpty()) {
+    if (struct instanceof HasChildStructs && !struct.getFields().isEmpty()) {
       try {
-        prototypes = ((HasAddRemovable)struct).getPrototypes();
+        prototypes = ((HasChildStructs)struct).getPrototypes();
       } catch (Exception e) {
         e.printStackTrace();
       }
@@ -503,7 +503,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
         Viewable selected = (Viewable)table.getModel().getValueAt(min, 1);
         createViewFrame(getTopLevelAncestor(), selected);
       } else if (buttonPanel.getControlByType(ButtonPanel.Control.REMOVE) == event.getSource()) {
-        if (!(struct instanceof HasAddRemovable)) {
+        if (!(struct instanceof HasChildStructs)) {
           return;
         }
         Window wnd = SwingUtilities.getWindowAncestor(this);
@@ -651,7 +651,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
     if (event.getSource() instanceof ButtonPopupMenu &&
         buttonPanel.getControlPosition((JComponent)event.getSource()) >= 0) {
       if (buttonPanel.getControlByType(ButtonPanel.Control.ADD) == event.getSource()) {
-        if (!(struct instanceof HasAddRemovable)) {
+        if (!(struct instanceof HasChildStructs)) {
           return;
         }
         ButtonPopupMenu bpmAdd = (ButtonPopupMenu)event.getSource();
@@ -664,7 +664,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
           }
         }
         try {
-          toadd = ((HasAddRemovable)struct).confirmAddEntry(toadd);
+          toadd = ((HasChildStructs)struct).confirmAddEntry(toadd);
           if (toadd != null) {
             toadd = (AddRemovable)toadd.clone();
           }

--- a/src/org/infinity/gui/StructViewer.java
+++ b/src/org/infinity/gui/StructViewer.java
@@ -516,9 +516,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
             Object entry = table.getModel().getValueAt(rows[i], 1);
             if (entry instanceof AddRemovable) {
               try {
-                if (((HasAddRemovable)struct).confirmRemoveEntry((AddRemovable)entry)) {
-                  struct.removeDatatype((AddRemovable)entry, true);
-                }
+                struct.removeDatatype((AddRemovable)entry, true);
               } catch (Exception e) {
                 e.printStackTrace();
               }

--- a/src/org/infinity/gui/StructViewer.java
+++ b/src/org/infinity/gui/StructViewer.java
@@ -178,7 +178,8 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
   private final StructTable table = new StructTable();
   private final HashMap<Integer, StructEntry> entryMap = new HashMap<>();
   private final HashMap<Viewable, ViewFrame> viewMap = new HashMap<>();
-  private AddRemovable emptyTypes[];
+  /** Array of prototype objects, that can be children of {@link #struct}. */
+  private AddRemovable prototypes[];
   private JMenuItem miFindAttribute, miFindReferences, miFindStateReferences, miFindRefToItem;
   private Editable editable;
   private JTabbedPane tabbedPane;
@@ -357,15 +358,15 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
 
     if (struct instanceof HasAddRemovable && !struct.getFields().isEmpty()) {
       try {
-        emptyTypes = ((HasAddRemovable)struct).getAddRemovables();
+        prototypes = ((HasAddRemovable)struct).getPrototypes();
       } catch (Exception e) {
         e.printStackTrace();
       }
-      JMenuItem menuItems[] = new JMenuItem[emptyTypes.length];
+      JMenuItem menuItems[] = new JMenuItem[prototypes.length];
       for (int i = 0; i < menuItems.length; i++) {
-        menuItems[i] = new JMenuItem(emptyTypes[i].getName());
+        menuItems[i] = new JMenuItem(prototypes[i].getName());
       }
-      if (emptyTypes.length > 0) {
+      if (prototypes.length > 0) {
         ButtonPopupMenu bpmAdd = (ButtonPopupMenu)buttonPanel.addControl(ButtonPanel.Control.ADD);
         bpmAdd.setMenuItems(menuItems);
         bpmAdd.addItemListener(this);
@@ -656,9 +657,9 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
         ButtonPopupMenu bpmAdd = (ButtonPopupMenu)event.getSource();
         JMenuItem item = bpmAdd.getSelectedItem();
         AddRemovable toadd = null;
-        for (final AddRemovable emptyType : emptyTypes) {
-          if (emptyType != null && emptyType.getName().equals(item.getText())) {
-            toadd = emptyType;
+        for (final AddRemovable proto : prototypes) {
+          if (proto.getName().equals(item.getText())) {
+            toadd = proto;
             break;
           }
         }

--- a/src/org/infinity/gui/StructViewer.java
+++ b/src/org/infinity/gui/StructViewer.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.gui;
@@ -361,8 +361,6 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
       } catch (Exception e) {
         e.printStackTrace();
       }
-      if (emptyTypes == null)
-        emptyTypes = new AddRemovable[0];
       JMenuItem menuItems[] = new JMenuItem[emptyTypes.length];
       for (int i = 0; i < menuItems.length; i++) {
         menuItems[i] = new JMenuItem(emptyTypes[i].getName());

--- a/src/org/infinity/resource/AbstractStruct.java
+++ b/src/org/infinity/resource/AbstractStruct.java
@@ -155,7 +155,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     name = entry.getResourceName();
     ByteBuffer bb = entry.getResourceBuffer();
     endoffset = read(bb, 0);
-    if (this instanceof HasAddRemovable && !fields.isEmpty()) {// Is this enough?
+    if (this instanceof HasChildStructs && !fields.isEmpty()) {// Is this enough?
       Collections.sort(fields); // This way we can writeField out in the order in list - sorted by offset
       fixHoles((ByteBuffer)bb.position(0));
       initAddStructMaps();
@@ -182,7 +182,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
   {
     this(superStruct, name, startoffset, listSize);
     endoffset = read(buffer, startoffset);
-    if (this instanceof HasAddRemovable) {
+    if (this instanceof HasChildStructs) {
       if (!(this instanceof Actor)) {  // Is this enough?
         Collections.sort(fields); // This way we can writeField out in the order in list - sorted by offset
       }
@@ -912,7 +912,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
 
   public void removeDatatype(AddRemovable removedEntry, boolean removeRecurse)
   {
-    if (removeRecurse && removedEntry instanceof HasAddRemovable) { // Recusivly removeTableLine substructures first
+    if (removeRecurse && removedEntry instanceof HasChildStructs) { // Recusivly removeTableLine substructures first
       AbstractStruct removedStruct = (AbstractStruct)removedEntry;
       for (int i = 0; i < removedStruct.fields.size(); i++) {
         final StructEntry o = removedStruct.fields.get(i);

--- a/src/org/infinity/resource/HasAddRemovable.java
+++ b/src/org/infinity/resource/HasAddRemovable.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource;
@@ -8,7 +8,8 @@ public interface HasAddRemovable
 {
   /**
    * Returns an array of available {@link AddRemovable} prototype objects.
-   * @return An array of available {@link AddRemovable} objects.
+   *
+   * @return An array of available {@link AddRemovable} objects. Can't be {@code null}
    */
   AddRemovable[] getAddRemovables() throws Exception;
 
@@ -31,4 +32,3 @@ public interface HasAddRemovable
    */
   boolean confirmRemoveEntry(AddRemovable entry) throws Exception;
 }
-

--- a/src/org/infinity/resource/HasAddRemovable.java
+++ b/src/org/infinity/resource/HasAddRemovable.java
@@ -22,13 +22,4 @@ public interface HasAddRemovable
    *         May return {@code null} to cancel the operation.
    */
   AddRemovable confirmAddEntry(AddRemovable entry) throws Exception;
-
-  /**
-   * This method is called whenever an {@link AddRemovable} entry is about to be removed from the
-   * parent structure. It allows subclasses to cancel the operation.
-   * @param entry The {@link AddRemovable} entry to remove.
-   * @return {@code true} to continue the remove operation. {@code false} to cancel the
-   *         remove operation.
-   */
-  boolean confirmRemoveEntry(AddRemovable entry) throws Exception;
 }

--- a/src/org/infinity/resource/HasAddRemovable.java
+++ b/src/org/infinity/resource/HasAddRemovable.java
@@ -4,14 +4,20 @@
 
 package org.infinity.resource;
 
+/**
+ * Implementor of this interface can store fields, that can be added or removed.
+ */
 public interface HasAddRemovable
 {
   /**
    * Returns an array of available {@link AddRemovable} prototype objects.
+   * Returned object will be {@link Object#clone cloned} when an editor needs to
+   * create the new element
    *
-   * @return An array of available {@link AddRemovable} objects. Can't be {@code null}
+   * @return An array of available {@link AddRemovable} objects.
+   *         Can't be {@code null} or contain {@code null}'s
    */
-  AddRemovable[] getAddRemovables() throws Exception;
+  AddRemovable[] getPrototypes() throws Exception;
 
   /**
    * This method is called whenever an {@link AddRemovable} entry is about to be added

--- a/src/org/infinity/resource/HasChildStructs.java
+++ b/src/org/infinity/resource/HasChildStructs.java
@@ -7,7 +7,7 @@ package org.infinity.resource;
 /**
  * Implementor of this interface can store fields, that can be added or removed.
  */
-public interface HasAddRemovable
+public interface HasChildStructs
 {
   /**
    * Returns an array of available {@link AddRemovable} prototype objects.

--- a/src/org/infinity/resource/are/Actor.java
+++ b/src/org/infinity/resource/are/Actor.java
@@ -19,14 +19,13 @@ import org.infinity.datatype.Unknown;
 import org.infinity.gui.StructViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.StructEntry;
 import org.infinity.resource.cre.CreResource;
 import org.infinity.util.io.StreamUtils;
 
-public final class Actor extends AbstractStruct implements AddRemovable, HasViewerTabs, HasAddRemovable
+public final class Actor extends AbstractStruct implements AddRemovable, HasViewerTabs
 {
   // ARE/Actor-specific field labels
   public static final String ARE_ACTOR                      = "Actor";
@@ -90,30 +89,6 @@ public final class Actor extends AbstractStruct implements AddRemovable, HasView
   }
 
 //--------------------- End Interface AddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
-  @Override
-  public AddRemovable[] getAddRemovables()
-  {
-    return new AddRemovable[]{};
-  }
-
-  @Override
-  public AddRemovable confirmAddEntry(AddRemovable entry) throws Exception
-  {
-    return entry;
-  }
-
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
 
 // --------------------- Begin Interface HasViewerTabs ---------------------
 

--- a/src/org/infinity/resource/are/AreResource.java
+++ b/src/org/infinity/resource/are/AreResource.java
@@ -35,7 +35,7 @@ import org.infinity.gui.hexview.BasicColorMap;
 import org.infinity.gui.hexview.StructHexViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
@@ -64,7 +64,7 @@ import org.infinity.util.io.StreamUtils;
  * {@link Container container} is stored in the ARE file, however the files themselves are
  * not embedded in the ARE file.
  */
-public final class AreResource extends AbstractStruct implements Resource, HasAddRemovable, HasViewerTabs
+public final class AreResource extends AbstractStruct implements Resource, HasChildStructs, HasViewerTabs
 {
   // ARE-specific field labels
   public static final String ARE_WED_RESOURCE             = "WED resource";
@@ -397,7 +397,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
   }
   //</editor-fold>
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/are/AreResource.java
+++ b/src/org/infinity/resource/are/AreResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -385,22 +385,19 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-//--------------------- Begin Interface Closeable ---------------------
+  //<editor-fold defaultstate="collapsed" desc="Closeable">
+  @Override
+  public void close() throws Exception
+  {
+    super.close();
+    if (areaViewer != null) {
+      areaViewer.close();
+      areaViewer = null;
+    }
+  }
+  //</editor-fold>
 
- @Override
- public void close() throws Exception
- {
-   super.close();
-   if (areaViewer != null) {
-     areaViewer.close();
-     areaViewer = null;
-   }
- }
-
-//--------------------- End Interface Closeable ---------------------
-
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -428,18 +425,9 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -484,20 +472,17 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
   {
     return (index == 0);
   }
+  //</editor-fold>
 
-// --------------------- End Interface HasViewerTabs ---------------------
-
-
-// --------------------- Begin Interface Writeable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Writeable">
   @Override
   public void write(OutputStream os) throws IOException
   {
     super.writeFlatFields(os);
   }
+  //</editor-fold>
 
-// --------------------- End Interface Writeable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void viewerInitialized(StructViewer viewer)
   {
@@ -597,7 +582,9 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
       hexViewer.dataModified();
     }
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -918,6 +905,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
     }
     return endoffset;
   }
+  //</editor-fold>
 
   private void updateActorCREOffsets()
   {

--- a/src/org/infinity/resource/are/AreResource.java
+++ b/src/org/infinity/resource/are/AreResource.java
@@ -399,7 +399,7 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     if (Profile.getEngine() == Profile.Engine.PST) {
       return new AddRemovable[]{new Actor(), new ITEPoint(), new SpawnPoint(),

--- a/src/org/infinity/resource/are/Container.java
+++ b/src/org/infinity/resource/are/Container.java
@@ -74,7 +74,7 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new Vertex(), new Item()};
   }

--- a/src/org/infinity/resource/are/Container.java
+++ b/src/org/infinity/resource/are/Container.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -72,8 +72,7 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
     super(superStruct, ARE_CONTAINER + " " + nr, buffer, offset);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -85,29 +84,17 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-//--------------------- Begin Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AddRemovable">
   @Override
   public boolean canRemove()
   {
     return true;
   }
+  //</editor-fold>
 
-//--------------------- End Interface AddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -131,12 +118,9 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
   {
     return true;
   }
+  //</editor-fold>
 
-// --------------------- End Interface HasViewerTabs ---------------------
-
-
-// --------------------- Begin Interface HasVertices ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasVertices">
   @Override
   public void readVertices(ByteBuffer buffer, int offset) throws Exception
   {
@@ -164,8 +148,7 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
     ((DecNumber)getAttribute(ARE_CONTAINER_NUM_VERTICES)).setValue(count);
     return count;
   }
-
-// --------------------- End Interface HasVertices ---------------------
+  //</editor-fold>
 
   @Override
   protected void setAddRemovableOffset(AddRemovable datatype)
@@ -213,6 +196,7 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
     return count;
   }
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -245,4 +229,5 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
     addField(new Unknown(buffer, offset + 136, 56));
     return offset + 192;
   }
+  //</editor-fold>
 }

--- a/src/org/infinity/resource/are/Container.java
+++ b/src/org/infinity/resource/are/Container.java
@@ -19,14 +19,14 @@ import org.infinity.datatype.Unknown;
 import org.infinity.gui.StructViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.StructEntry;
 import org.infinity.resource.vertex.Vertex;
 import org.infinity.util.io.StreamUtils;
 
 public final class Container extends AbstractStruct implements AddRemovable, HasVertices, HasViewerTabs,
-                                                               HasAddRemovable
+                                                               HasChildStructs
 {
   // ARE/Container-specific field labels
   public static final String ARE_CONTAINER                            = "Container";
@@ -72,7 +72,7 @@ public final class Container extends AbstractStruct implements AddRemovable, Has
     super(superStruct, ARE_CONTAINER + " " + nr, buffer, offset);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/are/Door.java
+++ b/src/org/infinity/resource/are/Door.java
@@ -17,7 +17,7 @@ import org.infinity.datatype.TextString;
 import org.infinity.datatype.Unknown;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.StructEntry;
 import org.infinity.resource.vertex.ClosedVertex;
@@ -27,7 +27,7 @@ import org.infinity.resource.vertex.OpenVertexImpeded;
 import org.infinity.resource.vertex.Vertex;
 import org.infinity.util.io.StreamUtils;
 
-public final class Door extends AbstractStruct implements AddRemovable, HasVertices, HasAddRemovable
+public final class Door extends AbstractStruct implements AddRemovable, HasVertices, HasChildStructs
 {
   // ARE/Door-specific field labels
   public static final String ARE_DOOR                                   = "Door";
@@ -94,7 +94,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
     super(superStruct, ARE_DOOR + " " + nr, buffer, offset);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/are/Door.java
+++ b/src/org/infinity/resource/are/Door.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -94,8 +94,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
     super(superStruct, ARE_DOOR + " " + nr, buffer, offset);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -108,29 +107,17 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-//--------------------- Begin Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AddRemovable">
   @Override
   public boolean canRemove()
   {
     return true;
   }
+  //</editor-fold>
 
-//--------------------- End Interface AddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasVertices ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasVertices">
   @Override
   public void readVertices(ByteBuffer buffer, int offset) throws Exception
   {
@@ -181,9 +168,9 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
     }
     return count;
   }
+  //</editor-fold>
 
-// --------------------- End Interface HasVertices ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void setAddRemovableOffset(AddRemovable datatype)
   {
@@ -209,7 +196,9 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
       datatype.setOffset(offset + 4 * (index - 1));
     }
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -267,4 +256,5 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
     addField(new Unknown(buffer, offset + 192, 8));
     return offset + 200;
   }
+  //</editor-fold>
 }

--- a/src/org/infinity/resource/are/Door.java
+++ b/src/org/infinity/resource/are/Door.java
@@ -96,7 +96,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasVerti
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new OpenVertex(), new ClosedVertex(), new ClosedVertexImpeded(),
                               new OpenVertexImpeded()};

--- a/src/org/infinity/resource/are/ITEPoint.java
+++ b/src/org/infinity/resource/are/ITEPoint.java
@@ -16,13 +16,13 @@ import org.infinity.datatype.TextString;
 import org.infinity.datatype.Unknown;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.StructEntry;
 import org.infinity.resource.vertex.Vertex;
 import org.infinity.util.io.StreamUtils;
 
-public final class ITEPoint extends AbstractStruct implements AddRemovable, HasVertices, HasAddRemovable
+public final class ITEPoint extends AbstractStruct implements AddRemovable, HasVertices, HasChildStructs
 {
   // ARE/Trigger-specific field labels
   public static final String ARE_TRIGGER                            = "Trigger";
@@ -77,7 +77,7 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
   }
   //</editor-fold>
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/are/ITEPoint.java
+++ b/src/org/infinity/resource/are/ITEPoint.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.are;
@@ -75,9 +75,9 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
   {
     super(superStruct, ARE_TRIGGER + " " + number, buffer, offset);
   }
+  //</editor-fold>
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -89,29 +89,17 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-//--------------------- Begin Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AddRemovable">
   @Override
   public boolean canRemove()
   {
     return true;
   }
+  //</editor-fold>
 
-//--------------------- End Interface AddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasVertices ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasVertices">
   @Override
   public void readVertices(ByteBuffer buffer, int offset) throws Exception
   {
@@ -139,9 +127,9 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
     ((DecNumber)getAttribute(ARE_TRIGGER_NUM_VERTICES)).setValue(count);
     return count;
   }
+  //</editor-fold>
 
-// --------------------- End Interface HasVertices ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void setAddRemovableOffset(AddRemovable datatype)
   {
@@ -153,7 +141,9 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
       ((AbstractStruct)datatype).realignStructOffsets();
     }
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -210,4 +200,5 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
     }
     return offset + 196;
   }
+  //</editor-fold>
 }

--- a/src/org/infinity/resource/are/ITEPoint.java
+++ b/src/org/infinity/resource/are/ITEPoint.java
@@ -79,7 +79,7 @@ public final class ITEPoint extends AbstractStruct implements AddRemovable, HasV
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new Vertex()};
   }

--- a/src/org/infinity/resource/chu/ChuResource.java
+++ b/src/org/infinity/resource/chu/ChuResource.java
@@ -36,7 +36,7 @@ import org.infinity.util.Pair;
  * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/chu_v1.htm">
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/chu_v1.htm</a>
  */
-public final class ChuResource extends AbstractStruct implements Resource, HasViewerTabs //, HasAddRemovable
+public final class ChuResource extends AbstractStruct implements Resource, HasViewerTabs //, HasChildStructs
 {
   // CHU-specific field labels
   public static final String CHU_NUM_PANELS       = "# panels";

--- a/src/org/infinity/resource/cre/CreResource.java
+++ b/src/org/infinity/resource/cre/CreResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.cre;
@@ -729,8 +729,7 @@ public final class CreResource extends AbstractStruct
     isChr = StreamUtils.readString(data, startoffset, 4).equalsIgnoreCase("CHR ");
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -756,28 +755,15 @@ public final class CreResource extends AbstractStruct
     return entry;
   }
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-//--------------------- Begin Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AddRemovable">
   @Override
   public boolean canRemove()
   {
     return true;
   }
+  //</editor-fold>
 
-//--------------------- End Interface AddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -816,6 +802,7 @@ public final class CreResource extends AbstractStruct
   {
     return (index == 0);
   }
+  //</editor-fold>
 
   // Needed for embedded CRE resources
   private boolean showRawTab()
@@ -827,20 +814,15 @@ public final class CreResource extends AbstractStruct
     return hasRawTab.booleanValue();
   }
 
-// --------------------- End Interface HasViewerTabs ---------------------
-
-
-// --------------------- Begin Interface Writeable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Writable">
   @Override
   public void write(OutputStream os) throws IOException
   {
     super.writeFlatFields(os);
   }
+  //</editor-fold>
 
-
-// --------------------- End Interface Writeable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void viewerInitialized(StructViewer viewer)
   {
@@ -908,7 +890,9 @@ public final class CreResource extends AbstractStruct
       hexViewer.dataModified();
     }
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -1008,6 +992,7 @@ public final class CreResource extends AbstractStruct
     }
     return readOther(version.toString(), buffer, offset);
   }
+  //</editor-fold>
 
   ////////////////////////
   // Icewind Dale 2
@@ -2140,8 +2125,7 @@ public final class CreResource extends AbstractStruct
     return retVal;
   }
 
-  //--------------------- Begin Interface ItemListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="ItemListener">
   @Override
   public void itemStateChanged(ItemEvent event)
   {
@@ -2154,11 +2138,9 @@ public final class CreResource extends AbstractStruct
       }
     }
   }
+  //</editor-fold>
 
-//--------------------- End Interface ItemListener ---------------------
-
-//--------------------- Begin Interface UpdateListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="UpdateListener">
   @Override
   public boolean valueUpdated(UpdateEvent event)
   {
@@ -2181,9 +2163,7 @@ public final class CreResource extends AbstractStruct
     }
     return false;
   }
-
-//--------------------- End Interface UpdateListener ---------------------
-
+  //</editor-fold>
 
   // Called by "Extended Search"
   // Checks whether the specified resource entry matches all available search options.

--- a/src/org/infinity/resource/cre/CreResource.java
+++ b/src/org/infinity/resource/cre/CreResource.java
@@ -55,7 +55,7 @@ import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.resource.Effect;
 import org.infinity.resource.Effect2;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
@@ -97,7 +97,7 @@ import org.infinity.util.io.StreamUtils;
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/cre_v1.htm</a>
  */
 public final class CreResource extends AbstractStruct
-  implements Resource, HasAddRemovable, AddRemovable, HasViewerTabs, ItemListener, UpdateListener
+  implements Resource, HasChildStructs, AddRemovable, HasViewerTabs, ItemListener, UpdateListener
 {
   // CHR-specific field labels
   public static final String CHR_NAME                         = "Character name";
@@ -729,7 +729,7 @@ public final class CreResource extends AbstractStruct
     isChr = StreamUtils.readString(data, startoffset, 4).equalsIgnoreCase("CHR ");
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/cre/CreResource.java
+++ b/src/org/infinity/resource/cre/CreResource.java
@@ -731,7 +731,7 @@ public final class CreResource extends AbstractStruct
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     IsNumeric effectVersion = (IsNumeric)getAttribute(CRE_EFFECT_VERSION);
     if (Profile.getEngine() == Profile.Engine.IWD2) {

--- a/src/org/infinity/resource/cre/Iwd2Struct.java
+++ b/src/org/infinity/resource/cre/Iwd2Struct.java
@@ -54,7 +54,7 @@ public final class Iwd2Struct extends AbstractStruct implements HasAddRemovable
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     switch (type) {
       case TYPE_SPELL:

--- a/src/org/infinity/resource/cre/Iwd2Struct.java
+++ b/src/org/infinity/resource/cre/Iwd2Struct.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.cre;
@@ -52,8 +52,7 @@ public final class Iwd2Struct extends AbstractStruct implements HasAddRemovable
     setOffset(offset);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -76,15 +75,9 @@ public final class Iwd2Struct extends AbstractStruct implements HasAddRemovable
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void datatypeAdded(AddRemovable datatype)
   {
@@ -102,10 +95,13 @@ public final class Iwd2Struct extends AbstractStruct implements HasAddRemovable
   {
     return count.getValue();
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset)
   {
     return -1;
   }
+  //</editor-fold>
 }

--- a/src/org/infinity/resource/cre/Iwd2Struct.java
+++ b/src/org/infinity/resource/cre/Iwd2Struct.java
@@ -9,9 +9,9 @@ import java.nio.ByteBuffer;
 import org.infinity.datatype.DecNumber;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 
-public final class Iwd2Struct extends AbstractStruct implements HasAddRemovable
+public final class Iwd2Struct extends AbstractStruct implements HasChildStructs
 {
   // CRE/Iwd2Struct-specific field labels
   public static final String CRE_STRUCT_NUM_MEMORIZABLE = "# memorizable (total)";
@@ -52,7 +52,7 @@ public final class Iwd2Struct extends AbstractStruct implements HasAddRemovable
     setOffset(offset);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/cre/SpellMemorization.java
+++ b/src/org/infinity/resource/cre/SpellMemorization.java
@@ -11,11 +11,11 @@ import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.HexNumber;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.StructEntry;
 import org.infinity.util.io.StreamUtils;
 
-public final class SpellMemorization extends AbstractStruct implements AddRemovable, HasAddRemovable
+public final class SpellMemorization extends AbstractStruct implements AddRemovable, HasChildStructs
 {
   // CRE/SpellMemorization-specific field labels
   public static final String CRE_MEMORIZATION                         = "Memorization info";
@@ -44,7 +44,7 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
   }
   //</editor-fold>
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/cre/SpellMemorization.java
+++ b/src/org/infinity/resource/cre/SpellMemorization.java
@@ -46,7 +46,7 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new MemorizedSpells()};
   }

--- a/src/org/infinity/resource/cre/SpellMemorization.java
+++ b/src/org/infinity/resource/cre/SpellMemorization.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.cre;
@@ -36,19 +36,15 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
     super(cre, CRE_MEMORIZATION + " " + nr, buffer, offset);
   }
 
-//--------------------- Begin Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AddRemovable">
   @Override
   public boolean canRemove()
   {
     return true;
   }
+  //</editor-fold>
 
-//--------------------- End Interface AddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -60,15 +56,9 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void setAddRemovableOffset(AddRemovable datatype)
   {
@@ -82,7 +72,9 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
       ((AbstractStruct)datatype).realignStructOffsets();
     }
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset)
   {
@@ -94,6 +86,7 @@ public final class SpellMemorization extends AbstractStruct implements AddRemova
     addField(new DecNumber(buffer, offset + 12, 4, CRE_MEMORIZATION_SPELL_COUNT));
     return offset + 16;
   }
+  //</editor-fold>
 
   public void readMemorizedSpells(ByteBuffer buffer, int offset) throws Exception
   {

--- a/src/org/infinity/resource/dlg/DlgResource.java
+++ b/src/org/infinity/resource/dlg/DlgResource.java
@@ -40,7 +40,7 @@ import org.infinity.gui.hexview.BasicColorMap;
 import org.infinity.gui.hexview.StructHexViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
@@ -92,7 +92,7 @@ import org.infinity.util.io.StreamUtils;
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/dlg_v1.htm</a>
  */
 public final class DlgResource extends AbstractStruct
-    implements Resource, HasAddRemovable, HasViewerTabs, ActionListener
+    implements Resource, HasChildStructs, HasViewerTabs, ActionListener
 {
   // DLG-specific field labels
   public static final String DLG_OFFSET_STATES            = "States offset";
@@ -122,7 +122,7 @@ public final class DlgResource extends AbstractStruct
     super(entry);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/dlg/DlgResource.java
+++ b/src/org/infinity/resource/dlg/DlgResource.java
@@ -124,7 +124,7 @@ public final class DlgResource extends AbstractStruct
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new State(), new Transition(), new StateTrigger(),
                               new ResponseTrigger(), new Action()};

--- a/src/org/infinity/resource/dlg/DlgResource.java
+++ b/src/org/infinity/resource/dlg/DlgResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.dlg;
@@ -122,8 +122,7 @@ public final class DlgResource extends AbstractStruct
     super(entry);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -136,18 +135,9 @@ public final class DlgResource extends AbstractStruct
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -191,11 +181,9 @@ public final class DlgResource extends AbstractStruct
   {
     return (index == 0);
   }
+  //</editor-fold>
 
-// --------------------- End Interface HasViewerTabs ---------------------
-
-// --------------------- Begin Interface Writeable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Writeable">
   @Override
   public void write(OutputStream os) throws IOException
   {
@@ -221,11 +209,9 @@ public final class DlgResource extends AbstractStruct
       }
     }
   }
+  //</editor-fold>
 
-// --------------------- End Interface Writeable ---------------------
-
-// --------------------- Begin Interface ActionListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="ActionListener">
   @Override
   public void actionPerformed(ActionEvent e)
   {
@@ -252,9 +238,9 @@ public final class DlgResource extends AbstractStruct
       }
     }
   }
+  //</editor-fold>
 
-// --------------------- End Interface ActionListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void viewerInitialized(StructViewer viewer)
   {
@@ -292,7 +278,9 @@ public final class DlgResource extends AbstractStruct
   {
     updateReferences(datatype, false);
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -369,6 +357,7 @@ public final class DlgResource extends AbstractStruct
     }
     return offset + textSize;
   }
+  //</editor-fold>
 
   /**
    * Returns state with specified number from this dialog.

--- a/src/org/infinity/resource/gam/GamResource.java
+++ b/src/org/infinity/resource/gam/GamResource.java
@@ -33,7 +33,7 @@ import org.infinity.gui.hexview.BasicColorMap;
 import org.infinity.gui.hexview.StructHexViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
@@ -55,7 +55,7 @@ import org.infinity.util.Variables;
  * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/gam_v1.1.htm">
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/gam_v1.1.htm</a>
  */
-public final class GamResource extends AbstractStruct implements Resource, HasAddRemovable, HasViewerTabs
+public final class GamResource extends AbstractStruct implements Resource, HasChildStructs, HasViewerTabs
 {
   // GAM-specific field labels
   public static final String GAM_GAME_TIME                        = "Game time (game seconds)";
@@ -136,7 +136,7 @@ public final class GamResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/gam/GamResource.java
+++ b/src/org/infinity/resource/gam/GamResource.java
@@ -138,7 +138,7 @@ public final class GamResource extends AbstractStruct implements Resource, HasAd
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     if (Profile.getEngine() == Profile.Engine.PST) {
       // TODO: missing CRE resource when adding PartyNPC structures

--- a/src/org/infinity/resource/gam/GamResource.java
+++ b/src/org/infinity/resource/gam/GamResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.gam;
@@ -168,12 +168,6 @@ public final class GamResource extends AbstractStruct implements Resource, HasAd
       }
     }
     return entry;
-  }
-
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/gam/PartyNPC.java
+++ b/src/org/infinity/resource/gam/PartyNPC.java
@@ -22,7 +22,6 @@ import org.infinity.datatype.UnsignDecNumber;
 import org.infinity.gui.StructViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.StructEntry;
@@ -30,7 +29,7 @@ import org.infinity.resource.cre.CreResource;
 import org.infinity.util.LongIntegerHashMap;
 import org.infinity.util.io.StreamUtils;
 
-public class PartyNPC extends AbstractStruct implements HasViewerTabs, HasAddRemovable, AddRemovable
+public class PartyNPC extends AbstractStruct implements HasViewerTabs, AddRemovable
 {
   // GAM/PartyNPC-specific field labels
   public static final String GAM_NPC                            = "Party member";
@@ -119,29 +118,6 @@ public class PartyNPC extends AbstractStruct implements HasViewerTabs, HasAddRem
   {
     super(superStruct, name, buffer, offset);
   }
-
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
-  @Override
-  public AddRemovable[] getAddRemovables() throws Exception
-  {
-    return new AddRemovable[]{};
-  }
-
-  @Override
-  public AddRemovable confirmAddEntry(AddRemovable struct) throws Exception
-  {
-    return struct;
-  }
-
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
 
 //--------------------- Begin Interface AddRemovable ---------------------
 

--- a/src/org/infinity/resource/itm/Ability.java
+++ b/src/org/infinity/resource/itm/Ability.java
@@ -67,7 +67,7 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new Effect()};
   }

--- a/src/org/infinity/resource/itm/Ability.java
+++ b/src/org/infinity/resource/itm/Ability.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.itm;
@@ -65,8 +65,7 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
     super(superStruct, ITM_ABIL + " " + number, buffer, offset);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -78,29 +77,17 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-//--------------------- Begin Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AddRemovable">
   @Override
   public boolean canRemove()
   {
     return true;
   }
+  //</editor-fold>
 
-//--------------------- End Interface AddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -124,9 +111,9 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
   {
     return true;
   }
+  //</editor-fold>
 
-// --------------------- End Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -187,5 +174,6 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
 
     return offset + 56;
   }
+  //</editor-fold>
 }
 

--- a/src/org/infinity/resource/itm/Ability.java
+++ b/src/org/infinity/resource/itm/Ability.java
@@ -22,13 +22,13 @@ import org.infinity.resource.AbstractAbility;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.resource.Effect;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.ResourceFactory;
 import org.infinity.util.io.StreamUtils;
 
-public final class Ability extends AbstractAbility implements AddRemovable, HasAddRemovable, HasViewerTabs
+public final class Ability extends AbstractAbility implements AddRemovable, HasChildStructs, HasViewerTabs
 {
   // ITM/Ability-specific field labels (more fields defined in AbstractAbility)
   public static final String ITM_ABIL                     = "Item ability";
@@ -65,7 +65,7 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
     super(superStruct, ITM_ABIL + " " + number, buffer, offset);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/itm/ItmResource.java
+++ b/src/org/infinity/resource/itm/ItmResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.itm;
@@ -223,8 +223,7 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -236,18 +235,9 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -292,12 +282,9 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
   {
     return (index == 0);
   }
+  //</editor-fold>
 
-// --------------------- End Interface HasViewerTabs ---------------------
-
-
-// --------------------- Begin Interface Writeable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Writable">
   @Override
   public void write(OutputStream os) throws IOException
   {
@@ -309,9 +296,9 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
       }
     }
   }
+  //</editor-fold>
 
-// --------------------- End Interface Writeable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void viewerInitialized(StructViewer viewer)
   {
@@ -379,7 +366,9 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
     super.datatypeRemovedInChild(child, datatype);
     incAbilityEffects(child, datatype, -1);
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -496,6 +485,7 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
 
     return Math.max(offset, offset2);
   }
+  //</editor-fold>
 
   private void incAbilityEffects(StructEntry child, AddRemovable datatype, int value)
   {

--- a/src/org/infinity/resource/itm/ItmResource.java
+++ b/src/org/infinity/resource/itm/ItmResource.java
@@ -33,7 +33,7 @@ import org.infinity.resource.AbstractAbility;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.resource.Effect;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
@@ -63,7 +63,7 @@ import org.infinity.util.io.StreamUtils;
  * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/itm_v1.htm">
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/itm_v1.htm</a>
  */
-public final class ItmResource extends AbstractStruct implements Resource, HasAddRemovable, HasViewerTabs
+public final class ItmResource extends AbstractStruct implements Resource, HasChildStructs, HasViewerTabs
 {
   // ITM-specific field labels
   public static final String ITM_NAME_GENERAL           = "General name";
@@ -223,7 +223,7 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/itm/ItmResource.java
+++ b/src/org/infinity/resource/itm/ItmResource.java
@@ -225,7 +225,7 @@ public final class ItmResource extends AbstractStruct implements Resource, HasAd
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new Ability(), new Effect()};
   }

--- a/src/org/infinity/resource/pro/ProResource.java
+++ b/src/org/infinity/resource/pro/ProResource.java
@@ -28,7 +28,7 @@ import org.infinity.gui.hexview.BasicColorMap;
 import org.infinity.gui.hexview.StructHexViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
@@ -154,7 +154,7 @@ public final class ProResource extends AbstractStruct implements Resource, HasVi
       HashBitmap proType = (HashBitmap)event.getSource();
       AbstractStruct struct = event.getStructure();
       // add/remove extended sections in the parent structure depending on the current value
-      if (struct instanceof Resource && struct instanceof HasAddRemovable) {
+      if (struct instanceof Resource && struct instanceof HasChildStructs) {
         if (proType.getValue() == 3L) {         // area of effect
           StructEntry entry = struct.getFields().get(struct.getFields().size() - 1);
           try {

--- a/src/org/infinity/resource/pro/ProResource.java
+++ b/src/org/infinity/resource/pro/ProResource.java
@@ -51,7 +51,7 @@ import org.infinity.util.LongIntegerHashMap;
  * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/pro_v1.htm">
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/pro_v1.htm</a>
  */
-public final class ProResource extends AbstractStruct implements Resource, HasAddRemovable, HasViewerTabs, UpdateListener
+public final class ProResource extends AbstractStruct implements Resource, HasViewerTabs, UpdateListener
 {
   // PRO-specific field labels
   public static final String PRO_TYPE = "Projectile type";
@@ -130,26 +130,6 @@ public final class ProResource extends AbstractStruct implements Resource, HasAd
   {
     super(entry);
   }
-
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
-  @Override
-  public AddRemovable[] getAddRemovables() throws Exception
-  {
-    return null;
-  }
-
-  @Override
-  public AddRemovable confirmAddEntry(AddRemovable entry) throws Exception
-  {
-    return entry;
-  }
-
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-  //</editor-fold>
 
   //<editor-fold defaultstate="collapsed" desc="UpdateListener">
   @Override

--- a/src/org/infinity/resource/spl/Ability.java
+++ b/src/org/infinity/resource/spl/Ability.java
@@ -45,7 +45,7 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new Effect()};
   }

--- a/src/org/infinity/resource/spl/Ability.java
+++ b/src/org/infinity/resource/spl/Ability.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.spl;
@@ -43,8 +43,7 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
     super(superStruct, SPL_ABIL + " " + number, buffer, offset);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -56,29 +55,17 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-//--------------------- Begin Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AddRemovable">
   @Override
   public boolean canRemove()
   {
     return true;
   }
+  //</editor-fold>
 
-//--------------------- End Interface AddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -102,9 +89,9 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
   {
     return true;
   }
+  //</editor-fold>
 
-// --------------------- End Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -137,5 +124,6 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
     }
     return offset + 40;
   }
+  //</editor-fold>
 }
 

--- a/src/org/infinity/resource/spl/Ability.java
+++ b/src/org/infinity/resource/spl/Ability.java
@@ -20,13 +20,13 @@ import org.infinity.resource.AbstractAbility;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.resource.Effect;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.ResourceFactory;
 import org.infinity.util.io.StreamUtils;
 
-public final class Ability extends AbstractAbility implements AddRemovable, HasAddRemovable, HasViewerTabs
+public final class Ability extends AbstractAbility implements AddRemovable, HasChildStructs, HasViewerTabs
 {
   // SPL/Ability-specific field labels (more fields defined in AbstractAbility)
   public static final String SPL_ABIL                     = "Spell ability";
@@ -43,7 +43,7 @@ public final class Ability extends AbstractAbility implements AddRemovable, HasA
     super(superStruct, SPL_ABIL + " " + number, buffer, offset);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/spl/SplResource.java
+++ b/src/org/infinity/resource/spl/SplResource.java
@@ -36,7 +36,7 @@ import org.infinity.resource.AbstractAbility;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.resource.Effect;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
@@ -62,7 +62,7 @@ import org.infinity.util.io.StreamUtils;
  * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/spl_v1.htm">
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/spl_v1.htm</a>
  */
-public final class SplResource extends AbstractStruct implements Resource, HasAddRemovable, HasViewerTabs,
+public final class SplResource extends AbstractStruct implements Resource, HasChildStructs, HasViewerTabs,
                                                                  UpdateListener
 {
   // SPL-specific field labels
@@ -154,7 +154,7 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/spl/SplResource.java
+++ b/src/org/infinity/resource/spl/SplResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.spl;
@@ -154,8 +154,7 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -167,18 +166,9 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -223,12 +213,9 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
   {
     return (index == 0);
   }
+  //</editor-fold>
 
-// --------------------- End Interface HasViewerTabs ---------------------
-
-
-// --------------------- Begin Interface Writeable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Writable">
   @Override
   public void write(OutputStream os) throws IOException
   {
@@ -240,11 +227,9 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
       }
     }
   }
+  //</editor-fold>
 
-// --------------------- End Interface Writeable ---------------------
-
-// --------------------- Begin Interface UpdateListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="UpdateListener">
   @Override
   public boolean valueUpdated(UpdateEvent event)
   {
@@ -264,9 +249,9 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
     }
     return false;
   }
+  //</editor-fold>
 
-// --------------------- End Interface UpdateListener ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void viewerInitialized(StructViewer viewer)
   {
@@ -334,7 +319,9 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
     super.datatypeRemovedInChild(child, datatype);
     incAbilityEffects(child, datatype, -1);
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -410,6 +397,7 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
 
     return Math.max(offset, offset2);
   }
+  //</editor-fold>
 
   private void incAbilityEffects(StructEntry child, AddRemovable datatype, int value)
   {

--- a/src/org/infinity/resource/spl/SplResource.java
+++ b/src/org/infinity/resource/spl/SplResource.java
@@ -156,7 +156,7 @@ public final class SplResource extends AbstractStruct implements Resource, HasAd
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new Ability(), new Effect()};
   }

--- a/src/org/infinity/resource/src/SrcResource.java
+++ b/src/org/infinity/resource/src/SrcResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.src;
@@ -43,8 +43,7 @@ public final class SrcResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -56,17 +55,9 @@ public final class SrcResource extends AbstractStruct implements Resource, HasAd
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-//--------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -95,9 +86,9 @@ public final class SrcResource extends AbstractStruct implements Resource, HasAd
   {
     return false;
   }
+  //</editor-fold>
 
-//--------------------- End Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -111,7 +102,9 @@ public final class SrcResource extends AbstractStruct implements Resource, HasAd
     }
     return offset;
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void viewerInitialized(StructViewer viewer)
   {
@@ -151,4 +144,5 @@ public final class SrcResource extends AbstractStruct implements Resource, HasAd
       hexViewer.dataModified();
     }
   }
+  //</editor-fold>
 }

--- a/src/org/infinity/resource/src/SrcResource.java
+++ b/src/org/infinity/resource/src/SrcResource.java
@@ -45,7 +45,7 @@ public final class SrcResource extends AbstractStruct implements Resource, HasAd
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new Entry()};
   }

--- a/src/org/infinity/resource/src/SrcResource.java
+++ b/src/org/infinity/resource/src/SrcResource.java
@@ -14,7 +14,7 @@ import org.infinity.gui.hexview.BasicColorMap;
 import org.infinity.gui.hexview.StructHexViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Resource;
 import org.infinity.resource.key.ResourceEntry;
@@ -31,7 +31,7 @@ import org.infinity.resource.key.ResourceEntry;
  * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/src.htm">
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/src.htm</a>
  */
-public final class SrcResource extends AbstractStruct implements Resource, HasAddRemovable, HasViewerTabs
+public final class SrcResource extends AbstractStruct implements Resource, HasChildStructs, HasViewerTabs
 {
   // SRC-specific field labels
   public static final String SRC_NUM_ENTRIES  = "# entries";
@@ -43,7 +43,7 @@ public final class SrcResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/sto/StoResource.java
+++ b/src/org/infinity/resource/sto/StoResource.java
@@ -27,7 +27,7 @@ import org.infinity.gui.hexview.BasicColorMap;
 import org.infinity.gui.hexview.StructHexViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
@@ -44,7 +44,7 @@ import org.infinity.util.io.StreamUtils;
  * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/sto_v1.htm">
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/sto_v1.htm</a>
  */
-public final class StoResource extends AbstractStruct implements Resource, HasAddRemovable, HasViewerTabs
+public final class StoResource extends AbstractStruct implements Resource, HasChildStructs, HasViewerTabs
 {
   // STO-specific field labels
   public static final String STO_TYPE                   = "Type";
@@ -99,7 +99,7 @@ public final class StoResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/sto/StoResource.java
+++ b/src/org/infinity/resource/sto/StoResource.java
@@ -101,7 +101,7 @@ public final class StoResource extends AbstractStruct implements Resource, HasAd
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     TextString version = (TextString)getAttribute(COMMON_VERSION);
     if (version.toString().equals("V1.1"))

--- a/src/org/infinity/resource/sto/StoResource.java
+++ b/src/org/infinity/resource/sto/StoResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.sto;
@@ -99,8 +99,7 @@ public final class StoResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -116,18 +115,9 @@ public final class StoResource extends AbstractStruct implements Resource, HasAd
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-// --------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -172,9 +162,9 @@ public final class StoResource extends AbstractStruct implements Resource, HasAd
   {
     return (index == 0);
   }
+  //</editor-fold>
 
-// --------------------- End Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -299,7 +289,9 @@ public final class StoResource extends AbstractStruct implements Resource, HasAd
     }
     return endoffset;
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void viewerInitialized(StructViewer viewer)
   {
@@ -339,6 +331,7 @@ public final class StoResource extends AbstractStruct implements Resource, HasAd
       hexViewer.dataModified();
     }
   }
+  //</editor-fold>
 
   /**
    * Checks whether the specified resource entry matches all available search options.

--- a/src/org/infinity/resource/var/VarResource.java
+++ b/src/org/infinity/resource/var/VarResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.var;
@@ -38,8 +38,7 @@ public final class VarResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -51,17 +50,9 @@ public final class VarResource extends AbstractStruct implements Resource, HasAd
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-//--------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -90,9 +81,9 @@ public final class VarResource extends AbstractStruct implements Resource, HasAd
   {
     return false;
   }
+  //</editor-fold>
 
-//--------------------- End Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -101,7 +92,9 @@ public final class VarResource extends AbstractStruct implements Resource, HasAd
       addField(new Entry(this, buffer, offset + i * 44, i));
     return offset + count * 44;
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void viewerInitialized(StructViewer viewer)
   {
@@ -141,4 +134,5 @@ public final class VarResource extends AbstractStruct implements Resource, HasAd
       hexViewer.dataModified();
     }
   }
+  //</editor-fold>
 }

--- a/src/org/infinity/resource/var/VarResource.java
+++ b/src/org/infinity/resource/var/VarResource.java
@@ -40,7 +40,7 @@ public final class VarResource extends AbstractStruct implements Resource, HasAd
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new Entry()};
   }

--- a/src/org/infinity/resource/var/VarResource.java
+++ b/src/org/infinity/resource/var/VarResource.java
@@ -13,7 +13,7 @@ import org.infinity.gui.hexview.BasicColorMap;
 import org.infinity.gui.hexview.StructHexViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Resource;
 import org.infinity.resource.key.ResourceEntry;
@@ -29,7 +29,7 @@ import org.infinity.resource.key.ResourceEntry;
  * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/var.htm">
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/var.htm</a>
  */
-public final class VarResource extends AbstractStruct implements Resource, HasAddRemovable, HasViewerTabs
+public final class VarResource extends AbstractStruct implements Resource, HasChildStructs, HasViewerTabs
 {
   private StructHexViewer hexViewer;
 
@@ -38,7 +38,7 @@ public final class VarResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/vef/VefResource.java
+++ b/src/org/infinity/resource/vef/VefResource.java
@@ -50,7 +50,7 @@ public final class VefResource extends AbstractStruct implements Resource, HasAd
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new PrimaryComponent(), new SecondaryComponent()};
   }

--- a/src/org/infinity/resource/vef/VefResource.java
+++ b/src/org/infinity/resource/vef/VefResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.vef;
@@ -48,11 +48,9 @@ public final class VefResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
-
   {
     return new AddRemovable[]{new PrimaryComponent(), new SecondaryComponent()};
   }
@@ -62,46 +60,38 @@ public final class VefResource extends AbstractStruct implements Resource, HasAd
   {
     return entry;
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
+  public int getViewerTabCount()
   {
-    return true;
+    return 1;
   }
 
-// --------------------- End Interface HasAddRemovable ---------------------
+  @Override
+  public String getViewerTabName(int index)
+  {
+    return StructViewer.TAB_RAW;
+  }
 
-//--------------------- Begin Interface HasViewerTabs ---------------------
+  @Override
+  public JComponent getViewerTab(int index)
+  {
+    if (hexViewer == null) {
+      hexViewer = new StructHexViewer(this, new BasicColorMap(this, true));
+    }
+    return hexViewer;
+  }
 
- @Override
- public int getViewerTabCount()
- {
-   return 1;
- }
+  @Override
+  public boolean viewerTabAddedBefore(int index)
+  {
+    return false;
+  }
+  //</editor-fold>
 
- @Override
- public String getViewerTabName(int index)
- {
-   return StructViewer.TAB_RAW;
- }
-
- @Override
- public JComponent getViewerTab(int index)
- {
-   if (hexViewer == null) {
-     hexViewer = new StructHexViewer(this, new BasicColorMap(this, true));
-   }
-   return hexViewer;
- }
-
- @Override
- public boolean viewerTabAddedBefore(int index)
- {
-   return false;
- }
-
-//--------------------- End Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -141,7 +131,9 @@ public final class VefResource extends AbstractStruct implements Resource, HasAd
     }
     return endoffset;
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void viewerInitialized(StructViewer viewer)
   {
@@ -181,4 +173,5 @@ public final class VefResource extends AbstractStruct implements Resource, HasAd
       hexViewer.dataModified();
     }
   }
+  //</editor-fold>
 }

--- a/src/org/infinity/resource/vef/VefResource.java
+++ b/src/org/infinity/resource/vef/VefResource.java
@@ -16,7 +16,7 @@ import org.infinity.gui.hexview.BasicColorMap;
 import org.infinity.gui.hexview.StructHexViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Resource;
 import org.infinity.resource.StructEntry;
@@ -33,7 +33,7 @@ import org.infinity.resource.key.ResourceEntry;
  * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/vef_v1.htm">
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/vef_v1.htm</a>
  */
-public final class VefResource extends AbstractStruct implements Resource, HasAddRemovable, HasViewerTabs
+public final class VefResource extends AbstractStruct implements Resource, HasChildStructs, HasViewerTabs
 {
   // VEF-specific field labels
   public static final String VEF_OFFSET_COMPONENT_PRI = "Primary component offset";
@@ -48,7 +48,7 @@ public final class VefResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/wed/Door.java
+++ b/src/org/infinity/resource/wed/Door.java
@@ -15,11 +15,11 @@ import org.infinity.datatype.SectionOffset;
 import org.infinity.datatype.TextString;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.StructEntry;
 import org.infinity.util.io.StreamUtils;
 
-public final class Door extends AbstractStruct implements AddRemovable, HasAddRemovable
+public final class Door extends AbstractStruct implements AddRemovable, HasChildStructs
 {
   // WED/Door-specific field labels
   public static final String WED_DOOR                         = "Door";
@@ -43,7 +43,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
     super(superStruct, WED_DOOR + " " + number, buffer, offset);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/wed/Door.java
+++ b/src/org/infinity/resource/wed/Door.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.wed;
@@ -43,8 +43,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
     super(superStruct, WED_DOOR + " " + number, buffer, offset);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -56,26 +55,17 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-//--------------------- Begin Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AddRemovable">
   @Override
   public boolean canRemove()
   {
     return true;
   }
+  //</editor-fold>
 
-//--------------------- End Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void setAddRemovableOffset(AddRemovable datatype)
   {
@@ -85,6 +75,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
       datatype.setOffset(offset + index * 2);
     }
   }
+  //</editor-fold>
 
   public DecNumber getTilemapIndex()
   {
@@ -124,6 +115,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
     }
   }
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -164,4 +156,5 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
     }
     return offset + 26;
   }
+  //</editor-fold>
 }

--- a/src/org/infinity/resource/wed/Door.java
+++ b/src/org/infinity/resource/wed/Door.java
@@ -45,7 +45,7 @@ public final class Door extends AbstractStruct implements AddRemovable, HasAddRe
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new OpenPolygon(), new ClosedPolygon()};
   }

--- a/src/org/infinity/resource/wed/Overlay.java
+++ b/src/org/infinity/resource/wed/Overlay.java
@@ -15,7 +15,7 @@ import org.infinity.datatype.Unknown;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.Profile;
 
-public final class Overlay extends AbstractStruct // implements AddRemovable, HasAddRemovable
+public final class Overlay extends AbstractStruct // implements AddRemovable, HasChildStructs
 {
   // WED/Overlay-specific field labels
   public static final String WED_OVERLAY                        = "Overlay";

--- a/src/org/infinity/resource/wed/Polygon.java
+++ b/src/org/infinity/resource/wed/Polygon.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.wed;
@@ -37,8 +37,7 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
     super(superStruct, name, buffer, offset, 8);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -50,26 +49,17 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-//--------------------- Begin Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AddRemovable">
   @Override
   public boolean canRemove()
   {
     return true;
   }
+  //</editor-fold>
 
-//--------------------- End Interface AddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void setAddRemovableOffset(AddRemovable datatype)
   {
@@ -84,6 +74,7 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
       ((AbstractStruct)datatype).realignStructOffsets();
     }
   }
+  //</editor-fold>
 
   public void readVertices(ByteBuffer buffer, int offset) throws Exception
   {
@@ -110,6 +101,7 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
     return count;
   }
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -123,4 +115,5 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
     addField(new DecNumber(buffer, offset + 16, 2, WED_POLY_MAX_COORD_Y));
     return offset + 18;
   }
+  //</editor-fold>
 }

--- a/src/org/infinity/resource/wed/Polygon.java
+++ b/src/org/infinity/resource/wed/Polygon.java
@@ -39,7 +39,7 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new Vertex()};
   }

--- a/src/org/infinity/resource/wed/Polygon.java
+++ b/src/org/infinity/resource/wed/Polygon.java
@@ -13,11 +13,11 @@ import org.infinity.datatype.SectionCount;
 import org.infinity.datatype.Unknown;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.StructEntry;
 import org.infinity.resource.vertex.Vertex;
 
-public abstract class Polygon extends AbstractStruct implements AddRemovable, HasAddRemovable
+public abstract class Polygon extends AbstractStruct implements AddRemovable, HasChildStructs
 {
   // WED/Polygon-specific field labels
   public static final String WED_POLY_VERTEX_INDEX  = "Vertex index";
@@ -37,7 +37,7 @@ public abstract class Polygon extends AbstractStruct implements AddRemovable, Ha
     super(superStruct, name, buffer, offset, 8);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/wed/WedResource.java
+++ b/src/org/infinity/resource/wed/WedResource.java
@@ -24,7 +24,7 @@ import org.infinity.gui.hexview.BasicColorMap;
 import org.infinity.gui.hexview.StructHexViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.HasViewerTabs;
 import org.infinity.resource.Resource;
 import org.infinity.resource.StructEntry;
@@ -60,7 +60,7 @@ import org.infinity.util.Misc;
  * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/wed_v1.3.htm">
  * https://gibberlings3.github.io/iesdp/file_formats/ie_formats/wed_v1.3.htm</a>
  */
-public final class WedResource extends AbstractStruct implements Resource, HasAddRemovable, HasViewerTabs
+public final class WedResource extends AbstractStruct implements Resource, HasChildStructs, HasViewerTabs
 {
   // WED-specific field labels
   public static final String WED_NUM_OVERLAYS               = "# overlays";
@@ -83,7 +83,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
+  //<editor-fold defaultstate="collapsed" desc="HasChildStructs">
   @Override
   public AddRemovable[] getPrototypes() throws Exception
   {

--- a/src/org/infinity/resource/wed/WedResource.java
+++ b/src/org/infinity/resource/wed/WedResource.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2020 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.wed;
@@ -83,8 +83,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     super(entry);
   }
 
-// --------------------- Begin Interface HasAddRemovable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
   public AddRemovable[] getAddRemovables() throws Exception
   {
@@ -96,28 +95,17 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
   {
     return entry;
   }
+  //</editor-fold>
 
-  @Override
-  public boolean confirmRemoveEntry(AddRemovable entry) throws Exception
-  {
-    return true;
-  }
-
-// --------------------- End Interface HasAddRemovable ---------------------
-
-
-// --------------------- Begin Interface Writeable ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="Writeable">
   @Override
   public void write(OutputStream os) throws IOException
   {
     super.writeFlatFields(os);
   }
+  //</editor-fold>
 
-// --------------------- End Interface Writeable ---------------------
-
-//--------------------- Begin Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="HasViewerTabs">
   @Override
   public int getViewerTabCount()
   {
@@ -144,9 +132,9 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
   {
     return false;
   }
+  //</editor-fold>
 
-//--------------------- End Interface HasViewerTabs ---------------------
-
+  //<editor-fold defaultstate="collapsed" desc="AbstractStruct">
   @Override
   protected void viewerInitialized(StructViewer viewer)
   {
@@ -214,7 +202,9 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
       hexViewer.dataModified();
     }
   }
+  //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Readable">
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception
   {
@@ -317,6 +307,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
     }
     return endoffset;
   }
+  //</editor-fold>
 
   private void updateSectionOffsets(AddRemovable datatype, int size)
   {

--- a/src/org/infinity/resource/wed/WedResource.java
+++ b/src/org/infinity/resource/wed/WedResource.java
@@ -85,7 +85,7 @@ public final class WedResource extends AbstractStruct implements Resource, HasAd
 
   //<editor-fold defaultstate="collapsed" desc="HasAddRemovable">
   @Override
-  public AddRemovable[] getAddRemovables() throws Exception
+  public AddRemovable[] getPrototypes() throws Exception
   {
     return new AddRemovable[]{new Door(), new WallPolygon(), new Wallgroup()};
   }

--- a/src/org/infinity/util/StructClipboard.java
+++ b/src/org/infinity/util/StructClipboard.java
@@ -130,8 +130,6 @@ public final class StructClipboard
       } catch (Exception e) {
         return CLIPBOARD_EMPTY;
       }
-      if (targetClasses == null)
-        targetClasses = new AddRemovable[0];
       for (final StructEntry entry: contents) {
         if (entry instanceof AddRemovable) {
           if (canConvertToEffectV1(struct, (AddRemovable)entry) ||
@@ -176,7 +174,6 @@ public final class StructClipboard
           index += i;
         }
         if (pasteEntry instanceof HasAddRemovable) {
-          ((HasAddRemovable)pasteEntry).getAddRemovables();
           List<AddRemovable> substructures = ((AbstractStruct)pasteEntry).removeAllRemoveables();
           lastIndex = targetStruct.addDatatype(pasteEntry, index);
           pasteSubStructures((AbstractStruct)pasteEntry, substructures);

--- a/src/org/infinity/util/StructClipboard.java
+++ b/src/org/infinity/util/StructClipboard.java
@@ -126,7 +126,7 @@ public final class StructClipboard
         return CLIPBOARD_ENTRIES;
       AddRemovable[] targetClasses;
       try {
-        targetClasses = ((HasAddRemovable)struct).getAddRemovables();
+        targetClasses = ((HasAddRemovable)struct).getPrototypes();
       } catch (Exception e) {
         return CLIPBOARD_EMPTY;
       }

--- a/src/org/infinity/util/StructClipboard.java
+++ b/src/org/infinity/util/StructClipboard.java
@@ -15,7 +15,7 @@ import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.resource.Effect;
 import org.infinity.resource.Effect2;
-import org.infinity.resource.HasAddRemovable;
+import org.infinity.resource.HasChildStructs;
 import org.infinity.resource.StructEntry;
 import org.infinity.resource.are.ProEffect;
 import org.infinity.resource.cre.CreResource;
@@ -44,7 +44,7 @@ public final class StructClipboard
   {
     for (int i = 0; i < substructures.size(); i++) {
       AddRemovable pasteEntry = (AddRemovable)substructures.get(i);
-      if (pasteEntry instanceof HasAddRemovable) {
+      if (pasteEntry instanceof HasChildStructs) {
         AbstractStruct pasteStruct = (AbstractStruct)pasteEntry;
         List<AddRemovable> subsubstructures = pasteStruct.removeAllRemoveables();
         targetStruct.addDatatype(pasteEntry);
@@ -126,7 +126,7 @@ public final class StructClipboard
         return CLIPBOARD_ENTRIES;
       AddRemovable[] targetClasses;
       try {
-        targetClasses = ((HasAddRemovable)struct).getPrototypes();
+        targetClasses = ((HasChildStructs)struct).getPrototypes();
       } catch (Exception e) {
         return CLIPBOARD_EMPTY;
       }
@@ -173,7 +173,7 @@ public final class StructClipboard
         if (targetStruct.isCompatibleDatatypeSelection(pasteEntry)) {
           index += i;
         }
-        if (pasteEntry instanceof HasAddRemovable) {
+        if (pasteEntry instanceof HasChildStructs) {
           List<AddRemovable> substructures = ((AbstractStruct)pasteEntry).removeAllRemoveables();
           lastIndex = targetStruct.addDatatype(pasteEntry, index);
           pasteSubStructures((AbstractStruct)pasteEntry, substructures);


### PR DESCRIPTION
I bet new names more clearly describe the intention of this interface.

Also I removed not actually used method `confirmRemoveEntry`, because all implementers always return `true`