### PR TITLE
Fixes for gemrb demo area 1

### DIFF
--- a/src/org/infinity/datatype/AreResourceRef.java
+++ b/src/org/infinity/datatype/AreResourceRef.java
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer;
 import org.infinity.resource.Profile;
 import org.infinity.resource.ResourceFactory;
 import org.infinity.resource.are.AreResource;
+import org.infinity.resource.key.BIFFEntry;
 import org.infinity.resource.key.BIFFResourceEntry;
 import org.infinity.resource.key.ResourceEntry;
 
@@ -26,7 +27,10 @@ public final class AreResourceRef extends ResourceRef {
         .getResourceEntry(((ResourceRef) are.getAttribute(AreResource.ARE_WED_RESOURCE)).getResourceName());
     String wedBIFF = "_dummy";
     if (res instanceof BIFFResourceEntry) {
-      wedBIFF = ((BIFFResourceEntry) res).getBIFFEntry().getFileName();
+      BIFFEntry biffEntry = ((BIFFResourceEntry) res).getBIFFEntry();
+      if (biffEntry != null) {
+        wedBIFF = biffEntry.getFileName();
+      }
     }
     if (Profile.getEngine() == Profile.Engine.BG1) {
       legalBIFs = new String[] { wedBIFF, "data/sfxsound.bif", "data/cresound.bif" };

--- a/src/org/infinity/resource/key/Keyfile.java
+++ b/src/org/infinity/resource/key/Keyfile.java
@@ -385,7 +385,7 @@ public class Keyfile {
 
   public BIFFEntry getBIFFEntry(Path keyFile, int index) {
     List<BIFFEntry> biffs = getBIFFList(keyFile, false);
-    if (biffs != null) {
+    if (biffs != null && biffs.size() > 0) {
       return biffs.get(index);
     }
     return null;


### PR DESCRIPTION
Even with a full chitin.key, the song entry problem persisted. This avoids it and allows the area to be loaded normally.

Btw, is there a way to make java report line numbers in the stack trace? It's absurd that they're there for the standard lib, but not for the local code.

fixes #136