### PR TITLE
fixes #123

### DIFF
--- a/src/org/infinity/datatype/ResourceRef.java
+++ b/src/org/infinity/datatype/ResourceRef.java
@@ -40,6 +40,7 @@ import org.infinity.icon.Icons;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.ResourceFactory;
 import org.infinity.resource.key.ResourceEntry;
+import org.infinity.resource.sound.SoundResource;
 import org.infinity.util.Misc;
 import org.infinity.util.io.StreamUtils;
 
@@ -80,6 +81,9 @@ public class ResourceRef extends Datatype
   /** Button that used to open editor of current selected element in the list. */
   private JButton bView;
 
+  /** Button that used to play sound of current selected element in the list. */
+  private JButton bPlay;
+
   /**
    * GUI component that lists all available resources that can be set to this resource reference and have edit field for
    * ability to enter resource reference manually.
@@ -116,6 +120,12 @@ public class ResourceRef extends Datatype
       final ResourceRefEntry selected = list.getSelectedValue();
       if (isEditable(selected)) {
         new ViewFrame(list.getTopLevelAncestor(), ResourceFactory.getResource(selected.entry));
+      }
+    } else if (event.getSource() == bPlay) {
+      final ResourceRefEntry selected = list.getSelectedValue();
+      if (isSound(selected)) {
+        SoundResource res = (SoundResource) ResourceFactory.getResource(selected.entry);
+        res.playSound();
       }
     }
   }
@@ -183,12 +193,15 @@ public class ResourceRef extends Datatype
     bView = new JButton("View/Edit", Icons.ICON_ZOOM_16.getIcon());
     bView.addActionListener(this);
     bView.setEnabled(isEditable(list.getSelectedValue()));
+    bPlay = new JButton("Play", Icons.ICON_PLAY_16.getIcon());
+    bPlay.addActionListener(this);
+    bPlay.setEnabled(isSound(list.getSelectedValue()));
     list.addListSelectionListener(this);
 
     GridBagConstraints gbc = null;
     JPanel panel = new JPanel(new GridBagLayout());
 
-    gbc = ViewerUtil.setGBC(gbc, 0, 0, 1, 2, 1.0, 1.0, GridBagConstraints.FIRST_LINE_START, GridBagConstraints.BOTH,
+    gbc = ViewerUtil.setGBC(gbc, 0, 0, 1, 3, 1.0, 1.0, GridBagConstraints.FIRST_LINE_START, GridBagConstraints.BOTH,
         new Insets(0, 0, 0, 0), 0, 0);
     panel.add(list, gbc);
     gbc = ViewerUtil.setGBC(gbc, 1, 0, 1, 1, 0.0, 1.0, GridBagConstraints.SOUTH, GridBagConstraints.HORIZONTAL,
@@ -197,6 +210,10 @@ public class ResourceRef extends Datatype
     gbc = ViewerUtil.setGBC(gbc, 1, 1, 1, 1, 0.0, 1.0, GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL,
         new Insets(3, 6, 3, 0), 0, 0);
     panel.add(bView, gbc);
+
+    gbc = ViewerUtil.setGBC(gbc, 1, 2, 1, 1, 0.0, 1.0, GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL,
+            new Insets(3, 6, 3, 0), 0, 0);
+    panel.add(bPlay, gbc);
 
     panel.setMinimumSize(Misc.getScaledDimension(DIM_MEDIUM));
     panel.setPreferredSize(panel.getMinimumSize());
@@ -252,6 +269,7 @@ public class ResourceRef extends Datatype
   @Override
   public void valueChanged(ListSelectionEvent e) {
     bView.setEnabled(isEditable(list.getSelectedValue()));
+    bPlay.setEnabled(isSound(list.getSelectedValue()));
   }
 
   @Override
@@ -375,6 +393,10 @@ public class ResourceRef extends Datatype
 
   private boolean isEditable(ResourceRefEntry ref) {
     return ref != null && ref != NONE && ref.entry != null;
+  }
+
+  private boolean isSound(ResourceRefEntry ref) {
+    return ref != null && ref != NONE && ref.entry != null && ref.entry.getExtension().equalsIgnoreCase("WAV");
   }
 
   private void setValue(String newValue) {

--- a/src/org/infinity/datatype/ResourceRef.java
+++ b/src/org/infinity/datatype/ResourceRef.java
@@ -396,7 +396,7 @@ public class ResourceRef extends Datatype
   }
 
   private boolean isSound(ResourceRefEntry ref) {
-    return ref != null && ref != NONE && ref.entry != null && ref.entry.getExtension().equalsIgnoreCase("WAV");
+    return ref != null && ref != NONE && ref.entry != null && ref.entry.isSound();
   }
 
   private void setValue(String newValue) {

--- a/src/org/infinity/resource/key/ResourceEntry.java
+++ b/src/org/infinity/resource/key/ResourceEntry.java
@@ -280,4 +280,10 @@ public abstract class ResourceEntry implements Comparable<ResourceEntry> {
   public abstract ResourceTreeFolder getTreeFolder();
 
   public abstract boolean hasOverride();
+
+  public boolean isSound() {
+    String extension = getExtension().toUpperCase();
+
+    return extension.equals("WAV") || extension.equals("MUS") || extension.equals("ACM");
+  }
 }

--- a/src/org/infinity/resource/sound/SoundResource.java
+++ b/src/org/infinity/resource/sound/SoundResource.java
@@ -168,8 +168,10 @@ public class SoundResource implements Resource, ActionListener, ItemListener, Cl
 
   @Override
   public void run() {
-    bPlay.setIcon(PLAY_ICONS.get(false));
-    bStop.setEnabled(true);
+    if (bPlay != null) {
+      bPlay.setIcon(PLAY_ICONS.get(false));
+      bStop.setEnabled(true);
+    }
     if (audioBuffer != null) {
       final TimerElapsedTask timerTask = new TimerElapsedTask(250L);
       try {
@@ -182,8 +184,10 @@ public class SoundResource implements Resource, ActionListener, ItemListener, Cl
       player.stopPlay();
       timerTask.stop();
     }
-    bStop.setEnabled(false);
-    bPlay.setIcon(PLAY_ICONS.get(true));
+    if (bPlay != null) {
+      bStop.setEnabled(false);
+      bPlay.setIcon(PLAY_ICONS.get(true));
+    }
   }
 
   // --------------------- End Interface Runnable ---------------------
@@ -294,10 +298,11 @@ public class SoundResource implements Resource, ActionListener, ItemListener, Cl
     if (bPlay != null) {
       bPlay.setEnabled(b);
       bPlay.setIcon(PLAY_ICONS.get(true));
+
+      updateTimeLabel(0);
+      miConvert.setEnabled(b);
+      buttonPanel.getControlByType(PROPERTIES).setEnabled(true);
     }
-    updateTimeLabel(0);
-    miConvert.setEnabled(b);
-    buttonPanel.getControlByType(PROPERTIES).setEnabled(true);
   }
 
   private synchronized void setClosed(boolean b) {
@@ -448,16 +453,22 @@ public class SoundResource implements Resource, ActionListener, ItemListener, Cl
         timer.cancel();
         timer = null;
         paused = false;
-        updateTimeLabel(0L);
+        if (bPlay != null) {
+          updateTimeLabel(0L);
+        }
       }
     }
 
     @Override
     public void run() {
-      if (!paused && timer != null && player != null && player.getDataLine() != null) {
+      if (!paused && timer != null && player != null && player.getDataLine() != null && bPlay != null) {
         updateTimeLabel(player.getDataLine().getMicrosecondPosition() / 1000L);
       }
     }
+  }
 
+  public void playSound() {
+    loadAudio();
+    new Thread(this).start();
   }
 }


### PR DESCRIPTION
this semi-implements issue #123 by adding a `Play` button in `ResourceRef` and will get enabled if the resource selected is a wav file.

Kinda hacky since `SoundResouce` playing audio capabilities is tightly coupled with the `SoundResouce` own Panel UI, so a lot of `if (bPlay != null) {` check is needed to prevent NPE being thrown when playing audio without the  `SoundResouce` Panel UI visible.

Another issue with this feature is that if the wave file is quite long... spamming the play button with different wav file will cause multiple wave file to be played (overlapping each other)

<img width="969" alt="Screen Shot 2023-08-18 at 1 01 20 PM" src="https://github.com/NearInfinityBrowser/NearInfinity/assets/285941/c95d9cc6-e0ee-4366-bd37-afc242749ab6">
