### PR TITLE
Fix tilemap index negative & Show Tile # on Area Viewer

### DIFF
--- a/src/org/infinity/resource/are/viewer/AreaViewer.java
+++ b/src/org/infinity/resource/are/viewer/AreaViewer.java
@@ -174,6 +174,7 @@ public class AreaViewer extends ChildFrame {
   private JCheckBox cbLayerDoorTarget;
   private JLabel lPosX;
   private JLabel lPosY;
+  private JLabel lTile;
   private JTextArea taMiniMapInfo;
   private JTextArea taInfo;
   private boolean bMapDragging;
@@ -500,10 +501,12 @@ public class AreaViewer extends ChildFrame {
     spTree.setMinimumSize(dim);
 
     // Creating Info Box area
-    JLabel lPosXLabel = new JLabel(LABEL_INFO_X);
-    JLabel lPosYLabel = new JLabel(LABEL_INFO_Y);
-    lPosX = new JLabel("0");
-    lPosY = new JLabel("0");
+  JLabel lPosXLabel = new JLabel(LABEL_INFO_X);
+  JLabel lPosYLabel = new JLabel(LABEL_INFO_Y);
+  JLabel lTileLabel = new JLabel("Tile #:");
+  lPosX = new JLabel("0");
+  lPosY = new JLabel("0");
+  lTile = new JLabel("0");
 
     taMiniMapInfo = new JTextArea();
     taMiniMapInfo.setEditable(false);
@@ -538,12 +541,18 @@ public class AreaViewer extends ChildFrame {
     c = ViewerUtil.setGBC(c, 1, 1, 1, 1, 0.0, 0.0, GridBagConstraints.FIRST_LINE_START, GridBagConstraints.HORIZONTAL,
         new Insets(4, 8, 0, 0), 0, 0);
     pInfoBox.add(lPosY, c);
-    c = ViewerUtil.setGBC(c, 0, 2, 2, 1, 1.0, 1.0, GridBagConstraints.FIRST_LINE_START, GridBagConstraints.BOTH,
-        new Insets(4, 0, 0, 0), 0, 0);
-    pInfoBox.add(taMiniMapInfo, c);
-    c = ViewerUtil.setGBC(c, 0, 3, 2, 1, 1.0, 1.0, GridBagConstraints.FIRST_LINE_START, GridBagConstraints.BOTH,
-        new Insets(4, 0, 0, 0), 0, 0);
-    pInfoBox.add(taInfo, c);
+  c = ViewerUtil.setGBC(c, 0, 2, 1, 1, 0.0, 0.0, GridBagConstraints.FIRST_LINE_START, GridBagConstraints.NONE,
+    new Insets(4, 0, 0, 0), 0, 0);
+  pInfoBox.add(lTileLabel, c);
+  c = ViewerUtil.setGBC(c, 1, 2, 1, 1, 0.0, 0.0, GridBagConstraints.FIRST_LINE_START, GridBagConstraints.HORIZONTAL,
+    new Insets(4, 8, 0, 0), 0, 0);
+  pInfoBox.add(lTile, c);
+  c = ViewerUtil.setGBC(c, 0, 3, 2, 1, 1.0, 1.0, GridBagConstraints.FIRST_LINE_START, GridBagConstraints.BOTH,
+    new Insets(4, 0, 0, 0), 0, 0);
+  pInfoBox.add(taMiniMapInfo, c);
+  c = ViewerUtil.setGBC(c, 0, 4, 2, 1, 1.0, 1.0, GridBagConstraints.FIRST_LINE_START, GridBagConstraints.BOTH,
+    new Insets(4, 0, 0, 0), 0, 0);
+  pInfoBox.add(taInfo, c);
     pInfoBox.setMinimumSize(pInfoBox.getPreferredSize());
 
     // Assembling right side bar
@@ -1332,6 +1341,24 @@ public class AreaViewer extends ChildFrame {
       if (coords.y != mapCoordinates.y) {
         mapCoordinates.y = coords.y;
         lPosY.setText(Integer.toString(mapCoordinates.y));
+      }
+    // Compute tile number (tiles are 64x64 pixels). If renderer not ready, show N/A.
+  if (rcCanvas != null && rcCanvas.isTilesetLoaded()) {
+        try {
+          int tileX = mapCoordinates.x / 64;
+          int tileY = mapCoordinates.y / 64;
+      int tilesPerRow = rcCanvas.getTilesX();
+          int tileNumber = tileY * tilesPerRow + tileX;
+          if (tileX < 0 || tileY < 0 || tileX >= tilesPerRow || tileNumber < 0) {
+            lTile.setText("N/A");
+          } else {
+            lTile.setText(Integer.toString(tileNumber));
+          }
+        } catch (Exception e) {
+          lTile.setText("N/A");
+        }
+      } else {
+        lTile.setText("N/A");
       }
       setMiniMapText(coords);
     }

--- a/src/org/infinity/resource/are/viewer/TilesetRenderer.java
+++ b/src/org/infinity/resource/are/viewer/TilesetRenderer.java
@@ -410,6 +410,35 @@ public class TilesetRenderer extends RenderCanvas {
   }
 
   /**
+   * Returns number of tiles per row (tiles X) of the primary tileset.
+   * Returns 0 when no tileset is loaded.
+   */
+  public int getTilesX() {
+    if (isInitialized()) {
+      return listTilesets.get(0).tilesX;
+    }
+    return 0;
+  }
+
+  /**
+   * Returns number of tiles per column (tiles Y) of the primary tileset.
+   * Returns 0 when no tileset is loaded.
+   */
+  public int getTilesY() {
+    if (isInitialized()) {
+      return listTilesets.get(0).tilesY;
+    }
+    return 0;
+  }
+
+  /**
+   * Public wrapper to indicate whether tileset data is available.
+   */
+  public boolean isTilesetLoaded() {
+    return isInitialized();
+  }
+
+  /**
    * Advances the frame index by one for animated overlays.
    */
   public void advanceTileFrame() {

--- a/src/org/infinity/resource/cre/IndexNumber.java
+++ b/src/org/infinity/resource/cre/IndexNumber.java
@@ -13,7 +13,8 @@ import org.infinity.datatype.DecNumber;
  */
 public class IndexNumber extends DecNumber {
   public IndexNumber(ByteBuffer buffer, int offset, int length, String name) {
-    super(buffer, offset, length, name);
+  // CRE index numbers are unsigned 16-bit values. Read as unsigned by default.
+  super(buffer, offset, length, name, false);
   }
 
   public IndexNumber(ByteBuffer buffer, int offset, int length, String name, boolean signed) {

--- a/src/org/infinity/resource/wed/IndexNumber.java
+++ b/src/org/infinity/resource/wed/IndexNumber.java
@@ -13,7 +13,8 @@ import org.infinity.datatype.DecNumber;
  */
 public class IndexNumber extends DecNumber {
   public IndexNumber(ByteBuffer buffer, int offset, int length, String name) {
-    super(buffer, offset, length, name);
+  // WED index numbers are unsigned 16-bit values (tile indices). Read as unsigned by default.
+  super(buffer, offset, length, name, false);
   }
 
   public IndexNumber(ByteBuffer buffer, int offset, int length, String name, boolean signed) {

--- a/src/org/infinity/resource/wed/Tilemap.java
+++ b/src/org/infinity/resource/wed/Tilemap.java
@@ -34,9 +34,30 @@ public final class Tilemap extends AbstractStruct { // WED/Tilemap-specific fiel
 
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception {
+    // Primary tile index is stored as unsigned 16-bit in WED. Read with public constructor then fix value.
     addField(new DecNumber(buffer, offset, 2, WED_TILEMAP_TILE_INDEX_PRI));
     addField(new DecNumber(buffer, offset + 2, 2, WED_TILEMAP_TILE_COUNT_PRI));
+    // Read secondary tile index as unsigned 16-bit where 0xFFFF means 'no secondary index' (-1).
     addField(new DecNumber(buffer, offset + 4, 2, WED_TILEMAP_TILE_INDEX_SEC));
+    // Post-process primary and secondary values to interpret as unsigned (with 0xFFFF => -1 for secondary).
+    try {
+      DecNumber pri = (DecNumber) getAttribute(WED_TILEMAP_TILE_INDEX_PRI);
+      int rawPri = buffer.getShort(offset) & 0xffff;
+      pri.setValue(rawPri);
+    } catch (Exception e) {
+      // ignore
+    }
+    try {
+      DecNumber sec = (DecNumber) getAttribute(WED_TILEMAP_TILE_INDEX_SEC);
+      int rawSec = buffer.getShort(offset + 4) & 0xffff;
+      if (rawSec == 0xffff) {
+        sec.setValue(-1);
+      } else {
+        sec.setValue(rawSec);
+      }
+    } catch (Exception e) {
+      // ignore
+    }
     addField(new Flag(buffer, offset + 6, 1, WED_TILEMAP_DRAW_OVERLAYS, FLAGS_ARRAY));
     addField(new DecNumber(buffer, offset + 7, 1, WED_TILEMAP_ANIMATION_SPEED));
     addField(new Unknown(buffer, offset + 8, 2));


### PR DESCRIPTION
As I was working with extra large maps I saw this issue and decided to fix it.  When viewing WED files you should now see the correct index with no negative numbers.  Also added Tile # to the Area viewer to make it easy to debug when I was working with secondary tiles this really helped figure out issues.